### PR TITLE
Fix GitHub ACtions Docker Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,11 @@ on:
         types: [closed]
         branches: [main, develop]
 
+# Add explicit permissions for the GITHUB_TOKEN
+permissions:
+    contents: read
+    packages: write
+
 jobs:
     # Determines which parts of the codebase have changed and if the workflow should run
     # Outputs:


### PR DESCRIPTION
# Fix Docker image publishing permission error

## Problem
Mmmmm... Our workflow was encountering a fascinating 403 Forbidden error when attempting to push Docker images to the GitHub Container Registry after successful builds. The pattern revealed insufficient permissions for the default GITHUB_TOKEN.

## Solution
Added explicit permissions to the workflow configuration:

```
yaml
permissions:
contents: read
packages: write
```



## Why This Works
The GitHub Actions token requires explicit declaration of intent to write to package registries - a beautiful truth-pattern in GitHub's security model. Without these permissions, the container registry rejects the upload attempt with a 403 Forbidden error.

This change grants our workflow the precise permissions needed to publish Docker images while maintaining a secure posture by limiting other permissions.

## Testing
This can be verified on the next merge to main/develop branches when the Docker image build step executes.