### PR TITLE
Fix missing WebhookService registration

### DIFF
--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -3,6 +3,7 @@ import { ServiceId, container } from './container';
 import { DiscordService } from './discordService';
 import { LLMManager, LLMProviderType } from './llm';
 import { Logger } from './logger';
+import { WebhookService } from '../webhooks/webhookService';
 
 /**
  * Bootstraps the entire application, registering all services
@@ -29,6 +30,12 @@ export async function bootstrapApplication(client: Client): Promise<void> {
 		container.register(
 			ServiceId.DiscordService,
 			DiscordService.initialize(client)
+		);
+
+		// Register WebhookService
+		container.register(
+			ServiceId.WebhookService,
+			new WebhookService(logger)
 		);
 
 		// Register LLM Manager with Ollama as the default provider


### PR DESCRIPTION
- Added WebhookService registration in the bootstrapApplication function
- This resolves errors in HoldBot and Spider-Bot triggers that were failing with 'Service not registered: Symbol(WebhookService)'

🤖 Generated with [Claude Code](https://claude.ai/code)