### PR TITLE
fix: disable automatic releases and add prod tag to manual deployments

### DIFF
--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -297,6 +297,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=v${{ steps.read-version.outputs.version }},enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=prod,enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version != '' }}
             type=raw,value=v${{ github.event.inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version != '' }}
             type=sha,prefix={{date 'YYYYMMDD-HHmmss'}}-,suffix=-{{branch}},format=short
             type=raw,value={{date 'YYYYMMDD-HHmmss'}}-{{sha}}-stable,enable=${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/semantic-versioning.yml
+++ b/.github/workflows/semantic-versioning.yml
@@ -1,8 +1,9 @@
 name: Release - Semantic Versioning
 
 on:
-  push:
-    branches: [main]
+  # Disabled automatic releases on push to main
+  # push:
+  #   branches: [main]
   workflow_dispatch:
     inputs:
       release_type:
@@ -61,14 +62,14 @@ jobs:
           fi
 
           CURRENT_VERSION=$(cat VERSION | tr -d '[:space:]')
-          
+
           # Validate that CURRENT_VERSION is a proper semver (X.Y.Z)
           if ! echo "$CURRENT_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "Error: Invalid version in VERSION file: '$CURRENT_VERSION'. Expected format: X.Y.Z"
             echo "should-release=false" >> $GITHUB_OUTPUT
             exit 0
           fi
-          
+
           echo "current-version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
           echo "Current version: $CURRENT_VERSION"
 


### PR DESCRIPTION
## 🎯 Problem

The `prod` tag was never being created for container images because:

1. The `semantic-versioning.yml` workflow automatically creates releases on every push to main
2. Releases created using `GITHUB_TOKEN` do NOT trigger the `release.yml` workflow (GitHub security feature)
3. Therefore, the release workflow never ran, and the `prod` tag was never created

## ✅ Solution

This PR fixes the issue by:

### 1. Disabling Automatic Releases
- Commented out the `push: branches: [main]` trigger in `semantic-versioning.yml`
- Releases should now be created manually via GitHub UI or CLI
- The workflow can still be triggered manually via `workflow_dispatch` if needed

### 2. Adding Prod Tag to Manual Deployments
- Added `prod` tag to `publish-main.yml` when workflow is dispatched with a version
- This provides a backup mechanism for tagging prod images

## 🎯 How It Works Now

### Manual Release Flow (Recommended)
1. **Create a release manually** in GitHub UI or via CLI
2. **Release workflow automatically triggers** (`release.yml`)
3. **Containers are built and tagged:**
   - Production release → `prod` + `vX.Y.Z` tags
   - Pre-release → `staging` + `vX.Y.Z` tags

### Main Branch Flow (Automatic)
1. **Merge to main**
2. **publish-main workflow triggers**
3. **Containers are built and tagged:**
   - `latest` tag
   - `vX.Y.Z` tag (from VERSION file)
   - Timestamped tags for rollback

## 🧪 Testing

After merging, test by creating a new release:
```bash
gh release create v1.4.3 --title "v1.4.3" --notes "Test release"
```

Verify the tags:
```bash
docker pull ghcr.io/andrewgari/bunkbot:prod
docker pull ghcr.io/andrewgari/bunkbot:v1.4.3
```

## 📝 Changes

- `.github/workflows/semantic-versioning.yml`: Disabled automatic release creation on push to main
- `.github/workflows/publish-main.yml`: Added `prod` tag when manually dispatched with a version

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release deployment workflows now require manual triggering via workflow dispatch instead of automatically deploying on push to main.
  * Added production tag support for containerized releases when manually triggered.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->