### PR TITLE
fix(djcova): correct Discord.js imports to fix production build

### DIFF
--- a/apps/djcova/src/commandHandler.ts
+++ b/apps/djcova/src/commandHandler.ts
@@ -1,4 +1,5 @@
-import { REST, Routes } from 'discord.js';
+import { REST } from '@discordjs/rest';
+import { Routes } from 'discord-api-types/v10';
 import fs from 'fs';
 // Minimal interaction shape used by this handler (structural typing)
 type InteractionLike = {

--- a/apps/djcova/src/commands/play.ts
+++ b/apps/djcova/src/commands/play.ts
@@ -1,5 +1,6 @@
 import { AudioPlayerStatus } from '@discordjs/voice';
-import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { ChatInputCommandInteraction } from 'discord.js';
 
 import { Readable } from 'stream';
 import type { ReadableStream as WebReadableStream } from 'node:stream/web';

--- a/apps/djcova/src/commands/setVolume.ts
+++ b/apps/djcova/src/commands/setVolume.ts
@@ -1,4 +1,5 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { ChatInputCommandInteraction } from 'discord.js';
 import { logger, sendErrorResponse, sendSuccessResponse, container, ServiceId } from '@starbunk/shared';
 import { DJCova } from '../djCova';
 

--- a/apps/djcova/src/commands/status.ts
+++ b/apps/djcova/src/commands/status.ts
@@ -1,4 +1,5 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { ChatInputCommandInteraction } from 'discord.js';
 import { logger, sendErrorResponse, sendSuccessResponse, container, ServiceId } from '@starbunk/shared';
 import { DJCova } from '../djCova';
 

--- a/apps/djcova/src/commands/stop.ts
+++ b/apps/djcova/src/commands/stop.ts
@@ -1,4 +1,5 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { ChatInputCommandInteraction } from 'discord.js';
 import { logger, sendErrorResponse, sendSuccessResponse, container, ServiceId } from '@starbunk/shared';
 import { disconnectVoiceConnection } from '../utils/voiceUtils';
 import { DJCova } from '../djCova';


### PR DESCRIPTION
## Summary
- Fixed incorrect Discord.js imports preventing production build
- Updated SlashCommandBuilder imports to use @discordjs/builders
- Updated REST and Routes imports to use correct packages
- All commands now build successfully

## Root Cause
Discord.js v14 exports specialized classes from separate packages, not from the main discord.js module. The codebase was incorrectly importing `SlashCommandBuilder`, `REST`, and `Routes` from `discord.js` instead of their proper packages.

## Changes
- `SlashCommandBuilder` → import from `@discordjs/builders`
- `REST` → import from `@discordjs/rest`
- `Routes` → import from `discord-api-types/v10`

## Files Changed
- apps/djcova/src/commands/play.ts
- apps/djcova/src/commands/stop.ts
- apps/djcova/src/commands/status.ts
- apps/djcova/src/commands/setVolume.ts
- apps/djcova/src/commandHandler.ts

## Test Plan
- [x] TypeScript build completes successfully
- [x] All command files compile to dist/
- [ ] Deploy to production and verify /play command works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated Discord library imports to align with current best practices, separating builders, routes, and REST client modules.
  - Standardized command definitions across play, set volume, status, and stop for consistency.
  - No changes to bot behavior, commands, or user experience.

- Chores
  - Minor code cleanup to improve maintainability and future compatibility without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->