### PR TITLE
fix: use inline path filters in publish-main workflow

### DIFF
--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -75,8 +75,26 @@ jobs:
         uses: dorny/paths-filter@v3
         id: filter
         with:
-          filters: .github/path-filters-optimized.yml
-          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: |
+            shared-src:
+              - 'packages/shared/**'
+            bunkbot:
+              - 'apps/bunkbot/**'
+              - 'packages/shared/**'
+            djcova:
+              - 'apps/djcova/**'
+              - 'packages/shared/**'
+            starbunk-dnd:
+              - 'apps/starbunk-dnd/**'
+              - 'packages/shared/**'
+            covabot:
+              - 'apps/covabot/**'
+              - 'packages/shared/**'
+            critical-infrastructure:
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig.json'
+              - 'docker-compose*.yml'
 
       - name: 🎯 Generate Dynamic Deployment Matrix
         id: generate-matrix


### PR DESCRIPTION
## Summary
Fixes the `publish-main.yml` workflow which was failing because it referenced the deleted `.github/path-filters-optimized.yml` file. Also adds new workflows for manual image building and releases.

## Changes

### 1. Fix publish-main.yml (commit 1)
- Updated to use inline path filters instead of external file
- Filters match the pattern used in `pr-validation.yml`

### 2. Add build-images.yml (commit 2)
Manual workflow to build Docker images on demand:
- Triggered via `workflow_dispatch`
- Can build all containers or specific ones (comma-separated)
- Tags images with `:latest` and `:sha`

### 3. Add release.yml (commit 2)
Triggered when a GitHub Release is published:
- Tags existing `:latest` images as `:stable` and `:version`
- Uses `docker buildx imagetools` to retag without rebuilding
- Generates release summary with pull commands

## Tag Strategy
| Tag | When Applied | Purpose |
|-----|--------------|---------|
| `:latest` | Every build | Current development version |
| `:pr-N` | PR builds | Preview for pull requests |
| `:sha` | Every build | Immutable reference |
| `:stable` | GitHub Release | Production-ready version |
| `:v1.2.3` | GitHub Release | Specific version |

## Testing
- All YAML syntax validated locally
- No other workflows reference the deleted file