### PR TITLE
Allow Covabot self-response in non-production

### DIFF
--- a/containers/covabot/src/cova-bot/triggers.ts
+++ b/containers/covabot/src/cova-bot/triggers.ts
@@ -24,13 +24,15 @@ async function getCovaIdentityWithValidation(message?: Message) {
 	}
 }
 
+const notFromCova = process.env.NODE_ENV === 'production' ? not(fromUser(userId.Cova)) : () => true;
+
 // Main trigger for CovaBot - uses LLM to decide if it should respond
 export const covaTrigger = createTriggerResponse({
 	name: 'cova-contextual-response',
 	priority: 3,
 	condition: and(
 		createLLMResponseDecisionCondition(), // This now handles all probability logic
-		not(fromUser(userId.Cova)),
+		notFromCova,
 		not(fromBot()),
 		// Removed withChance(50) since LLM decision now handles probability
 	),
@@ -42,7 +44,7 @@ export const covaTrigger = createTriggerResponse({
 export const covaDirectMentionTrigger = createTriggerResponse({
 	name: 'cova-direct-mention',
 	priority: 5, // Highest priority
-	condition: and((message) => message.mentions.has(userId.Cova), not(fromUser(userId.Cova)), not(fromBot())),
+	condition: and((message) => message.mentions.has(userId.Cova), notFromCova, not(fromBot())),
 	response: createLLMEmulatorResponse(),
 	identity: async (message) => getCovaIdentityWithValidation(message),
 });

--- a/containers/covabot/src/cova-bot/triggers.ts
+++ b/containers/covabot/src/cova-bot/triggers.ts
@@ -24,7 +24,10 @@ async function getCovaIdentityWithValidation(message?: Message) {
 	}
 }
 
-const notFromCova = process.env.NODE_ENV === 'production' ? not(fromUser(userId.Cova)) : () => true;
+const notFromCova =
+        process.env.NODE_ENV === 'production'
+                ? not(fromUser(userId.Cova))
+                : (_message) => true;
 
 // Main trigger for CovaBot - uses LLM to decide if it should respond
 export const covaTrigger = createTriggerResponse({

--- a/containers/covabot/src/cova-bot/triggers.ts
+++ b/containers/covabot/src/cova-bot/triggers.ts
@@ -47,7 +47,7 @@ export const covaTrigger = createTriggerResponse({
 export const covaDirectMentionTrigger = createTriggerResponse({
 	name: 'cova-direct-mention',
 	priority: 5, // Highest priority
-	condition: and((message) => message.mentions.has(userId.Cova), notFromCova, not(fromBot())),
+	condition: and((message) => message.mentions.has(userId.Cova), notFromCova, notFromBots),
 	response: createLLMEmulatorResponse(),
 	identity: async (message) => getCovaIdentityWithValidation(message),
 });


### PR DESCRIPTION
## Summary
- Allow Covabot to reply to Cova in non-production by gating self-response exclusion on `NODE_ENV`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f8084edd48332a5761cc9b1e6c3b1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment-aware message filtering for bot triggers: in production the bot ignores messages originating from the bot identity (including direct mentions); in non-production this filter is disabled to ease testing. All other decision logic and identity handling remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->