### PR TITLE
feat: standardize health ports and add covabot training infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,9 @@ scripts/*
 
 *.md
 
+# Claude Code local configuration
+.claude/
+
 # Allow the pre-push gate script to be tracked
 !scripts/
 !scripts/pre-push.sh

--- a/apps/bunkbot/package-lock.json
+++ b/apps/bunkbot/package-lock.json
@@ -48,6 +48,7 @@
 				"discord.js": "^14.18.0",
 				"dotenv": "^16.5.0",
 				"envalid": "^8.0.0",
+				"ioredis": "^5.3.2",
 				"node-fetch": "^2.7.0",
 				"node-schedule": "^2.1.1",
 				"openai": "^5.3.0",
@@ -57,6 +58,7 @@
 				"zod": "^3.24.2"
 			},
 			"devDependencies": {
+				"@types/ioredis": "^5.0.0",
 				"@types/jest": "^29.5.14",
 				"@types/node": "^20.17.14",
 				"@types/node-schedule": "^2.1.7",

--- a/apps/bunkbot/src/index.ts
+++ b/apps/bunkbot/src/index.ts
@@ -316,7 +316,7 @@ class BunkBotContainer {
 			}
 		});
 
-		const port = process.env.HEALTH_PORT ? parseInt(process.env.HEALTH_PORT) : 3002;
+		const port = process.env.HEALTH_PORT ? parseInt(process.env.HEALTH_PORT) : 3331;
 		this.healthServer.listen(port, () => {
 			logger.info(`🏥 Health check server running on port ${port}`);
 		});

--- a/apps/bunkbot/src/services/HealthServer.ts
+++ b/apps/bunkbot/src/services/HealthServer.ts
@@ -69,7 +69,7 @@ export class HealthServer {
 	private readonly maxResponseTimes = 100; // Keep last 100 response times
 
 	constructor(port?: number) {
-		this.port = port || parseInt(process.env.HEALTH_PORT || '3002');
+		this.port = port || parseInt(process.env.HEALTH_PORT || '3331');
 		this.metrics = {
 			totalRequests: 0,
 			errorCount: 0,

--- a/apps/covabot/package-lock.json
+++ b/apps/covabot/package-lock.json
@@ -19,6 +19,7 @@
 				"dotenv": "^16.5.0",
 				"express": "^5.1.0",
 				"multer": "^2.0.1",
+				"ollama": "^0.6.0",
 				"openai": "^4.95.1",
 				"rxjs": "^7.8.2",
 				"uuid": "^11.1.0",
@@ -57,6 +58,7 @@
 				"discord.js": "^14.18.0",
 				"dotenv": "^16.5.0",
 				"envalid": "^8.0.0",
+				"ioredis": "^5.3.2",
 				"node-fetch": "^2.7.0",
 				"node-schedule": "^2.1.1",
 				"openai": "^5.3.0",
@@ -66,6 +68,7 @@
 				"zod": "^3.24.2"
 			},
 			"devDependencies": {
+				"@types/ioredis": "^5.0.0",
 				"@types/jest": "^29.5.14",
 				"@types/node": "^20.17.14",
 				"@types/node-schedule": "^2.1.7",
@@ -8731,6 +8734,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/ollama": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/ollama/-/ollama-0.6.0.tgz",
+			"integrity": "sha512-FHjdU2Ok5x2HZsxPui/MBJZ5J+HzmxoWYa/p9wk736eT+uAhS8nvIICar5YgwlG5MFNjDR6UA5F3RSKq+JseOA==",
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-fetch": "^3.6.20"
+			}
+		},
 		"node_modules/on-finished": {
 			"version": "2.4.1",
 			"license": "MIT",
@@ -10408,6 +10420,12 @@
 		"node_modules/webidl-conversions": {
 			"version": "3.0.1",
 			"license": "BSD-2-Clause"
+		},
+		"node_modules/whatwg-fetch": {
+			"version": "3.6.20",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+			"integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+			"license": "MIT"
 		},
 		"node_modules/whatwg-url": {
 			"version": "5.0.0",

--- a/apps/covabot/package.json
+++ b/apps/covabot/package.json
@@ -11,8 +11,10 @@
 		"build:docker": "tsc -p tsconfig.docker.json && tsc-alias -p tsconfig.docker.json",
 		"start": "node dist/index-minimal.js",
 		"start:web": "node dist/index-web.js",
+		"start:simple": "node dist/index-simple.js",
 		"dev": "cross-env NODE_ENV=development DEBUG=true ts-node-dev --respawn --transpile-only -r tsconfig-paths/register src/index-minimal.ts",
 		"dev:web": "cross-env NODE_ENV=development DEBUG=true ts-node-dev --respawn --transpile-only -r tsconfig-paths/register src/index-web.ts",
+		"dev:simple": "cross-env NODE_ENV=development DEBUG=true ts-node-dev --respawn --transpile-only -r tsconfig-paths/register src/index-simple.ts",
 		"test": "jest",
 		"type-check": "tsc --noEmit",
 		"lint": "eslint src/**/*.ts",
@@ -29,7 +31,9 @@
 		"test:unraid:simple": "ts-node -r tsconfig-paths/register src/scripts/test-unraid-simple.ts",
 		"test:unraid:full": "npm run test:unraid && npm run test:persistence",
 		"test:web": "node test-web-interface.js",
-		"validate": "node validate-production.js"
+		"validate": "node validate-production.js",
+		"collect-training-data": "ts-node -r tsconfig-paths/register scripts/collectTrainingData.ts",
+		"validate-bot": "ts-node -r tsconfig-paths/register scripts/validateBot.ts"
 	},
 	"dependencies": {
 		"@discordjs/builders": "^1.6.5",
@@ -43,6 +47,7 @@
 		"dotenv": "^16.5.0",
 		"express": "^5.1.0",
 		"multer": "^2.0.1",
+		"ollama": "^0.6.0",
 		"openai": "^4.95.1",
 		"rxjs": "^7.8.2",
 		"uuid": "^11.1.0",

--- a/apps/covabot/scripts/collectTrainingData.ts
+++ b/apps/covabot/scripts/collectTrainingData.ts
@@ -1,0 +1,344 @@
+/**
+ * Training Data Collection Script
+ *
+ * Analyzes your actual Discord message history to understand:
+ * 1. When do you respond vs ignore?
+ * 2. What's your response style?
+ * 3. What phrases do you use?
+ * 4. What topics trigger responses?
+ */
+
+import { Client, GatewayIntentBits, TextChannel, Message, Collection } from 'discord.js';
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+
+const YOUR_USER_ID = '139592376443338752'; // Cova's Discord ID
+
+interface MessageData {
+	id: string;
+	content: string;
+	author: string;
+	authorId: string;
+	timestamp: Date;
+	channelId: string;
+	channelName: string;
+}
+
+interface ResponsePattern {
+	context: MessageData[];
+	yourResponse: MessageData;
+	timeSinceLastMessage: number; // ms
+	responseTime: number; // ms between trigger and your response
+}
+
+interface NonResponsePattern {
+	context: MessageData[];
+	messageYouIgnored: MessageData;
+	whyIgnored?: string; // We can infer this
+}
+
+interface TrainingData {
+	// When you DO respond
+	responsePatterns: ResponsePattern[];
+
+	// When you DON'T respond
+	nonResponsePatterns: NonResponsePattern[];
+
+	// Your writing style
+	yourPhrases: Record<string, number>; // phrase -> frequency
+	averageResponseLength: number;
+	commonWords: string[];
+
+	// Timing patterns
+	averageResponseTime: number;
+	mostActiveHours: number[];
+
+	// Topics you care about
+	topicKeywords: Record<string, number>;
+}
+
+async function collectData() {
+	console.log('🔍 Starting training data collection...\n');
+
+	const client = new Client({
+		intents: [
+			GatewayIntentBits.Guilds,
+			GatewayIntentBits.GuildMessages,
+			GatewayIntentBits.MessageContent,
+		],
+	});
+
+	const token = process.env.COVABOT_TOKEN || process.env.STARBUNK_TOKEN;
+	if (!token) {
+		throw new Error('Need COVABOT_TOKEN or STARBUNK_TOKEN');
+	}
+
+	await client.login(token);
+	await new Promise(resolve => client.once('ready', resolve));
+
+	console.log(`✅ Logged in as ${client.user?.tag}\n`);
+
+	const trainingData: TrainingData = {
+		responsePatterns: [],
+		nonResponsePatterns: [],
+		yourPhrases: {},
+		averageResponseLength: 0,
+		commonWords: [],
+		averageResponseTime: 0,
+		mostActiveHours: [],
+		topicKeywords: {},
+	};
+
+	// Get all text channels you have access to
+	const channels: TextChannel[] = [];
+	for (const guild of client.guilds.cache.values()) {
+		for (const channel of guild.channels.cache.values()) {
+			if (channel.isTextBased() && !channel.isDMBased()) {
+				channels.push(channel as TextChannel);
+			}
+		}
+	}
+
+	console.log(`📊 Found ${channels.length} channels to analyze\n`);
+
+	// Analyze each channel
+	for (const channel of channels) {
+		try {
+			console.log(`Analyzing #${channel.name}...`);
+			await analyzeChannel(channel, trainingData);
+		} catch (error) {
+			console.error(`Error analyzing #${channel.name}:`, error);
+		}
+	}
+
+	// Calculate aggregates
+	calculateAggregates(trainingData);
+
+	// Save to file
+	const outputPath = join(__dirname, '../data/training-data.json');
+	writeFileSync(outputPath, JSON.stringify(trainingData, null, 2));
+	console.log(`\n✅ Training data saved to: ${outputPath}`);
+
+	// Print summary
+	printSummary(trainingData);
+
+	await client.destroy();
+	process.exit(0);
+}
+
+async function analyzeChannel(channel: TextChannel, data: TrainingData) {
+	try {
+		// Fetch recent messages (Discord limit is 100 per request, can fetch multiple times)
+		let allMessages: Message[] = [];
+		let lastId: string | undefined;
+
+		// Fetch up to 500 messages
+		for (let i = 0; i < 5; i++) {
+			const fetchOptions: { limit: number; before?: string } = { limit: 100 };
+			if (lastId) {
+				fetchOptions.before = lastId;
+			}
+
+			const messagesCollection: Collection<string, Message> = await channel.messages.fetch(fetchOptions);
+
+			if (messagesCollection.size === 0) break;
+
+			const messagesArray = Array.from(messagesCollection.values());
+			allMessages.push(...messagesArray);
+
+			const lastMessage = messagesArray[messagesArray.length - 1];
+			if (lastMessage) {
+				lastId = lastMessage.id;
+			}
+		}
+
+		// Sort by timestamp
+		allMessages.sort((a, b) => a.createdTimestamp - b.createdTimestamp);
+
+		console.log(`  Found ${allMessages.length} messages`);
+
+		// Analyze message patterns
+		for (let i = 0; i < allMessages.length; i++) {
+			const message = allMessages[i];
+
+			// Is this YOUR message?
+			if (message.author.id === YOUR_USER_ID) {
+				// This is a response from you
+				const context = allMessages.slice(Math.max(0, i - 10), i); // 10 messages before
+
+				if (context.length > 0) {
+					const lastMessage = context[context.length - 1];
+					const responseTime = message.createdTimestamp - lastMessage.createdTimestamp;
+
+					data.responsePatterns.push({
+						context: context.map(toMessageData),
+						yourResponse: toMessageData(message),
+						timeSinceLastMessage: responseTime,
+						responseTime,
+					});
+
+					// Analyze your writing
+					analyzeYourWriting(message.content, data);
+				}
+			} else {
+				// Someone else's message - did you respond?
+				const nextMessages = allMessages.slice(i + 1, Math.min(i + 6, allMessages.length));
+				const youResponded = nextMessages.some(m => m.author.id === YOUR_USER_ID);
+
+				if (!youResponded) {
+					// You DIDN'T respond to this
+					const context = allMessages.slice(Math.max(0, i - 10), i);
+
+					data.nonResponsePatterns.push({
+						context: context.map(toMessageData),
+						messageYouIgnored: toMessageData(message),
+						whyIgnored: inferWhyIgnored(message),
+					});
+				}
+			}
+		}
+	} catch (error: any) {
+		if (error.code === 50013) {
+			console.log(`  ⏭️  No permission to read #${channel.name}`);
+		} else {
+			throw error;
+		}
+	}
+}
+
+function toMessageData(message: Message): MessageData {
+	return {
+		id: message.id,
+		content: message.content,
+		author: message.author.username,
+		authorId: message.author.id,
+		timestamp: message.createdAt,
+		channelId: message.channel.id,
+		channelName: (message.channel as TextChannel).name || 'unknown',
+	};
+}
+
+function analyzeYourWriting(content: string, data: TrainingData) {
+	// Extract phrases (2-4 words)
+	const words = content.toLowerCase().split(/\s+/);
+
+	for (let i = 0; i < words.length - 1; i++) {
+		const twoWord = words.slice(i, i + 2).join(' ');
+		data.yourPhrases[twoWord] = (data.yourPhrases[twoWord] || 0) + 1;
+
+		if (i < words.length - 2) {
+			const threeWord = words.slice(i, i + 3).join(' ');
+			data.yourPhrases[threeWord] = (data.yourPhrases[threeWord] || 0) + 1;
+		}
+	}
+
+	// Extract topic keywords
+	const topicWords = ['code', 'bot', 'docker', 'deploy', 'typescript', 'javascript', 'server', 'music', 'game'];
+	for (const word of words) {
+		if (topicWords.includes(word)) {
+			data.topicKeywords[word] = (data.topicKeywords[word] || 0) + 1;
+		}
+	}
+}
+
+function inferWhyIgnored(message: Message): string {
+	const content = message.content.toLowerCase();
+
+	if (content.length < 10) return 'Very short message';
+	if (!content.includes('?') && content.split(' ').length < 5) return 'Brief statement';
+	if (content.match(/^(lol|haha|lmao|nice|cool|yeah|ok)$/)) return 'Simple reaction';
+	if (!content.match(/code|bot|docker|typescript|tech/)) return 'Not technical topic';
+
+	return 'Unknown reason';
+}
+
+function calculateAggregates(data: TrainingData) {
+	// Average response length
+	if (data.responsePatterns.length > 0) {
+		const totalLength = data.responsePatterns.reduce((sum, p) => sum + p.yourResponse.content.length, 0);
+		data.averageResponseLength = totalLength / data.responsePatterns.length;
+	}
+
+	// Average response time
+	if (data.responsePatterns.length > 0) {
+		const totalTime = data.responsePatterns.reduce((sum, p) => sum + p.responseTime, 0);
+		data.averageResponseTime = totalTime / data.responsePatterns.length;
+	}
+
+	// Most common phrases (top 20)
+	const sortedPhrases = Object.entries(data.yourPhrases)
+		.sort((a, b) => b[1] - a[1])
+		.slice(0, 20);
+
+	data.yourPhrases = Object.fromEntries(sortedPhrases);
+
+	// Most active hours
+	const hourCounts: Record<number, number> = {};
+	for (const pattern of data.responsePatterns) {
+		const hour = pattern.yourResponse.timestamp.getHours();
+		hourCounts[hour] = (hourCounts[hour] || 0) + 1;
+	}
+
+	data.mostActiveHours = Object.entries(hourCounts)
+		.sort((a, b) => b[1] - a[1])
+		.slice(0, 5)
+		.map(([hour]) => parseInt(hour));
+
+	// Common words (single words, filtered)
+	const wordCounts: Record<string, number> = {};
+	for (const pattern of data.responsePatterns) {
+		const words = pattern.yourResponse.content.toLowerCase()
+			.split(/\s+/)
+			.filter(w => w.length > 3); // Filter short words
+
+		for (const word of words) {
+			wordCounts[word] = (wordCounts[word] || 0) + 1;
+		}
+	}
+
+	data.commonWords = Object.entries(wordCounts)
+		.sort((a, b) => b[1] - a[1])
+		.slice(0, 30)
+		.map(([word]) => word);
+}
+
+function printSummary(data: TrainingData) {
+	console.log('\n📊 TRAINING DATA SUMMARY\n');
+	console.log('='.repeat(50));
+
+	console.log('\n📈 Response Patterns:');
+	console.log(`  Messages you responded to: ${data.responsePatterns.length}`);
+	console.log(`  Messages you ignored: ${data.nonResponsePatterns.length}`);
+	const responseRate = (data.responsePatterns.length / (data.responsePatterns.length + data.nonResponsePatterns.length) * 100).toFixed(1);
+	console.log(`  Response rate: ${responseRate}%`);
+
+	console.log('\n✍️  Your Writing Style:');
+	console.log(`  Average response length: ${data.averageResponseLength.toFixed(0)} characters`);
+	console.log(`  Average response time: ${(data.averageResponseTime / 1000).toFixed(1)} seconds`);
+
+	console.log('\n💬 Most Common Phrases:');
+	Object.entries(data.yourPhrases).slice(0, 10).forEach(([phrase, count]) => {
+		console.log(`  "${phrase}": ${count} times`);
+	});
+
+	console.log('\n🔤 Common Words:');
+	console.log(`  ${data.commonWords.slice(0, 15).join(', ')}`);
+
+	console.log('\n🕐 Most Active Hours:');
+	console.log(`  ${data.mostActiveHours.map(h => `${h}:00`).join(', ')}`);
+
+	console.log('\n🎯 Topics You Engage With:');
+	Object.entries(data.topicKeywords).slice(0, 10).forEach(([topic, count]) => {
+		console.log(`  ${topic}: ${count} mentions`);
+	});
+
+	console.log('\n' + '='.repeat(50));
+	console.log('\n✅ Next steps:');
+	console.log('  1. Review data/training-data.json');
+	console.log('  2. Update data/personality.json with insights');
+	console.log('  3. Add real examples to exampleResponses');
+	console.log('  4. Test the bot with improved data\n');
+}
+
+// Run the script
+collectData().catch(console.error);

--- a/apps/covabot/scripts/validateBot.ts
+++ b/apps/covabot/scripts/validateBot.ts
@@ -1,0 +1,327 @@
+/**
+ * Bot Validation Script
+ *
+ * Tests the bot against your actual behavior to measure accuracy
+ * Requires: training-data.json from collectTrainingData.ts
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { Ollama } from 'ollama';
+
+interface TestCase {
+	scenario: string;
+	context: Array<{ author: string; content: string }>;
+	youDid: 'respond' | 'ignore';
+	yourActualResponse?: string;
+}
+
+interface ValidationResults {
+	accuracy: number;
+	precision: number;
+	recall: number;
+	details: {
+		truePositives: number; // Correctly responded
+		falsePositives: number; // Responded when you wouldn't
+		trueNegatives: number; // Correctly stayed silent
+		falseNegatives: number; // Stayed silent when you'd respond
+	};
+	styleMatches: {
+		usedYourPhrases: number;
+		similarLength: number;
+		similarTone: number;
+	};
+	examples: Array<{
+		scenario: string;
+		expected: string;
+		botDid: string;
+		correct: boolean;
+	}>;
+}
+
+async function validateBot() {
+	console.log('🧪 Starting bot validation...\n');
+
+	// Load training data
+	const trainingDataPath = join(__dirname, '../data/training-data.json');
+	let trainingData: any;
+
+	try {
+		trainingData = JSON.parse(readFileSync(trainingDataPath, 'utf-8'));
+	} catch (error) {
+		console.error('❌ Could not load training-data.json');
+		console.error('   Run: npm run collect-training-data first');
+		process.exit(1);
+	}
+
+	// Load personality
+	const personalityPath = join(__dirname, '../data/personality.json');
+	const personality = JSON.parse(readFileSync(personalityPath, 'utf-8'));
+
+	// Create test cases from training data
+	const testCases = createTestCases(trainingData);
+	console.log(`📋 Created ${testCases.length} test cases\n`);
+
+	// Initialize Ollama
+	const ollama = new Ollama({
+		host: process.env.OLLAMA_API_URL || 'http://localhost:11434',
+	});
+
+	const results: ValidationResults = {
+		accuracy: 0,
+		precision: 0,
+		recall: 0,
+		details: {
+			truePositives: 0,
+			falsePositives: 0,
+			trueNegatives: 0,
+			falseNegatives: 0,
+		},
+		styleMatches: {
+			usedYourPhrases: 0,
+			similarLength: 0,
+			similarTone: 0,
+		},
+		examples: [],
+	};
+
+	// Test each case
+	let testNum = 0;
+	for (const testCase of testCases.slice(0, 50)) {
+		// Limit to 50 tests for speed
+		testNum++;
+		process.stdout.write(`\rTesting ${testNum}/${Math.min(50, testCases.length)}...`);
+
+		const botResponse = await testWithBot(testCase, personality, ollama);
+		const botResponded = botResponse !== 'SKIP' && botResponse.trim() !== '';
+
+		// Check decision accuracy
+		if (testCase.youDid === 'respond' && botResponded) {
+			results.details.truePositives++;
+
+			// Check style similarity if both responded
+			if (testCase.yourActualResponse) {
+				analyzeStyleMatch(botResponse, testCase.yourActualResponse, trainingData, results);
+			}
+		} else if (testCase.youDid === 'respond' && !botResponded) {
+			results.details.falseNegatives++;
+		} else if (testCase.youDid === 'ignore' && !botResponded) {
+			results.details.trueNegatives++;
+		} else if (testCase.youDid === 'ignore' && botResponded) {
+			results.details.falsePositives++;
+		}
+
+		// Save example
+		if (results.examples.length < 10) {
+			results.examples.push({
+				scenario: testCase.scenario,
+				expected: testCase.youDid,
+				botDid: botResponded ? 'responded' : 'ignored',
+				correct:
+					(testCase.youDid === 'respond' && botResponded) || (testCase.youDid === 'ignore' && !botResponded),
+			});
+		}
+	}
+
+	console.log('\n');
+
+	// Calculate metrics
+	const { truePositives, falsePositives, trueNegatives, falseNegatives } = results.details;
+	const total = truePositives + falsePositives + trueNegatives + falseNegatives;
+
+	results.accuracy = (truePositives + trueNegatives) / total;
+	results.precision = truePositives / (truePositives + falsePositives);
+	results.recall = truePositives / (truePositives + falseNegatives);
+
+	// Print results
+	printResults(results);
+}
+
+function createTestCases(trainingData: any): TestCase[] {
+	const testCases: TestCase[] = [];
+
+	// From response patterns (where you DID respond)
+	for (const pattern of trainingData.responsePatterns) {
+		if (pattern.context.length > 0) {
+			testCases.push({
+				scenario: pattern.context[pattern.context.length - 1].content,
+				context: pattern.context.map((m: any) => ({
+					author: m.author,
+					content: m.content,
+				})),
+				youDid: 'respond',
+				yourActualResponse: pattern.yourResponse.content,
+			});
+		}
+	}
+
+	// From non-response patterns (where you DIDN'T respond)
+	for (const pattern of trainingData.nonResponsePatterns) {
+		testCases.push({
+			scenario: pattern.messageYouIgnored.content,
+			context: pattern.context.map((m: any) => ({
+				author: m.author,
+				content: m.content,
+			})),
+			youDid: 'ignore',
+		});
+	}
+
+	// Shuffle
+	return testCases.sort(() => Math.random() - 0.5);
+}
+
+async function testWithBot(testCase: TestCase, personality: any, ollama: any): Promise<string> {
+	// Build context string
+	const contextStr = testCase.context.map((m) => `${m.author}: ${m.content}`).join('\n');
+
+	// Build personality context
+	const personalityStr = `
+Conversational Style:
+${personality.conversationalStyle.map((s: string) => `- ${s}`).join('\n')}
+
+Common Phrases: ${personality.commonPhrases.join(', ')}
+`.trim();
+
+	// Build prompt (same as simpleCovaBot)
+	const prompt = `You are mimicking Cova in a Discord conversation.
+
+PERSONALITY:
+${personalityStr}
+
+RECENT CONVERSATION:
+${contextStr}
+
+NEW MESSAGE:
+${testCase.scenario}
+
+INSTRUCTIONS:
+1. Decide if Cova would respond to this message
+2. If yes, respond EXACTLY as Cova would
+3. If no, return only: SKIP
+
+YOUR RESPONSE:`;
+
+	try {
+		const response = await ollama.generate({
+			model: process.env.OLLAMA_MODEL || 'llama3.2',
+			prompt,
+			stream: false,
+			options: {
+				temperature: 0.7,
+				top_p: 0.9,
+			},
+		});
+
+		return response.response.trim();
+	} catch (error) {
+		console.error('Error calling Ollama:', error);
+		return 'SKIP';
+	}
+}
+
+function analyzeStyleMatch(botResponse: string, yourResponse: string, trainingData: any, results: ValidationResults) {
+	// Check if bot used your common phrases
+	const yourCommonPhrases = Object.keys(trainingData.yourPhrases);
+	const botUsedYourPhrases = yourCommonPhrases.some((phrase) => botResponse.toLowerCase().includes(phrase));
+
+	if (botUsedYourPhrases) {
+		results.styleMatches.usedYourPhrases++;
+	}
+
+	// Check length similarity (within 50% of your typical length)
+	const lengthRatio = botResponse.length / yourResponse.length;
+	if (lengthRatio >= 0.5 && lengthRatio <= 1.5) {
+		results.styleMatches.similarLength++;
+	}
+
+	// Check tone (very basic - count punctuation)
+	const yourExclamations = (yourResponse.match(/!/g) || []).length;
+	const botExclamations = (botResponse.match(/!/g) || []).length;
+	const yourQuestions = (yourResponse.match(/\?/g) || []).length;
+	const botQuestions = (botResponse.match(/\?/g) || []).length;
+
+	if (
+		Math.abs(yourExclamations - botExclamations) <= 1 &&
+		Math.abs(yourQuestions - botQuestions) <= 1
+	) {
+		results.styleMatches.similarTone++;
+	}
+}
+
+function printResults(results: ValidationResults) {
+	console.log('📊 VALIDATION RESULTS\n');
+	console.log('='.repeat(60));
+
+	console.log('\n🎯 Decision Accuracy:');
+	console.log(`  Overall Accuracy: ${(results.accuracy * 100).toFixed(1)}%`);
+	console.log(`  Precision: ${(results.precision * 100).toFixed(1)}% (when bot responds, is it correct?)`);
+	console.log(`  Recall: ${(results.recall * 100).toFixed(1)}% (does bot respond when you would?)`);
+
+	console.log('\n📈 Detailed Breakdown:');
+	console.log(`  ✅ True Positives: ${results.details.truePositives} (correctly responded)`);
+	console.log(`  ❌ False Positives: ${results.details.falsePositives} (responded when you wouldn't)`);
+	console.log(`  ✅ True Negatives: ${results.details.trueNegatives} (correctly stayed silent)`);
+	console.log(`  ❌ False Negatives: ${results.details.falseNegatives} (stayed silent when you'd respond)`);
+
+	console.log('\n✍️  Style Similarity:');
+	const totalResponses = results.details.truePositives;
+	if (totalResponses > 0) {
+		console.log(
+			`  Used your phrases: ${((results.styleMatches.usedYourPhrases / totalResponses) * 100).toFixed(1)}%`,
+		);
+		console.log(
+			`  Similar length: ${((results.styleMatches.similarLength / totalResponses) * 100).toFixed(1)}%`,
+		);
+		console.log(
+			`  Similar tone: ${((results.styleMatches.similarTone / totalResponses) * 100).toFixed(1)}%`,
+		);
+	}
+
+	console.log('\n📝 Example Results:');
+	for (const example of results.examples) {
+		const icon = example.correct ? '✅' : '❌';
+		console.log(`  ${icon} Expected: ${example.expected}, Bot: ${example.botDid}`);
+		console.log(`     Scenario: "${example.scenario.substring(0, 60)}..."`);
+	}
+
+	console.log('\n' + '='.repeat(60));
+
+	// Interpretation
+	console.log('\n💡 Interpretation:\n');
+
+	if (results.accuracy >= 0.8) {
+		console.log('  ✅ EXCELLENT: Bot mimics your behavior very well');
+	} else if (results.accuracy >= 0.7) {
+		console.log('  ✓  GOOD: Bot is decent but has room for improvement');
+	} else if (results.accuracy >= 0.6) {
+		console.log('  ⚠️  FAIR: Bot needs more tuning');
+	} else {
+		console.log('  ❌ POOR: Bot needs significant improvement');
+	}
+
+	if (results.details.falsePositives > results.details.falseNegatives) {
+		console.log('  📢 Bot is too chatty - responds too often');
+		console.log('     → Add "Only respond when you have something meaningful to add" to personality');
+	} else if (results.details.falseNegatives > results.details.falsePositives) {
+		console.log('  🤐 Bot is too quiet - misses opportunities to respond');
+		console.log('     → Add more examples of situations where you DO respond');
+	}
+
+	if (totalResponses > 0) {
+		if (results.styleMatches.usedYourPhrases / totalResponses < 0.3) {
+			console.log('  💬 Bot not using your phrases enough');
+			console.log('     → Add more of your common phrases to personality.json');
+		}
+
+		if (results.styleMatches.similarLength / totalResponses < 0.5) {
+			console.log('  📏 Bot response length doesn\'t match yours');
+			console.log('     → Update conversationalStyle to specify response length preference');
+		}
+	}
+
+	console.log('\n');
+}
+
+// Run validation
+validateBot().catch(console.error);

--- a/apps/covabot/src/cova-bot/exampleLoader.ts
+++ b/apps/covabot/src/cova-bot/exampleLoader.ts
@@ -1,0 +1,184 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { logger } from '@starbunk/shared';
+
+export interface CovaMessageExample {
+    conversationContext: Array<{
+        author: string;
+        content: string;
+        timestamp: string;
+    }>;
+    currentMessage: {
+        author: string;
+        content: string;
+    };
+    covaResponse: string | null; // null = Cova didn't respond
+    metadata: {
+        conversationVelocity: 'high' | 'medium' | 'low';
+        participantCount: number;
+        timeSinceCovaSpoke: number;
+        isDirectMention: boolean;
+        channelType?: string;
+    };
+}
+
+interface CovaMessagesData {
+    version: string;
+    lastUpdated: string;
+    examples: CovaMessageExample[];
+}
+
+/**
+ * Loads and manages Cova's message examples from JSON file
+ * 
+ * Uses static file approach - all examples are loaded at startup
+ * and included in every prompt. No vector search or filtering needed.
+ */
+export class ExampleLoader {
+    private examples: CovaMessageExample[];
+    private dataPath: string;
+
+    constructor(dataPath?: string) {
+        this.dataPath = dataPath || join(process.cwd(), 'data/covabot/cova-messages.json');
+        this.examples = this.loadExamples();
+        logger.info(`[ExampleLoader] Loaded ${this.examples.length} examples from ${this.dataPath}`);
+    }
+
+    /**
+     * Load examples from JSON file
+     */
+    private loadExamples(): CovaMessageExample[] {
+        try {
+            const fileContent = readFileSync(this.dataPath, 'utf-8');
+            const data: CovaMessagesData = JSON.parse(fileContent);
+
+            if (!data.examples || !Array.isArray(data.examples)) {
+                throw new Error('Invalid data format: missing examples array');
+            }
+
+            logger.info(`[ExampleLoader] Loaded version ${data.version} (updated: ${data.lastUpdated})`);
+            return data.examples;
+        } catch (error) {
+            logger.error(`[ExampleLoader] Failed to load examples from ${this.dataPath}:`, error);
+            throw error;
+        }
+    }
+
+    /**
+     * Get all curated examples
+     * 
+     * This is the primary method - returns all 50-100 examples
+     * to be included in every prompt. Modern LLMs can handle this easily.
+     */
+    getAllExamples(): CovaMessageExample[] {
+        return this.examples;
+    }
+
+    /**
+     * Get count of examples
+     */
+    getExampleCount(): number {
+        return this.examples.length;
+    }
+
+    /**
+     * Get count of examples where Cova responded vs. stayed quiet
+     */
+    getResponseStats(): { responded: number; skipped: number; total: number } {
+        const responded = this.examples.filter(ex => ex.covaResponse !== null).length;
+        const skipped = this.examples.filter(ex => ex.covaResponse === null).length;
+
+        return {
+            responded,
+            skipped,
+            total: this.examples.length,
+        };
+    }
+
+    /**
+     * Optional: Simple filtering without embeddings
+     * 
+     * Only use this if token usage becomes a concern (unlikely).
+     * Prefer getAllExamples() for maximum behavioral diversity.
+     */
+    getFilteredExamples(filters?: {
+        conversationVelocity?: 'high' | 'medium' | 'low';
+        minParticipants?: number;
+        includeNullResponses?: boolean;
+    }): CovaMessageExample[] {
+        if (!filters) {
+            return this.examples;
+        }
+
+        return this.examples.filter(ex => {
+            if (filters.conversationVelocity && ex.metadata.conversationVelocity !== filters.conversationVelocity) {
+                return false;
+            }
+
+            if (filters.minParticipants && ex.metadata.participantCount < filters.minParticipants) {
+                return false;
+            }
+
+            if (filters.includeNullResponses === false && ex.covaResponse === null) {
+                return false;
+            }
+
+            return true;
+        });
+    }
+
+    /**
+     * Optional: Stratified sampling for diversity
+     * 
+     * If we need to reduce token usage, this ensures we still show
+     * diverse examples across different conversation types.
+     */
+    getStratifiedSample(samplesPerCategory: number = 10): CovaMessageExample[] {
+        const highEnergy = this.examples
+            .filter(ex => ex.metadata.conversationVelocity === 'high')
+            .slice(0, samplesPerCategory);
+
+        const mediumEnergy = this.examples
+            .filter(ex => ex.metadata.conversationVelocity === 'medium')
+            .slice(0, samplesPerCategory);
+
+        const lowEnergy = this.examples
+            .filter(ex => ex.metadata.conversationVelocity === 'low')
+            .slice(0, samplesPerCategory);
+
+        const directMentions = this.examples
+            .filter(ex => ex.metadata.isDirectMention)
+            .slice(0, samplesPerCategory);
+
+        const noResponses = this.examples
+            .filter(ex => ex.covaResponse === null)
+            .slice(0, samplesPerCategory);
+
+        // Combine and deduplicate
+        const combined = [
+            ...highEnergy,
+            ...mediumEnergy,
+            ...lowEnergy,
+            ...directMentions,
+            ...noResponses,
+        ];
+
+        // Remove duplicates (same example might be in multiple categories)
+        const unique = Array.from(
+            new Map(combined.map(ex => [JSON.stringify(ex), ex])).values()
+        );
+
+        logger.debug(`[ExampleLoader] Stratified sample: ${unique.length} examples`);
+        return unique;
+    }
+
+    /**
+     * Reload examples from file
+     * Useful for hot-reloading during development
+     */
+    reload(): void {
+        this.examples = this.loadExamples();
+        logger.info(`[ExampleLoader] Reloaded ${this.examples.length} examples`);
+    }
+}
+

--- a/apps/covabot/src/cova-bot/unifiedCovaBot.ts
+++ b/apps/covabot/src/cova-bot/unifiedCovaBot.ts
@@ -1,0 +1,250 @@
+import { Message, TextChannel } from 'discord.js';
+import { logger, container, ServiceId, WebhookManager } from '@starbunk/shared';
+import { Ollama } from 'ollama';
+import { getCovaIdentity, BotIdentity } from '../services/identity';
+import { UnifiedPromptBuilder } from '../prompts/unifiedPromptBuilder';
+import { ResponseParser, ParsedResponse } from '../utils/responseParser';
+import { ExampleLoader } from './exampleLoader';
+
+const COVA_USER_ID = '139592376443338752';
+
+interface ConversationMessage {
+    author: string;
+    content: string;
+    timestamp: Date;
+    isBot: boolean;
+    isCova: boolean;
+}
+
+interface UnifiedCovaBotConfig {
+    contextWindowSize?: number; // Number of recent messages to include
+    llmModel?: string;
+    llmTemperature?: number;
+    llmMaxTokens?: number;
+    llmTimeout?: number;
+    useOllama?: boolean; // true = Ollama, false = OpenAI
+}
+
+/**
+ * Unified CovaBot implementation using example-based learning
+ * 
+ * Key principles:
+ * - Single LLM call (decision + response combined)
+ * - Learn from real message examples (no explicit rules)
+ * - Conversational dynamics over topic filtering
+ * - Fail silently (no hard-coded fallbacks)
+ */
+export class UnifiedCovaBot {
+    private promptBuilder: UnifiedPromptBuilder;
+    private exampleLoader: ExampleLoader;
+    private webhookManager: WebhookManager | null = null;
+    private ollama: Ollama | null = null;
+    private config: Required<UnifiedCovaBotConfig>;
+
+    constructor(config: UnifiedCovaBotConfig = {}) {
+        this.config = {
+            contextWindowSize: config.contextWindowSize || 15,
+            llmModel: config.llmModel || process.env.OLLAMA_MODEL || 'llama3.2',
+            llmTemperature: config.llmTemperature || 0.7,
+            llmMaxTokens: config.llmMaxTokens || 200,
+            llmTimeout: config.llmTimeout || 10000,
+            useOllama: config.useOllama !== undefined ? config.useOllama : true,
+        };
+
+        this.exampleLoader = new ExampleLoader();
+        this.promptBuilder = new UnifiedPromptBuilder(this.exampleLoader);
+
+        if (this.config.useOllama) {
+            this.ollama = new Ollama({
+                host: process.env.OLLAMA_API_URL || 'http://localhost:11434',
+            });
+        }
+
+        const stats = this.exampleLoader.getResponseStats();
+        logger.info(
+            `[UnifiedCovaBot] Initialized with ${stats.total} examples ` +
+                `(${stats.responded} responses, ${stats.skipped} skips)`
+        );
+    }
+
+    /**
+     * Main entry point - process a Discord message
+     */
+    async processMessage(message: Message): Promise<void> {
+        try {
+            // Skip bot messages
+            if (message.author.bot) {
+                return;
+            }
+
+            // Skip if not a text channel
+            if (!(message.channel instanceof TextChannel)) {
+                return;
+            }
+
+            logger.debug(`[UnifiedCovaBot] Processing message from ${message.author.username}`);
+
+            // Get recent messages for context
+            const recentMessages = await this.getRecentMessages(
+                message.channel as TextChannel,
+                this.config.contextWindowSize
+            );
+
+            // Build unified prompt
+            const prompt = this.promptBuilder.buildPrompt(message, recentMessages);
+
+            // Log token estimate
+            const tokenEstimate = this.promptBuilder.estimateTokenCount(prompt);
+            logger.debug(`[UnifiedCovaBot] Prompt token estimate: ${tokenEstimate}`);
+
+            // Single LLM call
+            const llmResponse = await this.callLLM(prompt);
+
+            // Parse response
+            const parsed = ResponseParser.parse(llmResponse);
+
+            if (!parsed.shouldRespond || !parsed.responseText) {
+                logger.debug('[UnifiedCovaBot] Decided not to respond');
+                return;
+            }
+
+            // Send response
+            await this.sendResponse(message, parsed.responseText);
+        } catch (error) {
+            logger.error('[UnifiedCovaBot] Error processing message:', error);
+            // Fail silently - don't respond if there's an error
+        }
+    }
+
+    /**
+     * Get recent messages from channel for context
+     */
+    private async getRecentMessages(
+        channel: TextChannel,
+        limit: number
+    ): Promise<ConversationMessage[]> {
+        try {
+            const messages = await channel.messages.fetch({ limit: limit + 1 });
+
+            return Array.from(messages.values())
+                .reverse()
+                .slice(0, limit) // Exclude current message
+                .map(m => ({
+                    author: m.author.username,
+                    content: m.content,
+                    timestamp: m.createdAt,
+                    isBot: m.author.bot,
+                    isCova: m.author.id === COVA_USER_ID,
+                }));
+        } catch (error) {
+            logger.error('[UnifiedCovaBot] Error fetching recent messages:', error);
+            return [];
+        }
+    }
+
+    /**
+     * Call LLM to generate response
+     */
+    private async callLLM(prompt: string): Promise<string> {
+        const startTime = Date.now();
+
+        try {
+            if (this.config.useOllama && this.ollama) {
+                const response = await this.ollama.generate({
+                    model: this.config.llmModel,
+                    prompt,
+                    stream: false,
+                    options: {
+                        temperature: this.config.llmTemperature,
+                        num_predict: this.config.llmMaxTokens,
+                    },
+                });
+
+                const duration = Date.now() - startTime;
+                logger.debug(`[UnifiedCovaBot] LLM call completed in ${duration}ms`);
+
+                return response.response.trim();
+            } else {
+                // TODO: Implement OpenAI fallback
+                throw new Error('OpenAI provider not yet implemented');
+            }
+        } catch (error) {
+            const duration = Date.now() - startTime;
+            logger.error(`[UnifiedCovaBot] LLM call failed after ${duration}ms:`, error);
+            throw error;
+        }
+    }
+
+    /**
+     * Send response via webhook with Cova's identity
+     */
+    private async sendResponse(message: Message, content: string): Promise<void> {
+        try {
+            // Get Cova's identity
+            const identity = await getCovaIdentity(message);
+            if (!identity) {
+                logger.warn('[UnifiedCovaBot] Could not get identity, skipping response');
+                return;
+            }
+
+            // Get webhook manager
+            if (!this.webhookManager) {
+                if (container.has(ServiceId.WebhookService)) {
+                    this.webhookManager = container.get<WebhookManager>(ServiceId.WebhookService);
+                } else {
+                    logger.warn('[UnifiedCovaBot] WebhookService not available');
+                    return;
+                }
+            }
+
+            // Format response for Discord
+            const formatted = ResponseParser.formatForDiscord(content);
+
+            // Send via webhook
+            await this.webhookManager.sendMessage(message.channel.id, {
+                content: formatted,
+                username: identity.botName,
+                avatarURL: identity.avatarUrl,
+            });
+
+            logger.info(
+                `[UnifiedCovaBot] Sent response as ${identity.botName}: "${formatted.substring(0, 50)}${formatted.length > 50 ? '...' : ''}"`
+            );
+        } catch (error) {
+            logger.error('[UnifiedCovaBot] Error sending response:', error);
+        }
+    }
+
+    /**
+     * Check if bot should always respond (e.g., direct mention)
+     */
+    shouldAlwaysRespond(message: Message): boolean {
+        // Check for direct mention
+        return message.mentions.has(COVA_USER_ID);
+    }
+
+    /**
+     * Get bot statistics
+     */
+    getStats(): {
+        exampleCount: number;
+        exampleStats: { responded: number; skipped: number; total: number };
+        config: Required<UnifiedCovaBotConfig>;
+    } {
+        return {
+            exampleCount: this.exampleLoader.getExampleCount(),
+            exampleStats: this.exampleLoader.getResponseStats(),
+            config: this.config,
+        };
+    }
+
+    /**
+     * Reload examples from file
+     * Useful for hot-reloading during development
+     */
+    reloadExamples(): void {
+        this.exampleLoader.reload();
+        logger.info('[UnifiedCovaBot] Reloaded examples');
+    }
+}
+

--- a/apps/covabot/src/index-simple.ts
+++ b/apps/covabot/src/index-simple.ts
@@ -1,0 +1,226 @@
+/**
+ * Simple CovaBot Entry Point
+ *
+ * Minimalist implementation - no triggers, no vector DB, no complex infrastructure
+ * Just: Message → LLM with context → Response or silence
+ */
+
+import { Events, Message } from 'discord.js';
+import { createServer, IncomingMessage, ServerResponse } from 'http';
+import {
+	logger,
+	ensureError,
+	validateEnvironment,
+	createDiscordClient,
+	ClientConfigs,
+	container,
+	ServiceId,
+	WebhookManager,
+	getMessageFilter,
+	MessageFilter,
+	initializeObservability,
+	DiscordService,
+} from '@starbunk/shared';
+import { SimpleCovaBot } from './simpleCovaBot';
+
+class SimpleCovaBotContainer {
+	private client!: ReturnType<typeof createDiscordClient>;
+	private webhookManager!: WebhookManager;
+	private messageFilter!: MessageFilter;
+	private bot!: SimpleCovaBot;
+	private hasInitialized = false;
+
+	async initialize(): Promise<void> {
+		logger.info('🤖 Initializing Simple CovaBot...');
+
+		try {
+			// Initialize observability
+			const { metrics, logger: _structuredLogger } = initializeObservability('covabot');
+			logger.info('✅ Observability initialized');
+
+			// Validate environment
+			this.validateEnvironment();
+
+			// Create Discord client
+			this.client = createDiscordClient(ClientConfigs.CovaBot);
+
+			// Initialize services
+			await this.initializeServices();
+
+			// Create the bot
+			this.bot = new SimpleCovaBot();
+
+			// Set up event handlers
+			this.setupEventHandlers();
+
+			logger.info('✅ Simple CovaBot initialized successfully');
+		} catch (error) {
+			logger.error('❌ Failed to initialize Simple CovaBot:', ensureError(error));
+			throw error;
+		}
+	}
+
+	private validateEnvironment(): void {
+		validateEnvironment({
+			required: [],
+			optional: [
+				'COVABOT_TOKEN',
+				'STARBUNK_TOKEN',
+				'OLLAMA_API_URL',
+				'OLLAMA_MODEL',
+				'DEBUG_MODE',
+				'TESTING_SERVER_IDS',
+				'TESTING_CHANNEL_IDS',
+			],
+		});
+	}
+
+	private async initializeServices(): Promise<void> {
+		// Register Discord client
+		container.register(ServiceId.DiscordClient, this.client);
+
+		// Register DiscordService
+		const discordService = new DiscordService(this.client);
+		container.register(ServiceId.DiscordService, discordService);
+
+		// Initialize webhook manager
+		this.webhookManager = new WebhookManager(this.client);
+		container.register(ServiceId.WebhookService, this.webhookManager);
+
+		// Initialize message filter
+		this.messageFilter = getMessageFilter();
+		container.register(ServiceId.MessageFilter, this.messageFilter);
+
+		logger.info('Simple CovaBot services initialized');
+	}
+
+	private setupEventHandlers(): void {
+		this.client.on(Events.Error, (error: Error) => {
+			logger.error('Discord client error:', error);
+		});
+
+		this.client.on(Events.Warn, (warning: string) => {
+			logger.warn('Discord client warning:', warning);
+		});
+
+		this.client.on(Events.MessageCreate, async (message: Message) => {
+			await this.handleMessage(message);
+		});
+
+		this.client.once(Events.ClientReady, () => {
+			logger.info('🤖 Simple CovaBot is ready and connected to Discord');
+			this.hasInitialized = true;
+		});
+	}
+
+	private async handleMessage(message: Message): Promise<void> {
+		// Skip bot messages
+		if (message.author.bot) return;
+
+		try {
+			// Create message context for filtering
+			const context = MessageFilter.createContextFromMessage(message);
+
+			// Check if message should be processed
+			const filterResult = this.messageFilter.shouldProcessMessage(context);
+			if (!filterResult.allowed) {
+				if (this.messageFilter.isDebugMode()) {
+					logger.debug(`Message filtered: ${filterResult.reason}`);
+				}
+				return;
+			}
+
+			// Process with simple bot
+			await this.bot.processMessage(message);
+		} catch (error) {
+			logger.error('Error handling message:', ensureError(error));
+		}
+	}
+
+	async start(): Promise<void> {
+		const token = process.env.COVABOT_TOKEN || process.env.STARBUNK_TOKEN;
+		if (!token) {
+			throw new Error('COVABOT_TOKEN or STARBUNK_TOKEN environment variable is required');
+		}
+
+		await this.client.login(token);
+		await this.waitForReady();
+		logger.info('🎉 Simple CovaBot started successfully');
+	}
+
+	private waitForReady(): Promise<void> {
+		return new Promise((resolve) => {
+			if (this.hasInitialized) {
+				resolve();
+			} else {
+				this.client.once(Events.ClientReady, () => resolve());
+			}
+		});
+	}
+
+	async stop(): Promise<void> {
+		logger.info('Stopping Simple CovaBot...');
+		if (this.client) {
+			await this.client.destroy();
+		}
+		logger.info('Simple CovaBot stopped');
+	}
+}
+
+// Main execution
+async function main(): Promise<void> {
+	if (process.env.CI_SMOKE_MODE === 'true') {
+		logger.info('CI_SMOKE_MODE enabled: starting minimal health server');
+		const port = process.env.HEALTH_PORT ? parseInt(process.env.HEALTH_PORT) : 3332;
+		const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+			if (req.url === '/health') {
+				res.writeHead(200, { 'Content-Type': 'application/json' });
+				res.end(JSON.stringify({ status: 'healthy', mode: 'smoke', timestamp: new Date().toISOString() }));
+				return;
+			}
+			res.writeHead(404, { 'Content-Type': 'text/plain' });
+			res.end('Not Found');
+		});
+		server.listen(port, () => logger.info(`🏥 [SMOKE] Simple CovaBot health server running on port ${port}`));
+		return;
+	}
+
+	try {
+		const bot = new SimpleCovaBotContainer();
+		await bot.initialize();
+		await bot.start();
+	} catch (error) {
+		logger.error('Failed to start Simple CovaBot:', ensureError(error));
+		process.exit(1);
+	}
+}
+
+// Graceful shutdown
+process.on('SIGINT', async () => {
+	logger.info('Received SIGINT, shutting down...');
+	try {
+		const { shutdownObservability } = await import('@starbunk/shared');
+		await shutdownObservability();
+	} catch (error) {
+		logger.error('Error during shutdown:', ensureError(error));
+	}
+	process.exit(0);
+});
+
+process.on('SIGTERM', async () => {
+	logger.info('Received SIGTERM, shutting down...');
+	try {
+		const { shutdownObservability } = await import('@starbunk/shared');
+		await shutdownObservability();
+	} catch (error) {
+		logger.error('Error during shutdown:', ensureError(error));
+	}
+	process.exit(0);
+});
+
+if (require.main === module) {
+	main().catch((error) => {
+		console.error('Fatal error:', ensureError(error));
+		process.exit(1);
+	});
+}

--- a/apps/covabot/src/index.ts
+++ b/apps/covabot/src/index.ts
@@ -234,7 +234,7 @@ class CovaBotContainer {
 async function main(): Promise<void> {
 	if (process.env.CI_SMOKE_MODE === 'true') {
 		logger.info('CI_SMOKE_MODE enabled: starting minimal health server and skipping Discord login');
-		const port = process.env.HEALTH_PORT ? parseInt(process.env.HEALTH_PORT) : 3003;
+		const port = process.env.HEALTH_PORT ? parseInt(process.env.HEALTH_PORT) : 3332;
 		const server = createServer((req: IncomingMessage, res: ServerResponse) => {
 			if (req.url === '/health') {
 				res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/apps/covabot/src/prompts/unifiedPromptBuilder.ts
+++ b/apps/covabot/src/prompts/unifiedPromptBuilder.ts
@@ -1,0 +1,181 @@
+import { Message } from 'discord.js';
+import { ExampleLoader, CovaMessageExample } from '../cova-bot/exampleLoader';
+import { logger } from '@starbunk/shared';
+
+interface ConversationMessage {
+    author: string;
+    content: string;
+    timestamp: Date;
+    isBot: boolean;
+    isCova: boolean;
+}
+
+/**
+ * Builds prompts for the unified CovaBot using example-based learning
+ * 
+ * Philosophy: Show, don't tell
+ * - NO explicit personality rules
+ * - NO "when to respond" guidelines
+ * - ONLY real examples of Cova's messages
+ * - Let LLM learn patterns implicitly from examples
+ */
+export class UnifiedPromptBuilder {
+    private exampleLoader: ExampleLoader;
+
+    constructor(exampleLoader?: ExampleLoader) {
+        this.exampleLoader = exampleLoader || new ExampleLoader();
+    }
+
+    /**
+     * Build the complete prompt for the LLM
+     * 
+     * Structure:
+     * 1. All curated examples (50-100)
+     * 2. Current conversation context
+     * 3. "Cova:" to prompt response
+     */
+    buildPrompt(currentMessage: Message, recentMessages: ConversationMessage[]): string {
+        const examples = this.exampleLoader.getAllExamples();
+
+        const examplesSection = this.formatExamples(examples);
+        const conversationSection = this.formatCurrentConversation(recentMessages, currentMessage);
+
+        const prompt = `${examplesSection}
+
+---
+
+${conversationSection}
+
+Cova:`;
+
+        logger.debug(`[UnifiedPromptBuilder] Built prompt with ${examples.length} examples, ${recentMessages.length} context messages`);
+
+        return prompt;
+    }
+
+    /**
+     * Format examples as conversation snippets
+     * 
+     * Each example shows:
+     * - Conversation context (previous messages)
+     * - Current message
+     * - Cova's response (or [no response] if null)
+     */
+    private formatExamples(examples: CovaMessageExample[]): string {
+        const formatted = examples.map(ex => {
+            // Format conversation context
+            const context = ex.conversationContext
+                .map(msg => `${msg.author}: ${msg.content}`)
+                .join('\n');
+
+            // Format current message
+            const current = `${ex.currentMessage.author}: ${ex.currentMessage.content}`;
+
+            // Format Cova's response
+            const response = ex.covaResponse !== null ? `Cova: ${ex.covaResponse}` : 'Cova: [no response]';
+
+            // Combine
+            return `${context}\n${current}\n${response}`;
+        });
+
+        return formatted.join('\n\n---\n\n');
+    }
+
+    /**
+     * Format current conversation context
+     * 
+     * Shows recent messages leading up to the current message
+     */
+    private formatCurrentConversation(
+        recentMessages: ConversationMessage[],
+        currentMessage: Message
+    ): string {
+        // Format recent messages
+        const context = recentMessages
+            .map(msg => {
+                // Mark if this is the real Cova (not the bot)
+                const prefix = msg.isCova ? '[REAL COVA] ' : '';
+                return `${prefix}${msg.author}: ${msg.content}`;
+            })
+            .join('\n');
+
+        // Format current message
+        const current = `${currentMessage.author.username}: ${currentMessage.content}`;
+
+        return `${context}\n${current}`;
+    }
+
+    /**
+     * Optional: Build prompt with conversation metadata
+     * 
+     * Includes additional context about conversation dynamics
+     * Only use if we find the LLM needs explicit signals
+     */
+    buildPromptWithMetadata(
+        currentMessage: Message,
+        recentMessages: ConversationMessage[],
+        metadata: {
+            conversationVelocity: 'high' | 'medium' | 'low';
+            participantCount: number;
+            timeSinceCovaSpoke: number;
+        }
+    ): string {
+        const examples = this.exampleLoader.getAllExamples();
+        const examplesSection = this.formatExamples(examples);
+        const conversationSection = this.formatCurrentConversation(recentMessages, currentMessage);
+
+        // Add metadata section
+        const metadataSection = `# CONVERSATION CONTEXT
+Recent activity: ${metadata.conversationVelocity} (${metadata.participantCount} participants)
+Time since Cova last spoke: ${metadata.timeSinceCovaSpoke} minutes`;
+
+        const prompt = `${examplesSection}
+
+---
+
+${metadataSection}
+
+${conversationSection}
+
+Cova:`;
+
+        return prompt;
+    }
+
+    /**
+     * Get token count estimate for the prompt
+     * Rough estimate: ~4 characters per token
+     */
+    estimateTokenCount(prompt: string): number {
+        return Math.ceil(prompt.length / 4);
+    }
+
+    /**
+     * Build a minimal prompt with fewer examples
+     * Only use if token usage becomes a concern
+     */
+    buildMinimalPrompt(
+        currentMessage: Message,
+        recentMessages: ConversationMessage[],
+        maxExamples: number = 30
+    ): string {
+        // Use stratified sampling for diversity
+        const examples = this.exampleLoader.getStratifiedSample(Math.ceil(maxExamples / 5));
+
+        const examplesSection = this.formatExamples(examples);
+        const conversationSection = this.formatCurrentConversation(recentMessages, currentMessage);
+
+        const prompt = `${examplesSection}
+
+---
+
+${conversationSection}
+
+Cova:`;
+
+        logger.debug(`[UnifiedPromptBuilder] Built minimal prompt with ${examples.length} examples`);
+
+        return prompt;
+    }
+}
+

--- a/apps/covabot/src/simpleCovaBot.ts
+++ b/apps/covabot/src/simpleCovaBot.ts
@@ -1,0 +1,241 @@
+/**
+ * Simplified CovaBot - Single LLM call approach
+ *
+ * Philosophy: Let the LLM do all the heavy lifting.
+ * - One call decides AND responds
+ * - Recent message context is sufficient
+ * - No probability calculations or heuristics
+ * - No vector database or embeddings
+ */
+
+import { Message, TextChannel } from 'discord.js';
+import { logger, container, ServiceId, WebhookManager } from '@starbunk/shared';
+import { getCovaIdentity } from './services/identity';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+interface PersonalityData {
+	conversationalStyle: string[];
+	commonPhrases: string[];
+	topics: string[];
+	exampleResponses: Array<{
+		context: string;
+		response: string;
+	}>;
+}
+
+export class SimpleCovaBot {
+	private webhookManager: WebhookManager | null = null;
+	private personality: PersonalityData;
+	private ollama: any; // Will initialize when needed
+
+	constructor() {
+		// Load personality from simple JSON file
+		try {
+			const personalityPath = join(__dirname, '../data/personality.json');
+			this.personality = JSON.parse(readFileSync(personalityPath, 'utf-8'));
+		} catch (error) {
+			// Use defaults if file doesn't exist yet
+			logger.warn('[SimpleCovaBot] No personality.json found, using defaults');
+			this.personality = {
+				conversationalStyle: [
+					'Casual and friendly',
+					'Technical but approachable',
+					'Uses short, direct responses',
+				],
+				commonPhrases: ['fair', 'makes sense', 'lol', 'honestly'],
+				topics: ['coding', 'discord bots', 'typescript', 'tech'],
+				exampleResponses: [
+					{
+						context: 'Someone asks a technical question',
+						response: 'what are you trying to build?',
+					},
+				],
+			};
+		}
+	}
+
+	/**
+	 * Main message handler - single entry point
+	 */
+	async processMessage(message: Message): Promise<void> {
+		try {
+			// Skip bot messages
+			if (message.author.bot) return;
+
+			// Get recent channel context (last 20 messages)
+			const recentMessages = await this.getRecentMessages(message.channel as TextChannel, 20);
+
+			// Single LLM call - decides AND responds
+			const response = await this.getLLMResponse(message, recentMessages);
+
+			// If LLM says to respond, send it
+			if (response && response !== 'SKIP') {
+				await this.sendMessage(message, response);
+			}
+		} catch (error) {
+			logger.error('[SimpleCovaBot] Error processing message:', error as Error);
+		}
+	}
+
+	/**
+	 * Get recent messages from channel for context
+	 */
+	private async getRecentMessages(channel: TextChannel, limit: number = 20): Promise<string> {
+		try {
+			const messages = await channel.messages.fetch({ limit });
+			const formatted = Array.from(messages.values())
+				.reverse()
+				.map((m) => `${m.author.username}: ${m.content}`)
+				.join('\n');
+
+			return formatted;
+		} catch (error) {
+			logger.error('[SimpleCovaBot] Error fetching recent messages:', error as Error);
+			return '';
+		}
+	}
+
+	/**
+	 * Single LLM call - decides whether to respond AND generates response
+	 */
+	private async getLLMResponse(message: Message, recentMessages: string): Promise<string> {
+		try {
+			// Initialize Ollama if needed
+			if (!this.ollama) {
+				const { Ollama } = await import('ollama');
+				this.ollama = new Ollama({
+					host: process.env.OLLAMA_API_URL || 'http://localhost:11434',
+				});
+			}
+
+			// Build personality context
+			const personalityContext = this.buildPersonalityContext();
+
+			// Build the prompt
+			const prompt = `You are mimicking Cova in a Discord conversation.
+
+PERSONALITY:
+${personalityContext}
+
+RECENT CONVERSATION (last 20 messages):
+${recentMessages}
+
+NEW MESSAGE:
+${message.author.username}: ${message.content}
+
+CRITICAL INSTRUCTIONS:
+1. Read the RECENT CONVERSATION to understand what people are ACTUALLY talking about
+2. Decide if Cova would respond based on:
+   - Is this relevant to the CURRENT topic being discussed?
+   - Would Cova have something meaningful to add to THIS conversation?
+   - Does this warrant a response, or is silence better?
+
+3. If responding:
+   - Respond to what's ACTUALLY being discussed, stay on topic
+   - Match Cova's style: short (1-2 sentences), casual, direct
+   - Use Cova's humor naturally when appropriate (dry/sarcastic about tech)
+   - Use common phrases naturally ("fair enough", "makes sense", "lol")
+   - NEVER force unrelated topics into the conversation
+   - NEVER mention personal details unless naturally relevant to current topic
+   - Sound like a real person having a conversation, not a bot with programmed responses
+
+4. If Cova WOULD NOT respond:
+   - Reply with only: SKIP
+
+YOUR RESPONSE:`;
+
+			const response = await this.ollama.generate({
+				model: process.env.OLLAMA_MODEL || 'llama3.2',
+				prompt,
+				stream: false,
+				options: {
+					temperature: 0.7,
+					top_p: 0.9,
+				},
+			});
+
+			const text = response.response.trim();
+
+			logger.debug(`[SimpleCovaBot] LLM response: ${text.substring(0, 100)}...`);
+
+			return text;
+		} catch (error) {
+			logger.error('[SimpleCovaBot] Error getting LLM response:', error as Error);
+			return 'SKIP';
+		}
+	}
+
+	/**
+	 * Build personality context string from loaded data
+	 */
+	private buildPersonalityContext(): string {
+		const { conversationalStyle, commonPhrases, topics, exampleResponses, importantRules } = this.personality;
+
+		let context = 'Conversational Style:\n';
+		context += conversationalStyle.map((s) => `- ${s}`).join('\n');
+		context += '\n\n';
+
+		if (importantRules && importantRules.length > 0) {
+			context += 'IMPORTANT RULES:\n';
+			context += importantRules.map((r) => `- ${r}`).join('\n');
+			context += '\n\n';
+		}
+
+		context += 'Common Phrases: ' + commonPhrases.join(', ');
+		context += '\n\n';
+
+		context += 'Topics of Interest: ' + topics.join(', ');
+		context += '\n\n';
+
+		if (exampleResponses.length > 0) {
+			context += 'Example Responses:\n';
+			exampleResponses.forEach((ex) => {
+				context += `When: ${ex.context}\n`;
+				context += `Response: "${ex.response}"\n\n`;
+			});
+		}
+
+		return context;
+	}
+
+	/**
+	 * Send message using webhook with Cova's identity
+	 */
+	private async sendMessage(message: Message, content: string): Promise<void> {
+		try {
+			if (!(message.channel instanceof TextChannel)) {
+				logger.warn('[SimpleCovaBot] Cannot send to non-text channel');
+				return;
+			}
+
+			// Get Cova's current identity (name/avatar)
+			const identity = await getCovaIdentity(message);
+			if (!identity) {
+				logger.warn('[SimpleCovaBot] Could not get identity');
+				return;
+			}
+
+			// Lazy-load webhook manager
+			if (!this.webhookManager) {
+				if (container.has(ServiceId.WebhookService)) {
+					this.webhookManager = container.get<WebhookManager>(ServiceId.WebhookService);
+				} else {
+					logger.warn('[SimpleCovaBot] WebhookService not available');
+					return;
+				}
+			}
+
+			// Send via webhook
+			await this.webhookManager.sendMessage(message.channel.id, {
+				content,
+				username: identity.botName,
+				avatarURL: identity.avatarUrl,
+			});
+
+			logger.info(`[SimpleCovaBot] Sent response as ${identity.botName}`);
+		} catch (error) {
+			logger.error('[SimpleCovaBot] Error sending message:', error as Error);
+		}
+	}
+}

--- a/apps/covabot/src/utils/responseParser.ts
+++ b/apps/covabot/src/utils/responseParser.ts
@@ -1,0 +1,201 @@
+import { logger } from '@starbunk/shared';
+
+export interface ParsedResponse {
+    shouldRespond: boolean;
+    responseText: string | null;
+}
+
+/**
+ * Parses LLM output to determine if Cova should respond
+ * and extracts the response text
+ * 
+ * Handles various "no response" signals:
+ * - Empty string
+ * - "[no response]"
+ * - "SKIP"
+ * - Very short responses (likely errors)
+ */
+export class ResponseParser {
+    /**
+     * Parse LLM response
+     */
+    static parse(llmOutput: string): ParsedResponse {
+        const trimmed = llmOutput.trim();
+
+        // Check for explicit skip signals
+        if (this.isSkipSignal(trimmed)) {
+            logger.debug('[ResponseParser] Detected skip signal');
+            return {
+                shouldRespond: false,
+                responseText: null,
+            };
+        }
+
+        // Clean the response
+        const cleaned = this.cleanResponse(trimmed);
+
+        // Validate response quality
+        if (!this.isValidResponse(cleaned)) {
+            logger.debug('[ResponseParser] Invalid response, treating as skip');
+            return {
+                shouldRespond: false,
+                responseText: null,
+            };
+        }
+
+        return {
+            shouldRespond: true,
+            responseText: cleaned,
+        };
+    }
+
+    /**
+     * Check if the response is a skip signal
+     */
+    private static isSkipSignal(text: string): boolean {
+        if (text === '') return true;
+
+        const upper = text.toUpperCase();
+
+        // Explicit skip signals
+        if (upper === 'SKIP') return true;
+        if (upper.startsWith('SKIP')) return true;
+        if (upper === '[NO RESPONSE]') return true;
+        if (upper === 'NO RESPONSE') return true;
+
+        // Check for annotation-style skip
+        if (text.match(/^\[.*no.*response.*\]$/i)) return true;
+
+        return false;
+    }
+
+    /**
+     * Clean response text
+     * 
+     * Removes common LLM artifacts:
+     * - "Cova:" prefix
+     * - Annotations like [thinking], [response], etc.
+     * - Extra whitespace
+     */
+    private static cleanResponse(text: string): string {
+        let cleaned = text;
+
+        // Remove "Cova:" prefix (case insensitive)
+        cleaned = cleaned.replace(/^Cova:\s*/i, '');
+
+        // Remove annotation-style prefixes
+        cleaned = cleaned.replace(/^\[.*?\]\s*/, '');
+
+        // Remove quotes if the entire response is quoted
+        if (cleaned.startsWith('"') && cleaned.endsWith('"')) {
+            cleaned = cleaned.slice(1, -1);
+        }
+        if (cleaned.startsWith("'") && cleaned.endsWith("'")) {
+            cleaned = cleaned.slice(1, -1);
+        }
+
+        // Trim whitespace
+        cleaned = cleaned.trim();
+
+        return cleaned;
+    }
+
+    /**
+     * Validate response meets quality criteria
+     */
+    private static isValidResponse(text: string): boolean {
+        // Too short (likely an error or incomplete)
+        if (text.length < 2) {
+            return false;
+        }
+
+        // Too long (Discord limit is 2000, but Cova is usually concise)
+        if (text.length > 2000) {
+            logger.warn('[ResponseParser] Response too long, truncating');
+            return false;
+        }
+
+        // Check for common error patterns
+        const errorPatterns = [
+            /^error/i,
+            /^undefined$/i,
+            /^null$/i,
+            /^\[object/i,
+        ];
+
+        for (const pattern of errorPatterns) {
+            if (pattern.test(text)) {
+                logger.warn(`[ResponseParser] Detected error pattern: ${text}`);
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Truncate response if too long
+     */
+    static truncate(text: string, maxLength: number = 1900): string {
+        if (text.length <= maxLength) {
+            return text;
+        }
+
+        // Truncate and add ellipsis
+        return text.substring(0, maxLength) + '...';
+    }
+
+    /**
+     * Format response for Discord
+     * 
+     * Ensures response meets Discord's requirements
+     */
+    static formatForDiscord(text: string): string {
+        let formatted = text;
+
+        // Truncate if needed
+        formatted = this.truncate(formatted, 1900);
+
+        // Escape Discord markdown if needed (optional)
+        // formatted = this.escapeMarkdown(formatted);
+
+        return formatted;
+    }
+
+    /**
+     * Optional: Escape Discord markdown
+     * Only use if we want to prevent markdown formatting
+     */
+    private static escapeMarkdown(text: string): string {
+        return text
+            .replace(/\*/g, '\\*')
+            .replace(/_/g, '\\_')
+            .replace(/~/g, '\\~')
+            .replace(/`/g, '\\`')
+            .replace(/\|/g, '\\|');
+    }
+
+    /**
+     * Get statistics about parsed responses
+     * Useful for monitoring
+     */
+    static getStats(responses: ParsedResponse[]): {
+        total: number;
+        responded: number;
+        skipped: number;
+        responseRate: number;
+    } {
+        const total = responses.length;
+        const responded = responses.filter(r => r.shouldRespond).length;
+        const skipped = total - responded;
+        const responseRate = total > 0 ? responded / total : 0;
+
+        return {
+            total,
+            responded,
+            skipped,
+            responseRate,
+        };
+    }
+}
+

--- a/apps/djcova/package-lock.json
+++ b/apps/djcova/package-lock.json
@@ -48,6 +48,7 @@
 				"discord.js": "^14.18.0",
 				"dotenv": "^16.5.0",
 				"envalid": "^8.0.0",
+				"ioredis": "^5.3.2",
 				"node-fetch": "^2.7.0",
 				"node-schedule": "^2.1.1",
 				"openai": "^5.3.0",
@@ -57,6 +58,7 @@
 				"zod": "^3.24.2"
 			},
 			"devDependencies": {
+				"@types/ioredis": "^5.0.0",
 				"@types/jest": "^29.5.14",
 				"@types/node": "^20.17.14",
 				"@types/node-schedule": "^2.1.7",

--- a/apps/djcova/src/index.ts
+++ b/apps/djcova/src/index.ts
@@ -228,7 +228,7 @@ class DJCovaContainer {
 async function main(): Promise<void> {
 	if (process.env.CI_SMOKE_MODE === 'true') {
 		logger.info('CI_SMOKE_MODE enabled: starting minimal health server and skipping Discord login');
-		const port = process.env.HEALTH_PORT ? parseInt(process.env.HEALTH_PORT) : 3004;
+		const port = process.env.HEALTH_PORT ? parseInt(process.env.HEALTH_PORT) : 3333;
 		const server = createServer((req: IncomingMessage, res: ServerResponse) => {
 			if (req.url === '/health') {
 				res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/apps/starbunk-dnd/package-lock.json
+++ b/apps/starbunk-dnd/package-lock.json
@@ -48,6 +48,7 @@
 				"discord.js": "^14.18.0",
 				"dotenv": "^16.5.0",
 				"envalid": "^8.0.0",
+				"ioredis": "^5.3.2",
 				"node-fetch": "^2.7.0",
 				"node-schedule": "^2.1.1",
 				"openai": "^5.3.0",
@@ -57,6 +58,7 @@
 				"zod": "^3.24.2"
 			},
 			"devDependencies": {
+				"@types/ioredis": "^5.0.0",
 				"@types/jest": "^29.5.14",
 				"@types/node": "^20.17.14",
 				"@types/node-schedule": "^2.1.7",

--- a/apps/starbunk-dnd/src/index.ts
+++ b/apps/starbunk-dnd/src/index.ts
@@ -256,7 +256,7 @@ class StarbunkDNDContainer {
 async function main(): Promise<void> {
 	if (process.env.CI_SMOKE_MODE === 'true') {
 		logger.info('CI_SMOKE_MODE enabled: starting minimal health server and skipping Discord login');
-		const port = process.env.HEALTH_PORT ? parseInt(process.env.HEALTH_PORT) : 3005;
+		const port = process.env.HEALTH_PORT ? parseInt(process.env.HEALTH_PORT) : 3334;
 		const server = createServer((req: IncomingMessage, res: ServerResponse) => {
 			if (req.url === '/health') {
 				res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/infrastructure/docker/docker-compose.yml
+++ b/infrastructure/docker/docker-compose.yml
@@ -58,8 +58,8 @@ services:
       - ENABLE_METRICS=${ENABLE_METRICS:-true}
       - ENABLE_STRUCTURED_LOGGING=${ENABLE_STRUCTURED_LOGGING:-true}
       - LOG_FORMAT=${LOG_FORMAT:-json}
-      - METRICS_PORT=3000
-      - HEALTH_PORT=3000
+      - METRICS_PORT=3331
+      - HEALTH_PORT=3331
       - PROMETHEUS_PUSHGATEWAY_URL=${PROMETHEUS_PUSHGATEWAY_URL:-}
       - METRICS_PUSH_INTERVAL=${METRICS_PUSH_INTERVAL:-30000}
     depends_on:
@@ -67,9 +67,9 @@ services:
         condition: service_healthy
     ports:
       # Metrics and health endpoint port
-      - "${BUNKBOT_METRICS_PORT:-9301}:3000"
+      - "${BUNKBOT_METRICS_PORT:-9301}:3331"
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:3000/health || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://localhost:3331/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -85,7 +85,7 @@ services:
       - com.starbunk.service=bunkbot
       - prometheus.io/scrape=true
       - prometheus.io/path=/metrics
-      - prometheus.io/port=3000
+      - prometheus.io/port=3331
     deploy:
       resources:
         limits:
@@ -113,8 +113,8 @@ services:
       - ENABLE_METRICS=${ENABLE_METRICS:-true}
       - ENABLE_STRUCTURED_LOGGING=${ENABLE_STRUCTURED_LOGGING:-true}
       - LOG_FORMAT=${LOG_FORMAT:-json}
-      - METRICS_PORT=3000
-      - HEALTH_PORT=3000
+      - METRICS_PORT=3333
+      - HEALTH_PORT=3333
       - PROMETHEUS_PUSHGATEWAY_URL=${PROMETHEUS_PUSHGATEWAY_URL:-}
       - METRICS_PUSH_INTERVAL=${METRICS_PUSH_INTERVAL:-30000}
     volumes:
@@ -123,9 +123,9 @@ services:
       - ${UNRAID_APPDATA_PATH:-./data}/djcova/temp:/tmp
     ports:
       # Metrics and health endpoint port
-      - "${DJCOVA_METRICS_PORT:-9304}:3000"
+      - "${DJCOVA_METRICS_PORT:-9304}:3333"
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:3000/health || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://localhost:3333/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -141,7 +141,7 @@ services:
       - com.starbunk.service=djcova
       - prometheus.io/scrape=true
       - prometheus.io/path=/metrics
-      - prometheus.io/port=3000
+      - prometheus.io/port=3333
     deploy:
       resources:
         limits:
@@ -175,8 +175,8 @@ services:
       - ENABLE_METRICS=${ENABLE_METRICS:-true}
       - ENABLE_STRUCTURED_LOGGING=${ENABLE_STRUCTURED_LOGGING:-true}
       - LOG_FORMAT=${LOG_FORMAT:-json}
-      - METRICS_PORT=3000
-      - HEALTH_PORT=3000
+      - METRICS_PORT=3334
+      - HEALTH_PORT=3334
       - PROMETHEUS_PUSHGATEWAY_URL=${PROMETHEUS_PUSHGATEWAY_URL:-}
       - METRICS_PUSH_INTERVAL=${METRICS_PUSH_INTERVAL:-30000}
     volumes:
@@ -186,12 +186,12 @@ services:
       - ${UNRAID_APPDATA_PATH:-./data}/starbunk-dnd/context:/app/data/llm_context
     ports:
       # Metrics and health endpoint port
-      - "${STARBUNK_DND_METRICS_PORT:-9305}:3000"
+      - "${STARBUNK_DND_METRICS_PORT:-9305}:3334"
     depends_on:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:3000/health || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://localhost:3334/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -207,7 +207,7 @@ services:
       - com.starbunk.service=starbunk-dnd
       - prometheus.io/scrape=true
       - prometheus.io/path=/metrics
-      - prometheus.io/port=3000
+      - prometheus.io/port=3334
     deploy:
       resources:
         limits:
@@ -241,8 +241,8 @@ services:
       - ENABLE_METRICS=${ENABLE_METRICS:-true}
       - ENABLE_STRUCTURED_LOGGING=${ENABLE_STRUCTURED_LOGGING:-true}
       - LOG_FORMAT=${LOG_FORMAT:-json}
-      - METRICS_PORT=3000
-      - HEALTH_PORT=3000
+      - METRICS_PORT=3332
+      - HEALTH_PORT=3332
       - PROMETHEUS_PUSHGATEWAY_URL=${PROMETHEUS_PUSHGATEWAY_URL:-}
       - METRICS_PUSH_INTERVAL=${METRICS_PUSH_INTERVAL:-30000}
     volumes:
@@ -251,12 +251,12 @@ services:
     ports:
       - "${COVABOT_WEB_PORT:-7080}:7080"
       # Metrics and health endpoint port
-      - "${COVABOT_METRICS_PORT:-9303}:3000"
+      - "${COVABOT_METRICS_PORT:-9303}:3332"
     depends_on:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:3000/health || curl -f http://localhost:7080/api/health || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://localhost:3332/health || curl -f http://localhost:7080/api/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -272,7 +272,7 @@ services:
       - com.starbunk.service=covabot
       - prometheus.io/scrape=true
       - prometheus.io/path=/metrics
-      - prometheus.io/port=3000
+      - prometheus.io/port=3332
 
     deploy:
       resources:

--- a/monitoring/docker-service-discovery.yml
+++ b/monitoring/docker-service-discovery.yml
@@ -1,0 +1,40 @@
+# Docker service discovery configuration for Prometheus
+# This file defines static targets for Discord bot services
+#
+# Port assignments:
+# - bunkbot: 3331
+# - covabot: 3332
+# - djcova: 3333
+# - starbunk-dnd: 3334
+
+- targets:
+    - 'starbunk-bunkbot:3331'
+  labels:
+    job: 'bunkbot'
+    service: 'bunkbot'
+    container: 'starbunk-bunkbot'
+    __metrics_path__: '/metrics'
+
+- targets:
+    - 'starbunk-covabot:3332'
+  labels:
+    job: 'covabot'
+    service: 'covabot'
+    container: 'starbunk-covabot'
+    __metrics_path__: '/metrics'
+
+- targets:
+    - 'starbunk-djcova:3333'
+  labels:
+    job: 'djcova'
+    service: 'djcova'
+    container: 'starbunk-djcova'
+    __metrics_path__: '/metrics'
+
+- targets:
+    - 'starbunk-dnd:3334'
+  labels:
+    job: 'starbunk-dnd'
+    service: 'starbunk-dnd'
+    container: 'starbunk-dnd'
+    __metrics_path__: '/metrics'


### PR DESCRIPTION
## Summary
- Standardized health/metrics ports across all services (3331-3334) to avoid conflicts
  - bunkbot: 3331, covabot: 3332, djcova: 3333, starbunk-dnd: 3334
- Updated docker-compose.yml with new port mappings and healthcheck URLs
- Added .claude/ directory to .gitignore for Claude Code local configuration
- Added Ollama dependency to covabot for local LLM support
- Created covabot training data collection and validation scripts
- Implemented unified CovaBot architecture with example loading
- Added simple CovaBot implementation for development/testing
- Added Docker service discovery configuration for Prometheus

## Test plan
- [ ] Verify all services start with new health ports
- [ ] Check healthcheck endpoints respond correctly on new ports
- [ ] Test Prometheus metrics collection on standardized ports
- [ ] Validate covabot training scripts functionality
- [ ] Ensure no port conflicts in Docker environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added training data collection tool to analyze Discord conversation patterns
  * Added bot validation utility to test response accuracy
  * Implemented example-based bot learning system
  * Added simplified bot startup and development modes

* **Chores**
  * Updated health endpoint port assignments across services
  * Updated Docker configuration for new port mappings
  * Added external dependency for bot operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->