### PR TITLE
Refactor bot message handling to skip by default

### DIFF
--- a/src/starbunk/bots/core/bot-builder.ts
+++ b/src/starbunk/bots/core/bot-builder.ts
@@ -84,7 +84,7 @@ export function validateBotConfig(config: ReplyBotConfig): ValidatedReplyBotConf
 		defaultIdentity: config.defaultIdentity,
 		triggers: config.triggers,
 		defaultResponseRate: responseRate,
-		skipBotMessages: config.skipBotMessages ?? false,
+		skipBotMessages: config.skipBotMessages ?? true, // Default to true for safer behavior
 		disabled,
 	};
 }
@@ -139,7 +139,7 @@ export function createReplyBot(config: ReplyBotConfig): ReplyBotImpl {
 			}
 
 			// Skip bot messages if configured
-			if (config.skipBotMessages && message.author.bot) {
+			if (validConfig.skipBotMessages && message.author.bot) {
 				logger.debug('Skipping bot message');
 				return;
 			}

--- a/src/starbunk/bots/createBot.ts
+++ b/src/starbunk/bots/createBot.ts
@@ -1,9 +1,9 @@
 import { BotIdentity } from '../types/botIdentity';
+import { ReplyBotImpl } from './core/bot-builder';
 import { BotFactory } from './core/bot-factory';
-import { createTriggerResponse, TriggerResponse } from './core/trigger-response';
 import { matchesPattern } from './core/conditions';
 import { staticResponse } from './core/responses';
-import { ReplyBotImpl } from './core/bot-builder';
+import { createTriggerResponse, TriggerResponse } from './core/trigger-response';
 
 /**
  * Interface for simplified bot configuration
@@ -106,6 +106,6 @@ export function createBot(config: SimpleBotConfig): ReplyBotImpl {
 		defaultIdentity,
 		triggers,
 		defaultResponseRate: config.responseRate,
-		skipBotMessages: config.skipBotMessages !== undefined ? config.skipBotMessages : true,
+		...(config.skipBotMessages !== undefined && { skipBotMessages: config.skipBotMessages }),
 	});
 }

--- a/src/starbunk/bots/reply-bots/README.md
+++ b/src/starbunk/bots/reply-bots/README.md
@@ -23,8 +23,8 @@ export default createBot({
   patterns: [/\bhello\b/i, /\bhi\b/i, /\bhey\b/i],
   responses: ['Hello there!', 'Hi!', 'Hey, how are you?'],
   avatarUrl: 'https://example.com/avatar.png',
-  responseRate: 80, // Optional: respond 80% of the time
-  skipBotMessages: true // Optional: don't respond to other bots
+  responseRate: 80 // Optional: respond 80% of the time
+  // skipBotMessages is true by default
 });
 ```
 
@@ -40,7 +40,7 @@ The `createBot()` function accepts the following options:
 | `responses` | string[] | Yes | Array of possible responses |
 | `avatarUrl` | string | No | URL to the avatar image for your bot |
 | `responseRate` | number | No | Percentage chance of responding (0-100) |
-| `skipBotMessages` | boolean | No | Whether to ignore messages from other bots |
+| `skipBotMessages` | boolean | No | Whether to ignore messages from other bots (defaults to true) |
 
 ### Pattern and Response Matching
 

--- a/src/starbunk/bots/reply-bots/baby-bot/index.ts
+++ b/src/starbunk/bots/reply-bots/baby-bot/index.ts
@@ -6,6 +6,5 @@ export default createBot({
 	description: 'Posts a Metroid gif when someone mentions "baby"',
 	patterns: [/\bbaby\b/i],
 	responses: ['https://media.tenor.com/NpnXNhWqKcwAAAAC/metroid-samus-aran.gif'],
-	avatarUrl: 'https://i.redd.it/qc9qus78dc581.jpg',
-	skipBotMessages: true
+	avatarUrl: 'https://i.redd.it/qc9qus78dc581.jpg'
 });

--- a/src/starbunk/bots/reply-bots/blue-bot/index.ts
+++ b/src/starbunk/bots/reply-bots/blue-bot/index.ts
@@ -17,7 +17,6 @@ export default BotFactory.createBot({
 		botName: BLUE_BOT_NAME,
 		avatarUrl: BLUE_BOT_AVATARS.Default
 	},
-	skipBotMessages: true,
 	triggers: [
 		// Order matters for processing, but priority is also considered
 		triggerBlueBotNiceVenn,            // Priority 1

--- a/src/starbunk/bots/reply-bots/bot-bot/index.ts
+++ b/src/starbunk/bots/reply-bots/bot-bot/index.ts
@@ -12,5 +12,7 @@ export default BotFactory.createBot({
 	},
 	// Set bot-specific default response rate
 	defaultResponseRate: BOT_BOT_RESPONSE_RATE,
+	// This bot needs to process messages from other bots
+	skipBotMessages: false,
 	triggers: [botTrigger]
 });

--- a/src/starbunk/bots/reply-bots/chad-bot/index.ts
+++ b/src/starbunk/bots/reply-bots/chad-bot/index.ts
@@ -10,8 +10,6 @@ export default BotFactory.createBot({
 		botName: CHAD_BOT_NAME,
 		avatarUrl: CHAD_BOT_AVATAR_URL
 	},
-	// We don't want Chad to respond to other bots
-	skipBotMessages: true,
 	// Always process messages since we handle chance in the trigger
 	defaultResponseRate: 100,
 	// All triggers with their priorities

--- a/src/starbunk/bots/reply-bots/cova-bot/index.ts
+++ b/src/starbunk/bots/reply-bots/cova-bot/index.ts
@@ -111,7 +111,6 @@ export default createReplyBot({
 		botName: 'Cova',
 		avatarUrl: '', // Will be overridden by dynamic identity from Cova's Discord user
 	},
-	skipBotMessages: true,
 	triggers: [
 		covaStatsCommandTrigger, // Highest priority - command for debugging
 		covaDirectMentionTrigger, // Higher priority - always respond to direct mentions

--- a/src/starbunk/bots/reply-bots/example-bot/index.ts
+++ b/src/starbunk/bots/reply-bots/example-bot/index.ts
@@ -6,6 +6,5 @@ export default createBot({
 	patterns: [/\bexample\b/i, /\bsimple\b/i],
 	responses: ['This is an example response from the simplified bot architecture!'],
 	avatarUrl: 'https://example.com/avatar.png',
-	responseRate: 100,
-	skipBotMessages: true,
+	responseRate: 100
 });


### PR DESCRIPTION
Update bot message handling to skip bot messages by default unless explicitly configured otherwise. Adjust tests and documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved test coverage for bot message handling, ensuring correct behavior when skipping or processing messages from other bots.

- **Bug Fixes**
  - Bots now default to skipping messages sent by other bots unless explicitly configured otherwise.

- **Documentation**
  - Updated documentation to clarify the default behavior of the `skipBotMessages` option.

- **Chores**
  - Updated bot configurations to align with the new default for skipping bot messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->