### PR TITLE
fix: resolve race condition in release pipeline

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,7 +1,10 @@
 name: Semantic Release
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Main - Deploy & Release"]
+    types:
+      - completed
     branches:
       - main
 
@@ -18,12 +21,15 @@ jobs:
   check-release-needed:
     name: Check if Release is Needed
     runs-on: ubuntu-latest
+    # Only run if the main-deploy workflow succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     outputs:
       should_release: ${{ steps.check.outputs.should_release }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Check changed files
@@ -36,14 +42,14 @@ jobs:
             # For initial commit, consider all files changed
             CHANGED_FILES=$(git ls-files)
           fi
-          
+
           echo "Changed files:"
           echo "${CHANGED_FILES}"
-          
+
           # Check if any files outside of .github/ or CI config were changed
           # These are files that affect the application itself
           APP_FILES_CHANGED=$(echo "$CHANGED_FILES" | grep -v '^\.github/' | grep -v '^\.eslintrc' | grep -v '^\.prettier' | grep -v '^\.editorconfig' || true)
-          
+
           if [ -z "$APP_FILES_CHANGED" ]; then
             echo "should_release=false" >> $GITHUB_OUTPUT
             echo "⏭️  Only CI/build configuration changed - skipping release"
@@ -64,6 +70,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
           token: ${{ secrets.CI_TOKEN }}
 


### PR DESCRIPTION
## Problem

The release pipeline had a **race condition** where the GitHub release was being created **before** the Docker images were built and published.

### Root Cause

Both `semantic-release.yml` and `main-deploy.yml` were triggered on `push` to `main` and ran in **parallel**:
- `semantic-release.yml` could finish first and create a GitHub release
- This triggered `release.yml` which tried to pull `:latest` images
- But `main-deploy.yml` might not have finished building/publishing the images yet!

## Solution

Changed `semantic-release.yml` to use `workflow_run` trigger to wait for `main-deploy.yml` to complete.

### Changes Made

1. **Trigger Change**: Use `workflow_run` instead of `push`
   - Waits for "Main - Deploy & Release" workflow to complete
   
2. **Success Check**: Only run if main-deploy succeeded
   - `if: ${{ github.event.workflow_run.conclusion == 'success' }}`
   
3. **Correct SHA Checkout**: Use the exact commit that was deployed
   - `ref: ${{ github.event.workflow_run.head_sha }}`

### New Flow

1. ✅ Push to main
2. ✅ `main-deploy.yml` runs (builds, validates, publishes `:latest` images)
3. ✅ `main-deploy.yml` completes successfully
4. ✅ `semantic-release.yml` triggers (creates GitHub release)
5. ✅ `release.yml` triggers (pulls `:latest` and re-tags with version)

## Semantic Versioning Verification

The semantic-release process should still work correctly:

- ✅ Analyzes commits with conventional commits (feat, fix, chore)
- ✅ Checks out exact SHA that was deployed
- ✅ Full commit history available (`fetch-depth: 0`)
- ✅ Version bumping rules unchanged:
  - `fix:` → Patch (1.0.0 → 1.0.1)
  - `feat:` → Minor (1.0.0 → 1.1.0)
  - `BREAKING CHANGE:` → Major (1.0.0 → 2.0.0)

## Testing

After merging, verify:
- [ ] `main-deploy.yml` completes successfully
- [ ] `semantic-release.yml` triggers after main-deploy
- [ ] Version is correctly bumped
- [ ] GitHub release is created
- [ ] `release.yml` successfully pulls and re-tags images
- [ ] No race condition errors

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author