### PR TITLE
feat(djcova): add attachment support to play command

### DIFF
--- a/containers/djcova/src/commands/play.ts
+++ b/containers/djcova/src/commands/play.ts
@@ -81,7 +81,11 @@ export default {
 					await sendErrorResponse(interaction, 'Failed to retrieve the provided audio file.');
 					return;
 				}
-				source = Readable.fromWeb(response.body as unknown as ReadableStream<Uint8Array>);
+				if (typeof response.body !== 'object' || typeof (response.body as any).getReader !== 'function') {
+					await sendErrorResponse(interaction, 'The provided audio file stream is not supported in this environment.');
+					return;
+				}
+				source = Readable.fromWeb(response.body as ReadableStream<Uint8Array>);
 			} else {
 				source = url!;
 			}

--- a/containers/djcova/src/commands/play.ts
+++ b/containers/djcova/src/commands/play.ts
@@ -1,33 +1,32 @@
 import { AudioPlayerStatus } from '@discordjs/voice';
 import { CommandInteraction, SlashCommandBuilder } from 'discord.js';
+import { Readable } from 'stream';
 import {
 	logger,
 	sendErrorResponse,
 	sendSuccessResponse,
 	deferInteractionReply,
 	container,
-	ServiceId
+	ServiceId,
 } from '@starbunk/shared';
-import {
-	validateVoiceChannelAccess,
-	createVoiceConnection,
-	subscribePlayerToConnection
-} from '../utils/voiceUtils';
+import { validateVoiceChannelAccess, createVoiceConnection, subscribePlayerToConnection } from '../utils/voiceUtils';
 import { DJCova } from '../djCova';
 
 const commandBuilder = new SlashCommandBuilder()
 	.setName('play')
-	.setDescription('Play a YouTube link in voice chat')
-	.addStringOption((option) => option.setName('song').setDescription('YouTube video URL').setRequired(true));
+	.setDescription('Play a YouTube link or audio file in voice chat')
+	.addStringOption((option) => option.setName('song').setDescription('YouTube video URL').setRequired(false))
+	.addAttachmentOption((option) => option.setName('file').setDescription('Audio file (.mp3, .wav, etc.)'));
 
 export default {
 	data: commandBuilder.toJSON(),
 	async execute(interaction: CommandInteraction) {
-		const url = interaction.options.get('song')?.value as string;
+		const attachment = interaction.options.getAttachment('file');
+		const url = interaction.options.getString('song');
 
-		if (!url) {
-			logger.warn('Play command executed without URL');
-			await sendErrorResponse(interaction, 'Please provide a valid YouTube link!');
+		if (!attachment && !url) {
+			logger.warn('Play command executed without URL or attachment');
+			await sendErrorResponse(interaction, 'Please provide a valid YouTube link or audio file!');
 			return;
 		}
 
@@ -41,14 +40,12 @@ export default {
 		const { voiceChannel } = voiceValidation;
 
 		try {
-			logger.info(`🎵 Attempting to play: ${url}`);
+			const sourceName = attachment ? attachment.name : url!;
+			logger.info(`🎵 Attempting to play: ${sourceName}`);
 			await deferInteractionReply(interaction);
 
 			// Create voice connection
-			const connection = createVoiceConnection(
-				voiceChannel!,
-				voiceChannel!.guild.voiceAdapterCreator
-			);
+			const connection = createVoiceConnection(voiceChannel!, voiceChannel!.guild.voiceAdapterCreator);
 
 			// Get music player from container
 			const musicPlayer = container.get<DJCova>(ServiceId.MusicPlayer);
@@ -58,15 +55,14 @@ export default {
 				try {
 					await interaction.followUp({ content: message, ephemeral: false });
 				} catch (error) {
-					logger.error('Failed to send auto-disconnect notification:', error instanceof Error ? error : new Error(String(error)));
+					logger.error(
+						'Failed to send auto-disconnect notification:',
+						error instanceof Error ? error : new Error(String(error)),
+					);
 				}
 			};
 
-			musicPlayer.initializeIdleManagement(
-				interaction.guild!.id,
-				interaction.channelId,
-				notificationCallback
-			);
+			musicPlayer.initializeIdleManagement(interaction.guild!.id, interaction.channelId, notificationCallback);
 
 			// Set up audio player event handlers
 			musicPlayer.on(AudioPlayerStatus.Playing, () => {
@@ -77,8 +73,21 @@ export default {
 				logger.info('⏹️ Audio playback ended');
 			});
 
+			// Resolve audio source
+			let source: string | Readable;
+			if (attachment) {
+				const response = await fetch(attachment.url);
+				if (!response.body) {
+					await sendErrorResponse(interaction, 'Failed to retrieve the provided audio file.');
+					return;
+				}
+				source = Readable.fromWeb(response.body as unknown as ReadableStream<Uint8Array>);
+			} else {
+				source = url!;
+			}
+
 			// Start playing the audio
-			await musicPlayer.start(url);
+			await musicPlayer.start(source);
 
 			// Subscribe player to voice connection
 			const subscription = subscribePlayerToConnection(connection, musicPlayer.getPlayer());
@@ -88,7 +97,7 @@ export default {
 			}
 
 			logger.info('Successfully subscribed to voice connection');
-			await sendSuccessResponse(interaction, `🎶 Now playing: ${url}`);
+			await sendSuccessResponse(interaction, `🎶 Now playing: ${sourceName}`);
 		} catch (error) {
 			logger.error('Error executing play command', error instanceof Error ? error : new Error(String(error)));
 			await sendErrorResponse(interaction, 'An error occurred while trying to play the music.');


### PR DESCRIPTION
## Summary
- allow `/play` to accept an audio file attachment
- handle attachment streams and generic URLs in the DJCova player
- expand tests for `/play` to cover audio file support

## Testing
- `npm run lint`
- `npm run type-check:djcova` *(fails: Cannot find module '@starbunk/shared' or its corresponding type declarations)*
- `npm run test:djcova` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8670f00d48332bbc277c31c030839

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Play command now accepts either a YouTube link or an uploaded audio file.
  * Streams attached audio files directly; “Now Playing” shows the file name when used.
* **Bug Fixes**
  * Clear user message when no URL or file is provided.
  * Improved error handling if an attached file can’t be read or streamed, preventing silent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->