### PR TITLE
fix: update changelog file path and assets for semantic-release

### DIFF
--- a/release.config.cjs
+++ b/release.config.cjs
@@ -18,7 +18,8 @@ module.exports = {
     [
       "@semantic-release/changelog",
       {
-        changelogFile: "CHANGELOG.md",
+	        // Write changelog into docs/ so it doesn't violate root-directory cleanliness checks
+	        changelogFile: "docs/CHANGELOG.md",
       },
     ],
     [
@@ -32,7 +33,8 @@ module.exports = {
     [
       "@semantic-release/git",
       {
-        assets: ["package.json", "VERSION", "CHANGELOG.md"],
+	        // Commit the synced version files and the docs changelog
+	        assets: ["package.json", "VERSION", "docs/CHANGELOG.md"],
         message:
           "chore(release): v${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
       },

--- a/stacktrace.ini
+++ b/stacktrace.ini
@@ -1,0 +1,365 @@
+Run npx semantic-release
+
+[1:22:12 AM] [semantic-release] › ℹ  Running semantic-release version 25.0.2
+[1:22:13 AM] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/changelog"
+[1:22:13 AM] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/exec"
+[1:22:13 AM] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/git"
+[1:22:13 AM] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/github"
+[1:22:13 AM] [semantic-release] › ✔  Loaded plugin "analyzeCommits" from "@semantic-release/commit-analyzer"
+[1:22:13 AM] [semantic-release] › ✔  Loaded plugin "analyzeCommits" from "@semantic-release/exec"
+[1:22:13 AM] [semantic-release] › ✔  Loaded plugin "verifyRelease" from "@semantic-release/exec"
+[1:22:13 AM] [semantic-release] › ✔  Loaded plugin "generateNotes" from "@semantic-release/release-notes-generator"
+[1:22:13 AM] [semantic-release] › ✔  Loaded plugin "generateNotes" from "@semantic-release/exec"
+[1:22:13 AM] [semantic-release] › ✔  Loaded plugin "prepare" from "@semantic-release/changelog"
+[1:22:13 AM] [semantic-release] › ✔  Loaded plugin "prepare" from "@semantic-release/exec"
+[1:22:13 AM] [semantic-release] › ✔  Loaded plugin "prepare" from "@semantic-release/git"
+[1:22:13 AM] [semantic-release] › ✔  Loaded plugin "publish" from "@semantic-release/exec"
+[1:22:13 AM] [semantic-release] › ✔  Loaded plugin "publish" from "@semantic-release/github"
+[1:22:13 AM] [semantic-release] › ✔  Loaded plugin "addChannel" from "@semantic-release/exec"
+[1:22:13 AM] [semantic-release] › ✔  Loaded plugin "addChannel" from "@semantic-release/github"
+[1:22:13 AM] [semantic-release] › ✔  Loaded plugin "success" from "@semantic-release/exec"
+[1:22:13 AM] [semantic-release] › ✔  Loaded plugin "success" from "@semantic-release/github"
+[1:22:13 AM] [semantic-release] › ✔  Loaded plugin "fail" from "@semantic-release/exec"
+[1:22:13 AM] [semantic-release] › ✔  Loaded plugin "fail" from "@semantic-release/github"
+[1:22:14 AM] [semantic-release] › ✔  Run automated release from branch main on repository git+https://github.com/andrewgari/starbunk-js.git
+[1:22:14 AM] [semantic-release] › ✔  Allowed to push to the Git repository
+[1:22:14 AM] [semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/changelog"
+[1:22:14 AM] [semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/changelog"
+[1:22:14 AM] [semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/exec"
+[1:22:14 AM] [semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/exec"
+[1:22:14 AM] [semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/git"
+[1:22:14 AM] [semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/git"
+[1:22:14 AM] [semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/github"
+[1:22:14 AM] [semantic-release] [@semantic-release/github] › ℹ  Verify GitHub authentication (https://api.github.com)
+[1:22:14 AM] [semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/github"
+[1:22:14 AM] [semantic-release] › ℹ  Found git tag v1.4.2 associated with version 1.4.2 on branch main
+[1:22:14 AM] [semantic-release] › ℹ  Found 14 commits since last release
+[1:22:14 AM] [semantic-release] › ℹ  Start step "analyzeCommits" of plugin "@semantic-release/commit-analyzer"
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: chore(ci): add conventionalcommits preset for semantic-release (#392)
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: fix: update Node version in CI workflow to meet semantic-release requirements (#391)
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is patch
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: chore: setup semantic-release versioning (#390)
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: Version check runs first in PR validation, auto-bumps if needed (#388)
+Co-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>
+Co-authored-by: andrewgari <35663269+andrewgari@users.noreply.github.com>
+Co-authored-by: Andrew Gari <covadax.ag@gmail.com>
+Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: fix: update allowed files in root directory compliance check (#389)
+Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is patch
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: Fix/main validate codebase node setup (#380)
+Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: Redesign CI/CD pipeline with simplified parallel execution and universal naming (#376)
+Co-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>
+Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+Co-authored-by: andrewgari <35663269+andrewgari@users.noreply.github.com>
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: Fix: Always build bunkbot, covabot, djcova on main merge (#374)
+Co-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>
+Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+Co-authored-by: andrewgari <35663269+andrewgari@users.noreply.github.com>
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: fix(ci): align main validation Node setup with PR workflow (#372)
+Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is patch
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: fix(ci): enforce PR version validation and tagging semantics (#370)
+Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>
+Co-authored-by: Copilot <198982749+Copilot@users.noreply.github.com>
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is patch
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: Reorganize PR pipeline with unconditional Docker builds, hash-based publishing, and auto-versioning (#369)
+Co-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>
+Co-authored-by: andrewgari <35663269+andrewgari@users.noreply.github.com>
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: feat: add manual container builder workflow (#363)
+Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>
+Co-authored-by: Copilot <198982749+Copilot@users.noreply.github.com>
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is minor
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: fix: disable automatic releases and add prod tag to manual deployments (#362)
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is patch
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: refactor: implement release-based deployment strategy (#361)
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
+[1:22:14 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analysis of 14 commits complete: minor release
+[1:22:14 AM] [semantic-release] › ✔  Completed step "analyzeCommits" of plugin "@semantic-release/commit-analyzer"
+[1:22:14 AM] [semantic-release] › ℹ  Start step "analyzeCommits" of plugin "@semantic-release/exec"
+[1:22:14 AM] [semantic-release] › ✔  Completed step "analyzeCommits" of plugin "@semantic-release/exec"
+[1:22:14 AM] [semantic-release] › ℹ  The next release version is 1.5.0
+[1:22:14 AM] [semantic-release] › ℹ  Start step "verifyRelease" of plugin "@semantic-release/exec"
+[1:22:14 AM] [semantic-release] › ✔  Completed step "verifyRelease" of plugin "@semantic-release/exec"
+[1:22:14 AM] [semantic-release] › ℹ  Start step "generateNotes" of plugin "@semantic-release/release-notes-generator"
+[1:22:14 AM] [semantic-release] › ✔  Completed step "generateNotes" of plugin "@semantic-release/release-notes-generator"
+[1:22:14 AM] [semantic-release] › ℹ  Start step "generateNotes" of plugin "@semantic-release/exec"
+[1:22:14 AM] [semantic-release] › ✔  Completed step "generateNotes" of plugin "@semantic-release/exec"
+[1:22:14 AM] [semantic-release] › ℹ  Start step "prepare" of plugin "@semantic-release/changelog"
+[1:22:14 AM] [semantic-release] [@semantic-release/changelog] › ℹ  Create /home/runner/work/starbunk-js/starbunk-js/CHANGELOG.md
+[1:22:14 AM] [semantic-release] › ✔  Completed step "prepare" of plugin "@semantic-release/changelog"
+[1:22:14 AM] [semantic-release] › ℹ  Start step "prepare" of plugin "@semantic-release/exec"
+[1:22:14 AM] [semantic-release] [@semantic-release/exec] › ℹ  Call script echo 1.5.0 > VERSION && bash scripts/sync-versions.sh
+📦 Syncing version 1.5.0 from VERSION file to all packages...
+Updating root package.json...
+✓ Updated package.json (1.4.10 → 1.5.0)
+Updating app packages...
+✓ Updated apps/bunkbot/package.json (1.4.10 → 1.5.0)
+✓ Updated apps/covabot/package.json (1.4.10 → 1.5.0)
+✓ Updated apps/djcova/package.json (1.4.10 → 1.5.0)
+✓ Updated apps/starbunk-dnd/package.json (1.4.10 → 1.5.0)
+Updating shared package...
+✓ Updated packages/shared/package.json (1.4.10 → 1.5.0)
+✅ Version sync complete! All packages are now at version 1.5.0
+[1:22:21 AM] [semantic-release] › ✔  Completed step "prepare" of plugin "@semantic-release/exec"
+[1:22:21 AM] [semantic-release] › ℹ  Start step "prepare" of plugin "@semantic-release/git"
+[1:22:22 AM] [semantic-release] [@semantic-release/git] › ℹ  Found 3 file(s) to commit
+[1:22:22 AM] [semantic-release] › ✘  Failed step "prepare" of plugin "@semantic-release/git"
+[1:22:22 AM] [semantic-release] › ✘  An error occurred while running semantic-release: Error: Command failed with exit code 1: git commit -m chore(release): v1.5.0 [skip ci]
+## [1.5.0](https://github.com/andrewgari/starbunk-js/compare/v1.4.2...v1.5.0) (2026-01-04)
+### Features
+* add manual container builder workflow ([#363](https://github.com/andrewgari/starbunk-js/issues/363)) ([a052c6a](https://github.com/andrewgari/starbunk-js/commit/a052c6ad0cd0b4cefe3e9c7240bcaefd23feebe0))
+### Bug Fixes
+* Always build bunkbot, covabot, djcova on main merge ([#374](https://github.com/andrewgari/starbunk-js/issues/374)) ([248705c](https://github.com/andrewgari/starbunk-js/commit/248705c584e5a89cca1a85e8c8770dc7c9f9c6d2))
+* **ci:** align main validation Node setup with PR workflow ([#372](https://github.com/andrewgari/starbunk-js/issues/372)) ([5e610be](https://github.com/andrewgari/starbunk-js/commit/5e610be75678191d0ceb70772e0720083964f710))
+* **ci:** enforce PR version validation and tagging semantics ([#370](https://github.com/andrewgari/starbunk-js/issues/370)) ([111bd24](https://github.com/andrewgari/starbunk-js/commit/111bd249724b6c65239a5cde010924a08642511c))
+* disable automatic releases and add prod tag to manual deployments ([#362](https://github.com/andrewgari/starbunk-js/issues/362)) ([b85203a](https://github.com/andrewgari/starbunk-js/commit/b85203abfa1b7ed31ae2c41c9dcde2ea6c7edeef))
+* update allowed files in root directory compliance check ([#389](https://github.com/andrewgari/starbunk-js/issues/389)) ([6328650](https://github.com/andrewgari/starbunk-js/commit/63286503a4ce3f60c6d253af8626a08ae4a7d3bb))
+* update Node version in CI workflow to meet semantic-release requirements ([#391](https://github.com/andrewgari/starbunk-js/issues/391)) ([5ecff8a](https://github.com/andrewgari/starbunk-js/commit/5ecff8a66e83298627a16af67d65bcae817e48fb))
+🔍 Running pre-commit validation checks...
+📦 Syncing VERSION file to package.json files...
+📦 Syncing version 1.5.0 from VERSION file to all packages...
+Updating root package.json...
+✓ package.json (already 1.5.0)
+Updating app packages...
+✓ apps/bunkbot/package.json (already 1.5.0)
+✓ apps/covabot/package.json (already 1.5.0)
+✓ apps/djcova/package.json (already 1.5.0)
+✓ apps/starbunk-dnd/package.json (already 1.5.0)
+Updating shared package...
+✓ packages/shared/package.json (already 1.5.0)
+✅ Version sync complete! All packages are now at version 1.5.0
+📁 Validating repository structure...
+🔍 Checking root directory compliance...
+❌ Unexpected file in root directory: CHANGELOG.md
+   Move to appropriate subdirectory per docs/development/agentic-style-guide.md
+   Suggested locations:
+     → docs/
+husky - pre-commit script failed (code 1)
+    at makeError (/home/runner/work/starbunk-js/starbunk-js/node_modules/execa/lib/error.js:60:11)
+    at handlePromise (/home/runner/work/starbunk-js/starbunk-js/node_modules/execa/index.js:118:26)
+    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+    at async commit (/home/runner/work/starbunk-js/starbunk-js/node_modules/@semantic-release/git/lib/git.js:38:3)
+    at async module.exports (/home/runner/work/starbunk-js/starbunk-js/node_modules/@semantic-release/git/lib/prepare.js:63:5)
+    at async prepare (/home/runner/work/starbunk-js/starbunk-js/node_modules/@semantic-release/git/index.js:28:3)
+    at async validator (file:///home/runner/work/starbunk-js/starbunk-js/node_modules/semantic-release/lib/plugins/normalize.js:36:24)
+    at async file:///home/runner/work/starbunk-js/starbunk-js/node_modules/semantic-release/lib/plugins/pipeline.js:38:36
+    at async file:///home/runner/work/starbunk-js/starbunk-js/node_modules/semantic-release/lib/plugins/pipeline.js:32:5
+    at async pluginsConfigAccumulator.<computed> [as prepare] (file:///home/runner/work/starbunk-js/starbunk-js/node_modules/semantic-release/lib/plugins/index.js:87:11) {
+  shortMessage: 'Command failed with exit code 1: git commit -m chore(release): v1.5.0 [skip ci]\n' +
+    '\n' +
+    '## [1.5.0](https://github.com/andrewgari/starbunk-js/compare/v1.4.2...v1.5.0) (2026-01-04)\n' +
+    '\n' +
+    '### Features\n' +
+    '\n' +
+    '* add manual container builder workflow ([#363](https://github.com/andrewgari/starbunk-js/issues/363)) ([a052c6a](https://github.com/andrewgari/starbunk-js/commit/a052c6ad0cd0b4cefe3e9c7240bcaefd23feebe0))\n' +
+    '\n' +
+    '### Bug Fixes\n' +
+    '\n' +
+    '* Always build bunkbot, covabot, djcova on main merge ([#374](https://github.com/andrewgari/starbunk-js/issues/374)) ([248705c](https://github.com/andrewgari/starbunk-js/commit/248705c584e5a89cca1a85e8c8770dc7c9f9c6d2))\n' +
+    '* **ci:** align main validation Node setup with PR workflow ([#372](https://github.com/andrewgari/starbunk-js/issues/372)) ([5e610be](https://github.com/andrewgari/starbunk-js/commit/5e610be75678191d0ceb70772e0720083964f710))\n' +
+    '* **ci:** enforce PR version validation and tagging semantics ([#370](https://github.com/andrewgari/starbunk-js/issues/370)) ([111bd24](https://github.com/andrewgari/starbunk-js/commit/111bd249724b6c65239a5cde010924a08642511c))\n' +
+    '* disable automatic releases and add prod tag to manual deployments ([#362](https://github.com/andrewgari/starbunk-js/issues/362)) ([b85203a](https://github.com/andrewgari/starbunk-js/commit/b85203abfa1b7ed31ae2c41c9dcde2ea6c7edeef))\n' +
+    '* update allowed files in root directory compliance check ([#389](https://github.com/andrewgari/starbunk-js/issues/389)) ([6328650](https://github.com/andrewgari/starbunk-js/commit/63286503a4ce3f60c6d253af8626a08ae4a7d3bb))\n' +
+    '* update Node version in CI workflow to meet semantic-release requirements ([#391](https://github.com/andrewgari/starbunk-js/issues/391)) ([5ecff8a](https://github.com/andrewgari/starbunk-js/commit/5ecff8a66e83298627a16af67d65bcae817e48fb))\n',
+  command: 'git commit -m chore(release): v1.5.0 [skip ci]\n' +
+    '\n' +
+    '## [1.5.0](https://github.com/andrewgari/starbunk-js/compare/v1.4.2...v1.5.0) (2026-01-04)\n' +
+    '\n' +
+    '### Features\n' +
+    '\n' +
+    '* add manual container builder workflow ([#363](https://github.com/andrewgari/starbunk-js/issues/363)) ([a052c6a](https://github.com/andrewgari/starbunk-js/commit/a052c6ad0cd0b4cefe3e9c7240bcaefd23feebe0))\n' +
+    '\n' +
+    '### Bug Fixes\n' +
+    '\n' +
+    '* Always build bunkbot, covabot, djcova on main merge ([#374](https://github.com/andrewgari/starbunk-js/issues/374)) ([248705c](https://github.com/andrewgari/starbunk-js/commit/248705c584e5a89cca1a85e8c8770dc7c9f9c6d2))\n' +
+    '* **ci:** align main validation Node setup with PR workflow ([#372](https://github.com/andrewgari/starbunk-js/issues/372)) ([5e610be](https://github.com/andrewgari/starbunk-js/commit/5e610be75678191d0ceb70772e0720083964f710))\n' +
+    '* **ci:** enforce PR version validation and tagging semantics ([#370](https://github.com/andrewgari/starbunk-js/issues/370)) ([111bd24](https://github.com/andrewgari/starbunk-js/commit/111bd249724b6c65239a5cde010924a08642511c))\n' +
+    '* disable automatic releases and add prod tag to manual deployments ([#362](https://github.com/andrewgari/starbunk-js/issues/362)) ([b85203a](https://github.com/andrewgari/starbunk-js/commit/b85203abfa1b7ed31ae2c41c9dcde2ea6c7edeef))\n' +
+    '* update allowed files in root directory compliance check ([#389](https://github.com/andrewgari/starbunk-js/issues/389)) ([6328650](https://github.com/andrewgari/starbunk-js/commit/63286503a4ce3f60c6d253af8626a08ae4a7d3bb))\n' +
+    '* update Node version in CI workflow to meet semantic-release requirements ([#391](https://github.com/andrewgari/starbunk-js/issues/391)) ([5ecff8a](https://github.com/andrewgari/starbunk-js/commit/5ecff8a66e83298627a16af67d65bcae817e48fb))\n',
+  escapedCommand: 'git commit -m "chore(release): v1.5.0 [skip ci]\n' +
+    '\n' +
+    '## [1.5.0](https://github.com/andrewgari/starbunk-js/compare/v1.4.2...v1.5.0) (2026-01-04)\n' +
+    '\n' +
+    '### Features\n' +
+    '\n' +
+    '* add manual container builder workflow ([#363](https://github.com/andrewgari/starbunk-js/issues/363)) ([a052c6a](https://github.com/andrewgari/starbunk-js/commit/a052c6ad0cd0b4cefe3e9c7240bcaefd23feebe0))\n' +
+    '\n' +
+    '### Bug Fixes\n' +
+    '\n' +
+    '* Always build bunkbot, covabot, djcova on main merge ([#374](https://github.com/andrewgari/starbunk-js/issues/374)) ([248705c](https://github.com/andrewgari/starbunk-js/commit/248705c584e5a89cca1a85e8c8770dc7c9f9c6d2))\n' +
+    '* **ci:** align main validation Node setup with PR workflow ([#372](https://github.com/andrewgari/starbunk-js/issues/372)) ([5e610be](https://github.com/andrewgari/starbunk-js/commit/5e610be75678191d0ceb70772e0720083964f710))\n' +
+    '* **ci:** enforce PR version validation and tagging semantics ([#370](https://github.com/andrewgari/starbunk-js/issues/370)) ([111bd24](https://github.com/andrewgari/starbunk-js/commit/111bd249724b6c65239a5cde010924a08642511c))\n' +
+    '* disable automatic releases and add prod tag to manual deployments ([#362](https://github.com/andrewgari/starbunk-js/issues/362)) ([b85203a](https://github.com/andrewgari/starbunk-js/commit/b85203abfa1b7ed31ae2c41c9dcde2ea6c7edeef))\n' +
+    '* update allowed files in root directory compliance check ([#389](https://github.com/andrewgari/starbunk-js/issues/389)) ([6328650](https://github.com/andrewgari/starbunk-js/commit/63286503a4ce3f60c6d253af8626a08ae4a7d3bb))\n' +
+    '* update Node version in CI workflow to meet semantic-release requirements ([#391](https://github.com/andrewgari/starbunk-js/issues/391)) ([5ecff8a](https://github.com/andrewgari/starbunk-js/commit/5ecff8a66e83298627a16af67d65bcae817e48fb))\n' +
+    '"',
+  exitCode: 1,
+  signal: undefined,
+  signalDescription: undefined,
+  stdout: '',
+  stderr: '🔍 Running pre-commit validation checks...\n' +
+    '📦 Syncing VERSION file to package.json files...\n' +
+    '\x1B[0;32m📦 Syncing version \x1B[1;33m1.5.0\x1B[0;32m from VERSION file to all packages...\x1B[0m\n' +
+    '\n' +
+    'Updating root package.json...\n' +
+    '✓ package.json (already 1.5.0)\n' +
+    '\n' +
+    'Updating app packages...\n' +
+    '✓ apps/bunkbot/package.json (already 1.5.0)\n' +
+    '✓ apps/covabot/package.json (already 1.5.0)\n' +
+    '✓ apps/djcova/package.json (already 1.5.0)\n' +
+    '✓ apps/starbunk-dnd/package.json (already 1.5.0)\n' +
+    '\n' +
+    'Updating shared package...\n' +
+    '✓ packages/shared/package.json (already 1.5.0)\n' +
+    '\n' +
+    '\x1B[0;32m✅ Version sync complete! All packages are now at version \x1B[1;33m1.5.0\x1B[0m\n' +
+    '📁 Validating repository structure...\n' +
+    '🔍 Checking root directory compliance...\n' +
+    '❌ Unexpected file in root directory: CHANGELOG.md\n' +
+    '   Move to appropriate subdirectory per docs/development/agentic-style-guide.md\n' +
+    '   Suggested locations:\n' +
+    '     → docs/\n' +
+    'husky - pre-commit script failed (code 1)',
+  failed: true,
+  timedOut: false,
+  isCanceled: false,
+  killed: false,
+  pluginName: '@semantic-release/git'
+}
+Error: Command failed with exit code 1: git commit -m chore(release): v1.5.0 [skip ci]
+## [1.5.0](https://github.com/andrewgari/starbunk-js/compare/v1.4.2...v1.5.0) (2026-01-04)
+### Features
+* add manual container builder workflow ([#363](https://github.com/andrewgari/starbunk-js/issues/363)) ([a052c6a](https://github.com/andrewgari/starbunk-js/commit/a052c6ad0cd0b4cefe3e9c7240bcaefd23feebe0))
+### Bug Fixes
+* Always build bunkbot, covabot, djcova on main merge ([#374](https://github.com/andrewgari/starbunk-js/issues/374)) ([248705c](https://github.com/andrewgari/starbunk-js/commit/248705c584e5a89cca1a85e8c8770dc7c9f9c6d2))
+* **ci:** align main validation Node setup with PR workflow ([#372](https://github.com/andrewgari/starbunk-js/issues/372)) ([5e610be](https://github.com/andrewgari/starbunk-js/commit/5e610be75678191d0ceb70772e0720083964f710))
+* **ci:** enforce PR version validation and tagging semantics ([#370](https://github.com/andrewgari/starbunk-js/issues/370)) ([111bd24](https://github.com/andrewgari/starbunk-js/commit/111bd249724b6c65239a5cde010924a08642511c))
+* disable automatic releases and add prod tag to manual deployments ([#362](https://github.com/andrewgari/starbunk-js/issues/362)) ([b85203a](https://github.com/andrewgari/starbunk-js/commit/b85203abfa1b7ed31ae2c41c9dcde2ea6c7edeef))
+* update allowed files in root directory compliance check ([#389](https://github.com/andrewgari/starbunk-js/issues/389)) ([6328650](https://github.com/andrewgari/starbunk-js/commit/63286503a4ce3f60c6d253af8626a08ae4a7d3bb))
+* update Node version in CI workflow to meet semantic-release requirements ([#391](https://github.com/andrewgari/starbunk-js/issues/391)) ([5ecff8a](https://github.com/andrewgari/starbunk-js/commit/5ecff8a66e83298627a16af67d65bcae817e48fb))
+🔍 Running pre-commit validation checks...
+📦 Syncing VERSION file to package.json files...
+📦 Syncing version 1.5.0 from VERSION file to all packages...
+Updating root package.json...
+✓ package.json (already 1.5.0)
+Updating app packages...
+✓ apps/bunkbot/package.json (already 1.5.0)
+✓ apps/covabot/package.json (already 1.5.0)
+✓ apps/djcova/package.json (already 1.5.0)
+✓ apps/starbunk-dnd/package.json (already 1.5.0)
+Updating shared package...
+✓ packages/shared/package.json (already 1.5.0)
+✅ Version sync complete! All packages are now at version 1.5.0
+📁 Validating repository structure...
+🔍 Checking root directory compliance...
+❌ Unexpected file in root directory: CHANGELOG.md
+   Move to appropriate subdirectory per docs/development/agentic-style-guide.md
+   Suggested locations:
+     → docs/
+husky - pre-commit script failed (code 1)
+    at makeError (/home/runner/work/starbunk-js/starbunk-js/node_modules/execa/lib/error.js:60:11)
+    at handlePromise (/home/runner/work/starbunk-js/starbunk-js/node_modules/execa/index.js:118:26)
+    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+    at async commit (/home/runner/work/starbunk-js/starbunk-js/node_modules/@semantic-release/git/lib/git.js:38:3)
+    at async module.exports (/home/runner/work/starbunk-js/starbunk-js/node_modules/@semantic-release/git/lib/prepare.js:63:5)
+    at async prepare (/home/runner/work/starbunk-js/starbunk-js/node_modules/@semantic-release/git/index.js:28:3)
+    at async validator (file:///home/runner/work/starbunk-js/starbunk-js/node_modules/semantic-release/lib/plugins/normalize.js:36:24)
+    at async file:///home/runner/work/starbunk-js/starbunk-js/node_modules/semantic-release/lib/plugins/pipeline.js:38:36
+    at async file:///home/runner/work/starbunk-js/starbunk-js/node_modules/semantic-release/lib/plugins/pipeline.js:32:5
+    at async pluginsConfigAccumulator.<computed> [as prepare] (file:///home/runner/work/starbunk-js/starbunk-js/node_modules/semantic-release/lib/plugins/index.js:87:11) {
+  shortMessage: 'Command failed with exit code 1: git commit -m chore(release): v1.5.0 [skip ci]\n' +
+    '\n' +
+    '## [1.5.0](https://github.com/andrewgari/starbunk-js/compare/v1.4.2...v1.5.0) (2026-01-04)\n' +
+    '\n' +
+    '### Features\n' +
+    '\n' +
+    '* add manual container builder workflow ([#363](https://github.com/andrewgari/starbunk-js/issues/363)) ([a052c6a](https://github.com/andrewgari/starbunk-js/commit/a052c6ad0cd0b4cefe3e9c7240bcaefd23feebe0))\n' +
+    '\n' +
+    '### Bug Fixes\n' +
+    '\n' +
+    '* Always build bunkbot, covabot, djcova on main merge ([#374](https://github.com/andrewgari/starbunk-js/issues/374)) ([248705c](https://github.com/andrewgari/starbunk-js/commit/248705c584e5a89cca1a85e8c8770dc7c9f9c6d2))\n' +
+    '* **ci:** align main validation Node setup with PR workflow ([#372](https://github.com/andrewgari/starbunk-js/issues/372)) ([5e610be](https://github.com/andrewgari/starbunk-js/commit/5e610be75678191d0ceb70772e0720083964f710))\n' +
+    '* **ci:** enforce PR version validation and tagging semantics ([#370](https://github.com/andrewgari/starbunk-js/issues/370)) ([111bd24](https://github.com/andrewgari/starbunk-js/commit/111bd249724b6c65239a5cde010924a08642511c))\n' +
+    '* disable automatic releases and add prod tag to manual deployments ([#362](https://github.com/andrewgari/starbunk-js/issues/362)) ([b85203a](https://github.com/andrewgari/starbunk-js/commit/b85203abfa1b7ed31ae2c41c9dcde2ea6c7edeef))\n' +
+    '* update allowed files in root directory compliance check ([#389](https://github.com/andrewgari/starbunk-js/issues/389)) ([6328650](https://github.com/andrewgari/starbunk-js/commit/63286503a4ce3f60c6d253af8626a08ae4a7d3bb))\n' +
+    '* update Node version in CI workflow to meet semantic-release requirements ([#391](https://github.com/andrewgari/starbunk-js/issues/391)) ([5ecff8a](https://github.com/andrewgari/starbunk-js/commit/5ecff8a66e83298627a16af67d65bcae817e48fb))\n',
+  command: 'git commit -m chore(release): v1.5.0 [skip ci]\n' +
+    '\n' +
+    '## [1.5.0](https://github.com/andrewgari/starbunk-js/compare/v1.4.2...v1.5.0) (2026-01-04)\n' +
+    '\n' +
+    '### Features\n' +
+    '\n' +
+    '* add manual container builder workflow ([#363](https://github.com/andrewgari/starbunk-js/issues/363)) ([a052c6a](https://github.com/andrewgari/starbunk-js/commit/a052c6ad0cd0b4cefe3e9c7240bcaefd23feebe0))\n' +
+    '\n' +
+    '### Bug Fixes\n' +
+    '\n' +
+    '* Always build bunkbot, covabot, djcova on main merge ([#374](https://github.com/andrewgari/starbunk-js/issues/374)) ([248705c](https://github.com/andrewgari/starbunk-js/commit/248705c584e5a89cca1a85e8c8770dc7c9f9c6d2))\n' +
+    '* **ci:** align main validation Node setup with PR workflow ([#372](https://github.com/andrewgari/starbunk-js/issues/372)) ([5e610be](https://github.com/andrewgari/starbunk-js/commit/5e610be75678191d0ceb70772e0720083964f710))\n' +
+    '* **ci:** enforce PR version validation and tagging semantics ([#370](https://github.com/andrewgari/starbunk-js/issues/370)) ([111bd24](https://github.com/andrewgari/starbunk-js/commit/111bd249724b6c65239a5cde010924a08642511c))\n' +
+    '* disable automatic releases and add prod tag to manual deployments ([#362](https://github.com/andrewgari/starbunk-js/issues/362)) ([b85203a](https://github.com/andrewgari/starbunk-js/commit/b85203abfa1b7ed31ae2c41c9dcde2ea6c7edeef))\n' +
+    '* update allowed files in root directory compliance check ([#389](https://github.com/andrewgari/starbunk-js/issues/389)) ([6328650](https://github.com/andrewgari/starbunk-js/commit/63286503a4ce3f60c6d253af8626a08ae4a7d3bb))\n' +
+    '* update Node version in CI workflow to meet semantic-release requirements ([#391](https://github.com/andrewgari/starbunk-js/issues/391)) ([5ecff8a](https://github.com/andrewgari/starbunk-js/commit/5ecff8a66e83298627a16af67d65bcae817e48fb))\n',
+  escapedCommand: 'git commit -m "chore(release): v1.5.0 [skip ci]\n' +
+    '\n' +
+    '## [1.5.0](https://github.com/andrewgari/starbunk-js/compare/v1.4.2...v1.5.0) (2026-01-04)\n' +
+    '\n' +
+    '### Features\n' +
+    '\n' +
+    '* add manual container builder workflow ([#363](https://github.com/andrewgari/starbunk-js/issues/363)) ([a052c6a](https://github.com/andrewgari/starbunk-js/commit/a052c6ad0cd0b4cefe3e9c7240bcaefd23feebe0))\n' +
+    '\n' +
+    '### Bug Fixes\n' +
+    '\n' +
+    '* Always build bunkbot, covabot, djcova on main merge ([#374](https://github.com/andrewgari/starbunk-js/issues/374)) ([248705c](https://github.com/andrewgari/starbunk-js/commit/248705c584e5a89cca1a85e8c8770dc7c9f9c6d2))\n' +
+    '* **ci:** align main validation Node setup with PR workflow ([#372](https://github.com/andrewgari/starbunk-js/issues/372)) ([5e610be](https://github.com/andrewgari/starbunk-js/commit/5e610be75678191d0ceb70772e0720083964f710))\n' +
+    '* **ci:** enforce PR version validation and tagging semantics ([#370](https://github.com/andrewgari/starbunk-js/issues/370)) ([111bd24](https://github.com/andrewgari/starbunk-js/commit/111bd249724b6c65239a5cde010924a08642511c))\n' +
+    '* disable automatic releases and add prod tag to manual deployments ([#362](https://github.com/andrewgari/starbunk-js/issues/362)) ([b85203a](https://github.com/andrewgari/starbunk-js/commit/b85203abfa1b7ed31ae2c41c9dcde2ea6c7edeef))\n' +
+    '* update allowed files in root directory compliance check ([#389](https://github.com/andrewgari/starbunk-js/issues/389)) ([6328650](https://github.com/andrewgari/starbunk-js/commit/63286503a4ce3f60c6d253af8626a08ae4a7d3bb))\n' +
+    '* update Node version in CI workflow to meet semantic-release requirements ([#391](https://github.com/andrewgari/starbunk-js/issues/391)) ([5ecff8a](https://github.com/andrewgari/starbunk-js/commit/5ecff8a66e83298627a16af67d65bcae817e48fb))\n' +
+    '"',
+  exitCode: 1,
+  signal: undefined,
+  signalDescription: undefined,
+  stdout: '',
+  stderr: '🔍 Running pre-commit validation checks...\n' +
+    '📦 Syncing VERSION file to package.json files...\n' +
+    '\x1B[0;32m📦 Syncing version \x1B[1;33m1.5.0\x1B[0;32m from VERSION file to all packages...\x1B[0m\n' +
+    '\n' +
+    'Updating root package.json...\n' +
+    '✓ package.json (already 1.5.0)\n' +
+    '\n' +
+    'Updating app packages...\n' +
+    '✓ apps/bunkbot/package.json (already 1.5.0)\n' +
+    '✓ apps/covabot/package.json (already 1.5.0)\n' +
+    '✓ apps/djcova/package.json (already 1.5.0)\n' +
+    '✓ apps/starbunk-dnd/package.json (already 1.5.0)\n' +
+    '\n' +
+    'Updating shared package...\n' +
+    '✓ packages/shared/package.json (already 1.5.0)\n' +
+    '\n' +
+    '\x1B[0;32m✅ Version sync complete! All packages are now at version \x1B[1;33m1.5.0\x1B[0m\n' +
+    '📁 Validating repository structure...\n' +
+    '🔍 Checking root directory compliance...\n' +
+    '❌ Unexpected file in root directory: CHANGELOG.md\n' +
+    '   Move to appropriate subdirectory per docs/development/agentic-style-guide.md\n' +
+    '   Suggested locations:\n' +
+    '     → docs/\n' +
+    'husky - pre-commit script failed (code 1)',
+  failed: true,
+  timedOut: false,
+  isCanceled: false,
+  killed: false,
+  pluginName: '@semantic-release/git'
+}
+Error: Process completed with exit code 1.


### PR DESCRIPTION
- Changed the changelog file path to "docs/CHANGELOG.md" to comply with root-directory cleanliness checks.
- Updated the assets in the semantic-release git plugin to include the new changelog path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and release configuration for changelog management.
  * Added diagnostic logging for the release process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->