### PR TITLE
chore(ci): fix semantic versioning workflow handoff

### DIFF
--- a/.github/workflows/semantic-versioning.yml
+++ b/.github/workflows/semantic-versioning.yml
@@ -50,13 +50,6 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Install semantic release tools
-        run: |
-          npm install -g semantic-release
-          npm install -g @semantic-release/changelog
-          npm install -g @semantic-release/git
-          npm install -g conventional-changelog-cli
-
       - name: Analyze commits and determine version
         id: analysis
         run: |
@@ -352,8 +345,8 @@ jobs:
               workflow_id: 'publish-main.yml',
               ref: 'main',
               inputs: {
-                version: newVersion,
-                force_build: 'true'
+                force_all: 'true',
+                skip_validation: 'false'
               }
             });
 


### PR DESCRIPTION
Fixes the semantic versioning workflow handoff into the main container deployment pipeline.

Changes:
- Remove unused global `semantic-release` installs from `.github/workflows/semantic-versioning.yml` (the workflow already uses custom shell logic instead).
- Update the `trigger-container-builds` job to dispatch `publish-main.yml` with the correct inputs (`force_all` and `skip_validation`), so a successful release reliably triggers container builds on `main`.

Scope is limited to `.github/workflows/semantic-versioning.yml` to keep this PR focused on the handoff behavior.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed semantic-release tooling from the continuous integration workflow analysis phase.
  * Updated workflow parameters for managing and triggering downstream builds in the deployment pipeline, transitioning from version-specific inputs to more flexible configuration options for enhanced control over build execution, validation management, and release processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->