### PR TITLE
Add 10% chance for GuyBot to respond to Guy's messages

### DIFF
--- a/src/starbunk/bots/strategy-bots/guy-bot/constants.ts
+++ b/src/starbunk/bots/strategy-bots/guy-bot/constants.ts
@@ -1,6 +1,7 @@
 // Constants for Guy Bot
 export const GUY_BOT_NAME = 'GuyBot';
 export const GUY_BOT_AVATAR_URL = 'https://i.imgur.com/default-guy.jpg';
+export const GUY_TRIGGER_CHANCE = 10; // 10% chance to respond to Guy's messages
 
 export const GUY_BOT_PATTERNS = {
 	Default: /\bguy\b/i

--- a/src/starbunk/bots/strategy-bots/guy-bot/triggers.ts
+++ b/src/starbunk/bots/strategy-bots/guy-bot/triggers.ts
@@ -1,9 +1,9 @@
 import userId from '@/discord/userId';
 import { BotIdentity } from '@/starbunk/types/botIdentity';
-import { matchesPattern } from '../../core/conditions';
+import { and, fromUser, matchesPattern, or, withChance } from '../../core/conditions';
 import { getBotIdentityFromDiscord } from '../../core/get-bot-identity';
 import { createTriggerResponse } from '../../core/trigger-response';
-import { GUY_BOT_NAME, GUY_BOT_PATTERNS, getRandomGuyResponse } from './constants';
+import { GUY_BOT_NAME, GUY_BOT_PATTERNS, GUY_TRIGGER_CHANCE, getRandomGuyResponse } from './constants';
 
 // Get Guy's identity from Discord
 async function getGuyIdentityFromDiscord(): Promise<BotIdentity> {
@@ -13,10 +13,13 @@ async function getGuyIdentityFromDiscord(): Promise<BotIdentity> {
 	});
 }
 
-// Trigger for guy mentions
+// Trigger for guy mentions or Guy's messages
 export const guyTrigger = createTriggerResponse({
 	name: 'guy-trigger',
-	condition: matchesPattern(GUY_BOT_PATTERNS.Default),
+	condition: or(
+		matchesPattern(GUY_BOT_PATTERNS.Default),
+		and(fromUser(userId.Guy), withChance(GUY_TRIGGER_CHANCE))
+	),
 	response: async () => getRandomGuyResponse(),
 	identity: async () => getGuyIdentityFromDiscord(),
 	priority: 1


### PR DESCRIPTION
## Summary
- Added a 10% chance for GuyBot to respond to any message from Guy
- Implemented using similar pattern as BananaBot's trigger condition
- Added GUY_TRIGGER_CHANCE constant for easier configuration

## Test plan
- Check that GuyBot still responds to messages containing 'guy'
- Verify that GuyBot now has a 10% chance to respond to Guy's messages
- Confirm tests still pass

🤖 Generated with [Claude Code](https://claude.ai/code)