### PR TITLE
fix: Convert Loki timestamps to strings to fix 400 Bad Request errors

### DIFF
--- a/packages/shared/src/services/observability/StructuredLogger.ts
+++ b/packages/shared/src/services/observability/StructuredLogger.ts
@@ -110,7 +110,7 @@ export class StructuredLogger {
 					event: log.event, // eslint-disable-line @typescript-eslint/no-unused-vars
 					level: log.event === 'bot_error' ? 'error' : 'info', // eslint-disable-line @typescript-eslint/no-unused-vars
 				},
-				values: [[Date.now() * 1000000, JSON.stringify(structuredLog)]], // eslint-disable-line @typescript-eslint/no-unused-vars
+				values: [[(Date.now() * 1000000).toString(), JSON.stringify(structuredLog)]], // eslint-disable-line @typescript-eslint/no-unused-vars
 			});
 		}
 	}
@@ -137,7 +137,7 @@ export class StructuredLogger {
 					event: 'channel_activity', // eslint-disable-line @typescript-eslint/no-unused-vars
 					level: 'info', // eslint-disable-line @typescript-eslint/no-unused-vars
 				},
-				values: [[Date.now() * 1000000, JSON.stringify(log)]], // eslint-disable-line @typescript-eslint/no-unused-vars
+				values: [[(Date.now() * 1000000).toString(), JSON.stringify(log)]], // eslint-disable-line @typescript-eslint/no-unused-vars
 			});
 		}
 	}
@@ -164,7 +164,7 @@ export class StructuredLogger {
 					event: log.event, // eslint-disable-line @typescript-eslint/no-unused-vars
 					level,
 				},
-				values: [[Date.now() * 1000000, JSON.stringify(log)]], // eslint-disable-line @typescript-eslint/no-unused-vars
+				values: [[(Date.now() * 1000000).toString(), JSON.stringify(log)]], // eslint-disable-line @typescript-eslint/no-unused-vars
 			});
 		}
 	}
@@ -197,7 +197,7 @@ export class StructuredLogger {
 					event,
 					level: 'debug', // eslint-disable-line @typescript-eslint/no-unused-vars
 				},
-				values: [[Date.now() * 1000000, JSON.stringify(context)]], // eslint-disable-line @typescript-eslint/no-unused-vars
+				values: [[(Date.now() * 1000000).toString(), JSON.stringify(context)]], // eslint-disable-line @typescript-eslint/no-unused-vars
 			});
 		}
 	}
@@ -233,9 +233,10 @@ export class StructuredLogger {
 }
 
 // Loki client for log shipping
+// Note: Loki API requires timestamp as string in nanoseconds, not number
 interface LokiStream {
 	stream: Record<string, string>; // eslint-disable-line @typescript-eslint/no-unused-vars
-	values: [number, string][]; // eslint-disable-line @typescript-eslint/no-unused-vars
+	values: [string, string][]; // eslint-disable-line @typescript-eslint/no-unused-vars
 }
 
 class LokiClient {


### PR DESCRIPTION
## Problem

Logs were being generated by the application but were **not reaching Grafana/Loki**. Investigation revealed that Loki was rejecting all log pushes with `400 Bad Request` errors:

```
Error: Loki responded with 400: Bad Request
    at LokiClient.flush (/app/node_modules/@starbunk/shared/dist/services/observability/StructuredLogger.js:215:23)
```

## Root Cause

The [Loki Push API](https://grafana.com/docs/loki/latest/api/#push-log-entries-to-loki) requires timestamps to be **strings in nanoseconds format**, not numbers. Our code was sending timestamps as numbers, causing Loki to reject the payload.

## Solution

### Changes Made:

1. **Updated `LokiStream` interface** (line 238):
   - Changed from `values: [number, string][]`
   - Changed to `values: [string, string][]`

2. **Converted all timestamp values to strings** (lines 113, 140, 167, 200):
   - Changed from `Date.now() * 1000000`
   - Changed to `(Date.now() * 1000000).toString()`

3. **Added documentation comment** explaining the Loki API requirement

## Testing

After this fix:
- ✅ Loki will accept the log payloads
- ✅ Logs will appear in Grafana
- ✅ No more 400 Bad Request errors

## Impact

- **Severity**: High - This was preventing all structured logging from working
- **Scope**: All services using StructuredLogger (bunkbot, djcova, covabot, starbunk-dnd)
- **Breaking Changes**: None - this is a bug fix

## Deployment Notes

After merging, containers will need to be rebuilt and redeployed to pick up the fix:

```bash
# Rebuild and redeploy
npm run build
docker-compose build
docker-compose up -d
```

Or for production images:
```bash
# Will be handled by CI/CD pipeline
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timestamp formatting in the logging service to ensure proper compatibility with log aggregation infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->