### PR TITLE
fix: update covabot LLM test imports to use shared package

### DIFF
--- a/src/covabot/tests/services/llm/embedding-manager.scheduling.test.ts
+++ b/src/covabot/tests/services/llm/embedding-manager.scheduling.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { EmbeddingManager } from '../../../src/services/llm/embedding-manager';
+import { EmbeddingManager } from '@starbunk/shared/services/llm';
 
 describe('EmbeddingManager - Scheduling', () => {
   const originalEnv = process.env;

--- a/src/covabot/tests/services/llm/ollama-model-manager.config.test.ts
+++ b/src/covabot/tests/services/llm/ollama-model-manager.config.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { OllamaModelManager } from '../../../src/services/llm/ollama-model-manager';
+import { OllamaModelManager } from '@starbunk/shared/services/llm';
 
 describe('OllamaModelManager - Configuration', () => {
   const originalEnv = process.env;

--- a/src/covabot/tests/services/llm/ollama-model-manager.interval.test.ts
+++ b/src/covabot/tests/services/llm/ollama-model-manager.interval.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { OllamaModelManager } from '../../../src/services/llm/ollama-model-manager';
+import { OllamaModelManager } from '@starbunk/shared/services/llm';
 
 describe('OllamaModelManager - Interval Descriptions', () => {
   const originalEnv = process.env;

--- a/src/covabot/tests/services/llm/ollama-model-manager.scheduling.test.ts
+++ b/src/covabot/tests/services/llm/ollama-model-manager.scheduling.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { OllamaModelManager } from '../../../src/services/llm/ollama-model-manager';
+import { OllamaModelManager } from '@starbunk/shared/services/llm';
 
 describe('OllamaModelManager - Scheduling', () => {
   const originalEnv = process.env;


### PR DESCRIPTION
## Problem
CovaBot test suite had 4 failing tests importing from incorrect local paths:
- `embedding-manager.scheduling.test.ts`
- `ollama-model-manager.config.test.ts`
- `ollama-model-manager.interval.test.ts`
- `ollama-model-manager.scheduling.test.ts`

All were trying to import directly from `../../../src/services/llm/` but these classes are actually exported from the shared package.

## Solution
Updated all 4 test files to import from `@starbunk/shared/services/llm` instead of local paths.

## Changes
- Fixed EmbeddingManager import: `@starbunk/shared/services/llm`
- Fixed OllamaModelManager imports (3 files): `@starbunk/shared/services/llm`

## Test Results
✅ CovaBot test suite: 101/101 passing (10 test files)
- All previously failing tests now pass
- No regressions in other tests

## Files Modified
- `src/covabot/tests/services/llm/embedding-manager.scheduling.test.ts`
- `src/covabot/tests/services/llm/ollama-model-manager.config.test.ts`
- `src/covabot/tests/services/llm/ollama-model-manager.interval.test.ts`
- `src/covabot/tests/services/llm/ollama-model-manager.scheduling.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal module import paths in test files to use centralized package aliases for improved code organization and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->