### PR TITLE
chore(ci): use CI_TOKEN for semantic-release

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.CI_TOKEN }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -38,7 +39,7 @@ jobs:
 
       - name: Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
           HUSKY: 0
         run: npx semantic-release
 


### PR DESCRIPTION
This PR updates the semantic-release workflow to authenticate using the CI_TOKEN secret so that releases can bypass the protected main ruleset when run under the appropriate actor.

Changes:
- Checkout step in `.github/workflows/semantic-release.yml` now uses `secrets.CI_TOKEN`.
- semantic-release is executed with `GITHUB_TOKEN` set to `secrets.CI_TOKEN`.

This should allow semantic-release to create tags and push to main using the PAT owner identity that has ruleset bypass permissions, while keeping PR validation protections enforced for normal contributors.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD authentication configuration to streamline token management in the release workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->