### PR TITLE
Remove env_file from services in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ services:
     image: ghcr.io/andrewgari/bunkbot:prod
     container_name: starbunk-bunkbot
     restart: unless-stopped
-    env_file:
-      - .env
     environment:
       # Required: Discord bot token for BunkBot
       - DISCORD_TOKEN=${BUNKBOT_TOKEN}
@@ -60,8 +58,6 @@ services:
     image: ghcr.io/andrewgari/djcova:prod
     container_name: starbunk-djcova
     restart: unless-stopped
-    env_file:
-      - .env
     environment:
       - NODE_ENV=production
       # Optional: Discord bot token (default: STARBUNK_TOKEN)
@@ -121,8 +117,6 @@ services:
     image: ghcr.io/andrewgari/covabot:prod
     container_name: starbunk-covabot
     restart: unless-stopped
-    env_file:
-      - .env
     environment:
       - NODE_ENV=production
       - NODE_OPTIONS=--max-old-space-size=768
@@ -214,8 +208,6 @@ services:
     image: ghcr.io/andrewgari/bluebot:prod
     container_name: starbunk-bluebot
     restart: unless-stopped
-    env_file:
-      - .env
     environment:
       - NODE_ENV=production
       # Optional: Discord bot token (default: STARBUNK_TOKEN)


### PR DESCRIPTION
Removed env_file entries for multiple services in docker-compose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment variable configuration in the deployment setup. Environment variables are now sourced exclusively from configuration sections rather than external files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->