### PR TITLE
chore: move deployments to circleci runner

### DIFF
--- a/.circleci/workflows/deploy-production.yml
+++ b/.circleci/workflows/deploy-production.yml
@@ -62,7 +62,7 @@ commands:
             TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
             BUILD_URL="https://app.circleci.com/pipelines/github/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}"
 
-            PAYLOAD=$(cat <<EOF
+            PAYLOAD=$(cat <<-EOF
             {
               "embeds": [{
                 "title": "${EMOJI} ${TITLE}",
@@ -127,7 +127,7 @@ jobs:
             # Add Unraid server to known hosts
             ssh-keyscan -H "${PROD_SERVER_HOST}" >> ~/.ssh/known_hosts 2>/dev/null || true
 
-            cat > ~/.ssh/config <<EOF
+            cat > ~/.ssh/config <<-EOF
             Host unraid-prod
               HostName ${PROD_SERVER_HOST}
               User ${PROD_SERVER_USER}

--- a/.circleci/workflows/main-merge.yml
+++ b/.circleci/workflows/main-merge.yml
@@ -104,7 +104,7 @@ jobs:
             npx semantic-release
 
   tag_version_images:
-    executor: docker
+    executor: runner
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## Overview
Fixes two critical issues in the CircleCI deployment workflows that were preventing image tagging and deployment.

## Changes
- **tag_version_images executor**: Changed from `docker` to `runner` 
  - The `docker` executor doesn't have Docker daemon available
  - The `runner` executor (self-hosted) has Docker available
  - Resolves: `Cannot connect to the Docker daemon at unix:///var/run/docker.sock`

- **Heredoc syntax in deploy-production.yml**: Changed `<<EOF` to `<<-EOF`
  - CircleCI v2.1+ requires `<<-` to properly handle indented heredocs
  - Applied to both notify_discord command and SSH config setup

## Testing
- Pre-commit validations passed
- All existing tests pass
- Repository structure validations passed