### PR TITLE
fix: Resolve Loki 400 errors and filter infrastructure logs

### DIFF
--- a/docs/observability/promtail.yml.example
+++ b/docs/observability/promtail.yml.example
@@ -22,6 +22,10 @@ scrape_configs:
       - host: unix:///var/run/docker.sock
         refresh_interval: 30s
     relabel_configs:
+      # Exclude observability infrastructure containers (they generate noise and metrics data)
+      - source_labels: [__meta_docker_container_name]
+        regex: '.*(prometheus|loki|promtail|grafana|pushgateway|alertmanager).*'
+        action: drop
       # Only pick Starbunk containers (optional). Comment out to include all containers.
       - source_labels: [__meta_docker_container_label_com_starbunk_service]
         action: keep

--- a/infrastructure/docker/docker-compose.observability.yml
+++ b/infrastructure/docker/docker-compose.observability.yml
@@ -129,6 +129,7 @@ services:
       - ./docs/observability/promtail.yml.example:/etc/promtail/config.yml:ro
       - /var/log:/var/log:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     command:
       - '-config.file=/etc/promtail/config.yml'
     networks:

--- a/packages/shared/src/services/observability/StructuredLogger.ts
+++ b/packages/shared/src/services/observability/StructuredLogger.ts
@@ -106,7 +106,6 @@ export class StructuredLogger {
 					// eslint-disable-line @typescript-eslint/no-unused-vars
 					service: this.service, // eslint-disable-line @typescript-eslint/no-unused-vars
 					environment: this.environment, // eslint-disable-line @typescript-eslint/no-unused-vars
-					bot: log.bot_name, // eslint-disable-line @typescript-eslint/no-unused-vars
 					event: log.event, // eslint-disable-line @typescript-eslint/no-unused-vars
 					level: log.event === 'bot_error' ? 'error' : 'info', // eslint-disable-line @typescript-eslint/no-unused-vars
 				},
@@ -133,7 +132,6 @@ export class StructuredLogger {
 					// eslint-disable-line @typescript-eslint/no-unused-vars
 					service: this.service, // eslint-disable-line @typescript-eslint/no-unused-vars
 					environment: this.environment, // eslint-disable-line @typescript-eslint/no-unused-vars
-					channel_id: log.channel_id, // eslint-disable-line @typescript-eslint/no-unused-vars
 					event: 'channel_activity', // eslint-disable-line @typescript-eslint/no-unused-vars
 					level: 'info', // eslint-disable-line @typescript-eslint/no-unused-vars
 				},
@@ -193,7 +191,6 @@ export class StructuredLogger {
 					// eslint-disable-line @typescript-eslint/no-unused-vars
 					service: this.service, // eslint-disable-line @typescript-eslint/no-unused-vars
 					environment: this.environment, // eslint-disable-line @typescript-eslint/no-unused-vars
-					bot: botName, // eslint-disable-line @typescript-eslint/no-unused-vars
 					event,
 					level: 'debug', // eslint-disable-line @typescript-eslint/no-unused-vars
 				},

--- a/packages/shared/src/services/observability/server:.yml
+++ b/packages/shared/src/services/observability/server:.yml
@@ -1,0 +1,45 @@
+server:
+    http_listen_port: 9080
+    grpc_listen_port: 0
+positions:
+    filename: /positions/positions.yaml
+clients:
+    - url: http://loki:3100/loki/api/v1/push
+scrape_configs:
+    - job_name: docker-logs
+      docker_sd_configs:
+          - host: unix:///var/run/docker.sock
+            refresh_interval: 30s
+      relabel_configs:
+          # Exclude observability infrastructure containers (they generate noise and metrics data)
+          - source_labels: [__meta_docker_container_name]
+            regex: '.*(prometheus|loki|promtail|grafana|pushgateway|alertmanager).*'
+            action: drop
+          # Only pick Starbunk containers (your bots have com.starbunk.service=...)
+          - source_labels: [__meta_docker_container_label_com_starbunk_service]
+            action: keep
+            regex: .+
+          # Attach container labels as log labels
+          - source_labels: [__meta_docker_container_label_com_starbunk_service]
+            target_label: service
+          - source_labels: [__meta_docker_container_name]
+            target_label: container
+          - source_labels: [__meta_docker_container_image]
+            target_label: image
+          - source_labels: [__meta_docker_container_label_log_level]
+            target_label: log_level
+      pipeline_stages:
+          - docker: {}
+          - json:
+                expressions:
+                    level: level
+                    msg: message
+                    service: service
+                    ts: timestamp
+                on_failure: drop
+          - labels:
+                level:
+                service:
+          - timestamp:
+                source: ts
+                format: RFC3339


### PR DESCRIPTION
## Problem

This PR addresses two critical observability issues:

1. **Loki 400 Bad Request errors occurring every 5 seconds**
   - Caused by high-cardinality labels (`bot`, `channel_id`) in Loki stream definitions
   - Each unique combination creates a new stream, causing stream explosion
   - Exceeded Loki's cardinality limits

2. **Prometheus metrics appearing in Loki as "unknown_services" logs**
   - Promtail was scraping ALL Docker containers including infrastructure
   - Prometheus, Loki, Grafana, Pushgateway logs polluting application logs
   - Docker socket not mounted, preventing proper service discovery

## Solution

### 1. Fixed High-Cardinality Labels in StructuredLogger

**Changed:** `packages/shared/src/services/observability/StructuredLogger.ts`

- Removed high-cardinality labels from Loki streams:
  - ❌ `bot: log.bot_name`
  - ❌ `channel_id: log.channel_id`
  - ❌ `bot: botName`
- Now only uses low-cardinality labels:
  - ✅ `service` (e.g., "bunkbot")
  - ✅ `environment` (e.g., "production")
  - ✅ `event` (e.g., "channel_activity", "bot_responded")
  - ✅ `level` (e.g., "info", "error", "debug")

**Important:** High-cardinality data (bot names, channel IDs) is still preserved in the log content (JSON payload), so it remains fully searchable in Grafana.

### 2. Added Infrastructure Container Filtering

**Changed:** 
- `infrastructure/docker/docker-compose.observability.yml`
- `docs/observability/promtail.yml.example`
- `packages/shared/src/services/observability/server:.yml`

**Docker Compose:**
- Added `/var/run/docker.sock:/var/run/docker.sock:ro` mount to Promtail
- Enables Docker service discovery to work properly

**Promtail Config:**
- Added drop rule to exclude infrastructure containers:
  ```yaml
  - source_labels: [__meta_docker_container_name]
    regex: '.*(prometheus|loki|promtail|grafana|pushgateway|alertmanager).*'
    action: drop
  ```
- Only scrapes containers with `com.starbunk.service` label
- Properly extracts service names from Docker labels

## Impact

✅ **Eliminates** recurring 400 errors every 5 seconds  
✅ **Reduces** log noise from infrastructure containers  
✅ **Improves** Loki performance and query efficiency  
✅ **Maintains** full log searchability and filtering capabilities  
✅ **Fixes** "unknown_services" appearing in logs  

## Testing

After deploying these changes:

1. Rebuild the shared package: `npm run build` in `packages/shared`
2. Restart bot services to pick up new code
3. Restart Promtail to pick up new config: `docker-compose -f infrastructure/docker/docker-compose.observability.yml restart promtail`
4. Monitor logs - 400 errors should stop appearing
5. Check Grafana - infrastructure container logs should no longer appear

## Related Issues

Fixes the Loki 400 Bad Request errors and "unknown_services" log pollution.

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are focused and minimal
- [x] Commit message follows conventional commits
- [x] All configuration files updated consistently
- [x] No breaking changes to existing functionality

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated observability stack configuration to improve log collection and filtering
  * Refined logging pipeline to exclude infrastructure tool containers from logs, reducing noise
  * Enhanced Promtail integration with Docker container logging infrastructure
  * Streamlined log metadata structure for better observability service performance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->