### PR TITLE
fix(djcova): resolve command registration issues preventing /play from appearing

### DIFF
--- a/apps/djcova/src/commands/play.ts
+++ b/apps/djcova/src/commands/play.ts
@@ -1,18 +1,5 @@
 import { AudioPlayerStatus } from '@discordjs/voice';
-import { SlashCommandBuilder } from 'discord.js';
-// Minimal interaction shape for this command
-type InteractionLike = {
-	options: {
-		getString(name: string): string | null;
-		getAttachment(name: string): { url: string; name: string } | null;
-	};
-	guild?: { id: string } | null;
-	channelId: string;
-	replied?: boolean;
-	deferred?: boolean;
-	reply: (opts: { content: string; ephemeral?: boolean }) => Promise<unknown>;
-	followUp: (opts: { content: string; ephemeral?: boolean }) => Promise<unknown>;
-};
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
 
 import { Readable } from 'stream';
 import type { ReadableStream as WebReadableStream } from 'node:stream/web';
@@ -27,27 +14,16 @@ import {
 } from '@starbunk/shared';
 import { validateVoiceChannelAccess, createVoiceConnection, subscribePlayerToConnection } from '../utils/voiceUtils';
 import { DJCova } from '../djCova';
-// Local minimal types for builder options
-export type StringOpt = {
-	setName(n: string): StringOpt;
-	setDescription(d: string): StringOpt;
-	setRequired(r: boolean): StringOpt;
-};
-export type AttachmentOpt = { setName(n: string): AttachmentOpt; setDescription(d: string): AttachmentOpt };
 
 const commandBuilder = new SlashCommandBuilder()
 	.setName('play')
 	.setDescription('Play a YouTube link or audio file in voice chat')
-	.addStringOption((option: StringOpt) =>
-		option.setName('song').setDescription('YouTube video URL').setRequired(false),
-	)
-	.addAttachmentOption((option: AttachmentOpt) =>
-		option.setName('file').setDescription('Audio file (.mp3, .wav, etc.)'),
-	);
+	.addStringOption((option) => option.setName('song').setDescription('YouTube video URL').setRequired(false))
+	.addAttachmentOption((option) => option.setName('file').setDescription('Audio file (.mp3, .wav, etc.)'));
 
 export default {
 	data: commandBuilder.toJSON(),
-	async execute(interaction: InteractionLike) {
+	async execute(interaction: ChatInputCommandInteraction) {
 		const attachment = interaction.options.getAttachment('file');
 		const url = interaction.options.getString('song');
 

--- a/apps/djcova/src/commands/setVolume.ts
+++ b/apps/djcova/src/commands/setVolume.ts
@@ -1,37 +1,18 @@
-import { SlashCommandBuilder } from 'discord.js';
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
 import { logger, sendErrorResponse, sendSuccessResponse, container, ServiceId } from '@starbunk/shared';
-
-// Minimal interaction shape for this command
-type InteractionLike = {
-	options: {
-		get(name: string): { value?: number } | null;
-	};
-	replied?: boolean;
-	deferred?: boolean;
-	reply: (opts: { content: string; ephemeral?: boolean }) => Promise<unknown>;
-	followUp: (opts: { content: string; ephemeral?: boolean }) => Promise<unknown>;
-};
 import { DJCova } from '../djCova';
-// Local minimal type for integer option builder
-export type IntegerOpt = {
-	setName(n: string): IntegerOpt;
-	setDescription(d: string): IntegerOpt;
-	setRequired(r: boolean): IntegerOpt;
-};
 
 const commandBuilder = new SlashCommandBuilder()
 	.setName('volume')
 	.setDescription('It makes the noises go up and down')
-	.addIntegerOption((option: IntegerOpt) =>
-		option.setName('noise').setDescription('set player volume %').setRequired(true),
-	);
+	.addIntegerOption((option) => option.setName('noise').setDescription('set player volume %').setRequired(true));
 
 export default {
 	data: commandBuilder.toJSON(),
-	async execute(interaction: InteractionLike) {
+	async execute(interaction: ChatInputCommandInteraction) {
 		try {
 			// Get volume from the 'noise' option (as defined in the command builder)
-			const vol = interaction.options.get('noise')?.value as number;
+			const vol = interaction.options.getInteger('noise');
 
 			if (!vol || vol < 1 || vol > 100) {
 				await sendErrorResponse(interaction, 'Volume must be between 1 and 100!');

--- a/apps/djcova/src/commands/status.ts
+++ b/apps/djcova/src/commands/status.ts
@@ -1,13 +1,5 @@
-import { SlashCommandBuilder } from 'discord.js';
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
 import { logger, sendErrorResponse, sendSuccessResponse, container, ServiceId } from '@starbunk/shared';
-
-// Minimal interaction shape for this command
-type InteractionLike = {
-	replied?: boolean;
-	deferred?: boolean;
-	reply: (opts: { content: string; ephemeral?: boolean }) => Promise<unknown>;
-	followUp: (opts: { content: string; ephemeral?: boolean }) => Promise<unknown>;
-};
 import { DJCova } from '../djCova';
 
 const commandBuilder = new SlashCommandBuilder()
@@ -16,7 +8,7 @@ const commandBuilder = new SlashCommandBuilder()
 
 export default {
 	data: commandBuilder.toJSON(),
-	async execute(interaction: InteractionLike) {
+	async execute(interaction: ChatInputCommandInteraction) {
 		try {
 			// Get music player from container
 			const musicPlayer = container.get<DJCova>(ServiceId.MusicPlayer);

--- a/apps/djcova/src/commands/stop.ts
+++ b/apps/djcova/src/commands/stop.ts
@@ -1,14 +1,5 @@
-import { SlashCommandBuilder } from 'discord.js';
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
 import { logger, sendErrorResponse, sendSuccessResponse, container, ServiceId } from '@starbunk/shared';
-
-// Minimal interaction shape for this command
-type InteractionLike = {
-	guild?: { id: string } | null;
-	replied?: boolean;
-	deferred?: boolean;
-	reply: (opts: { content: string; ephemeral?: boolean }) => Promise<unknown>;
-	followUp: (opts: { content: string; ephemeral?: boolean }) => Promise<unknown>;
-};
 import { disconnectVoiceConnection } from '../utils/voiceUtils';
 import { DJCova } from '../djCova';
 
@@ -16,7 +7,7 @@ const commandBuilder = new SlashCommandBuilder().setName('stop').setDescription(
 
 export default {
 	data: commandBuilder.toJSON(),
-	async execute(interaction: InteractionLike) {
+	async execute(interaction: ChatInputCommandInteraction) {
 		try {
 			// Get music player from container
 			const musicPlayer = container.get<DJCova>(ServiceId.MusicPlayer);

--- a/apps/djcova/tsconfig.json
+++ b/apps/djcova/tsconfig.json
@@ -28,14 +28,7 @@
 		"node_modules",
 		"dist",
 		"tests",
-		"src/**/__tests__/**",
-		"src/services/personalityNotesServiceDb.ts",
-		"src/cova-bot/enhancedLlmTriggers.ts",
-		"src/cova-bot/llm-triggers.ts",
-		"src/cova-bot/index.ts",
-		"src/commands/**/*.ts",
-		"src/index.ts",
-		"src/commandHandler.ts"
+		"src/**/__tests__/**"
 	],
 	"references": [
 		{ "path": "../../packages/shared" }


### PR DESCRIPTION
## Problem
DJCova's `/play` command was not appearing in Discord due to critical TypeScript configuration errors that excluded essential files from compilation.

## Root Cause Analysis
- ❌ TypeScript config excluded `src/commands/**/*.ts` preventing command compilation
- ❌ TypeScript config excluded `src/index.ts` and `src/commandHandler.ts` 
- ❌ Custom type definitions caused Discord.js type mismatches
- ❌ Build process silently failed, commands never reached Discord

## Solution Implementation
- ✅ **Fixed tsconfig.json exclusions** - Removed incorrect file exclusions
- ✅ **Updated command types** - Migrated to proper `ChatInputCommandInteraction` types
- ✅ **Removed custom types** - Used Discord.js native types for better compatibility
- ✅ **Verified build process** - All commands now compile successfully

## Impact & Benefits
- 🎵 **`/play` command now appears** in Discord - Core functionality restored
- 🎛️ **All DJCova commands working** - `/play`, `/stop`, `/volume`, `/status`
- 🏗️ **Clean build process** - No TypeScript compilation errors
- 📊 **Container startup success** - Proper initialization with observability

## Technical Details
### Files Modified
- `apps/djcova/tsconfig.json` - Fixed exclusion patterns
- `apps/djcova/src/commands/*.ts` - Updated to use proper Discord.js types

### Testing Completed
- ✅ `npm run build:djcova` - Successful compilation
- ✅ `npm run lint` - No linting errors  
- ✅ `npm run type-check` - No TypeScript errors
- ✅ `npm run dev:djcova` - Container starts successfully
- ✅ Pre-push validation - All automated checks pass

## Validation Results
```
[✅] Building completed (2s)
[✅] Type checking completed (1s) 
[✅] Linting completed (1s)
[✅] Testing completed (1s)
[✅] All validations passed!
```

## What's Next
This fixes the foundation issue preventing DJCova from working. Next phase will implement:
- Queue management system
- Enhanced audio player (pause/resume/skip)
- Multi-format audio source support
- Extended command set

**Ready for review and testing!** 🚀

🤖 Generated with [Claude Code](https://claude.ai/code)