### PR TITLE
chore: update OTLP collector ports for external access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -274,8 +274,8 @@ services:
       - ./infrastructure/monitoring/otel-collector-config.yml:/etc/otel-collector-config.yml:ro
     # OTLP collector exposed to host for external access
     ports:
-      - "4317:4317"   # OTLP gRPC receiver (for bot services and host)
-      - "4318:4318"   # OTLP HTTP receiver (for bot services and host)
+      - "14317:4317"   # OTLP gRPC receiver (for bot services and host)
+      - "14318:4318"   # OTLP HTTP receiver (for bot services and host)
     expose:
       - "8888"        # Prometheus metrics (internal only)
       - "8889"        # Prometheus exporter (internal only)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated external port mappings for the OpenTelemetry Collector service in Docker configuration (host ports changed from 4317/4318 to 14317/14318).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->