### PR TITLE
feat(ci): add automatic deployment to unraid on main branch

### DIFF
--- a/.circleci/main-merge.yml
+++ b/.circleci/main-merge.yml
@@ -207,6 +207,65 @@ jobs:
               docker push ${IMAGE}:${VERSION}
             done
 
+  deploy_to_unraid:
+    machine: true
+    resource_class: medium
+    steps:
+      - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "${SSH_KEY_FINGERPRINT}"
+      - setup_ssh_config
+      - notify_discord:
+          status: started
+          version: "${CIRCLE_BRANCH}"
+          message: "Deploying Starbunk services (tag: main) to Unraid server..."
+      - run:
+          name: Deploy to Unraid Server
+          command: |
+            VERSION=$(cat config/VERSION | tr -d '\n')
+            DEPLOY_TAG="main"  # Use :main tag from main branch
+
+            echo "========================================"
+            echo "Deploying version: ${VERSION}"
+            echo "Using image tag: ${DEPLOY_TAG}"
+            echo "Target: ${PROD_SERVER_HOST}"
+            echo "========================================"
+
+            # Copy deployment script to server
+            scp scripts/deployment/deploy.sh unraid-prod:/tmp/starbunk-deploy.sh
+            scp scripts/deployment/health-check.sh unraid-prod:/tmp/starbunk-health-check.sh
+
+            # Execute deployment on server
+            ssh unraid-prod "bash /tmp/starbunk-deploy.sh '${PROD_DOCKER_COMPOSE_DIR}' '${DEPLOY_TAG}' '${VERSION}'"
+
+      - run:
+          name: Verify Deployment Health
+          command: |
+            echo "========================================"
+            echo "Running post-deployment health checks..."
+            echo "========================================"
+
+            # Run health check script on server
+            ssh unraid-prod "bash /tmp/starbunk-health-check.sh '${PROD_DOCKER_COMPOSE_DIR}'"
+
+      - run:
+          name: Cleanup Remote Scripts
+          when: always
+          command: |
+            ssh unraid-prod "rm -f /tmp/starbunk-*.sh" || true
+
+      - notify_discord:
+          status: success
+          version: "${CIRCLE_BRANCH}"
+          message: "All services deployed and healthy on Unraid server!"
+
+      - run:
+          name: Handle Deployment Failure
+          when: on_fail
+          command: |
+            echo "Deployment failed - Discord notification will be sent by notify_discord with when: always"
+
 workflows:
   main_merge:
     jobs:
@@ -255,3 +314,7 @@ workflows:
             - publish_bluebot_latest
       - tag_version_images:
           requires: [semantic_release]
+      - deploy_to_unraid:
+          context:
+            - deployment-production
+          requires: [tag_version_images]

--- a/.circleci/shared-config.yml
+++ b/.circleci/shared-config.yml
@@ -75,3 +75,125 @@ commands:
               sudo apt-get install -y --no-install-recommends docker.io
             fi
             docker --version
+  notify_discord:
+    description: "Send deployment notification to Discord"
+    parameters:
+      status:
+        type: string
+        description: "Deployment status: started, success, failed"
+      version:
+        type: string
+        default: "${CIRCLE_BRANCH}"
+      message:
+        type: string
+        default: ""
+    steps:
+      - run:
+          name: Send Discord Notification
+          when: always
+          command: |
+            if [ -z "${DISCORD_WEBHOOK_URL:-}" ]; then
+              echo "WARNING: DISCORD_WEBHOOK_URL not configured - skipping notification"
+              exit 0
+            fi
+
+            STATUS="<< parameters.status >>"
+            VERSION="<< parameters.version >>"
+            MESSAGE="<< parameters.message >>"
+
+            case "$STATUS" in
+              started)
+                COLOR=3447003  # Blue
+                EMOJI=":rocket:"
+                TITLE="Deployment Started"
+                ;;
+              success)
+                COLOR=3066993  # Green
+                EMOJI=":white_check_mark:"
+                TITLE="Deployment Successful"
+                ;;
+              failed)
+                COLOR=15158332  # Red
+                EMOJI=":x:"
+                TITLE="Deployment Failed"
+                ;;
+              *)
+                COLOR=10181046  # Purple
+                EMOJI=":information_source:"
+                TITLE="Deployment Update"
+                ;;
+            esac
+
+            TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            BUILD_URL="https://app.circleci.com/pipelines/github/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}"
+
+            PAYLOAD=$(cat \<<-EOF
+            {
+              "embeds": [{
+                "title": "${EMOJI} ${TITLE}",
+                "description": "${MESSAGE}",
+                "color": ${COLOR},
+                "fields": [
+                  {
+                    "name": "Version/Branch",
+                    "value": "\`${VERSION}\`",
+                    "inline": true
+                  },
+                  {
+                    "name": "Branch",
+                    "value": "\`${CIRCLE_BRANCH:-N/A}\`",
+                    "inline": true
+                  },
+                  {
+                    "name": "Commit",
+                    "value": "\`${CIRCLE_SHA1:0:7}\`",
+                    "inline": true
+                  },
+                  {
+                    "name": "Triggered By",
+                    "value": "${CIRCLE_USERNAME:-CircleCI}",
+                    "inline": true
+                  }
+                ],
+                "timestamp": "${TIMESTAMP}",
+                "footer": {
+                  "text": "Starbunk Production Deployment"
+                },
+                "url": "${BUILD_URL}"
+              }]
+            }
+            EOF
+            )
+
+            curl -H "Content-Type: application/json" \
+                 -d "${PAYLOAD}" \
+                 "${DISCORD_WEBHOOK_URL}"
+
+  setup_ssh_config:
+    description: "Setup SSH config for Unraid server access"
+    steps:
+      - run:
+          name: Setup SSH Config
+          command: |
+            mkdir -p ~/.ssh
+            chmod 700 ~/.ssh
+
+            # Add Unraid server to known hosts
+            ssh-keyscan -H "${PROD_SERVER_HOST}" >> ~/.ssh/known_hosts 2>/dev/null || true
+
+            cat > ~/.ssh/config \<<-EOF
+            Host unraid-prod
+              HostName ${PROD_SERVER_HOST}
+              User ${PROD_SERVER_USER}
+              StrictHostKeyChecking no
+              UserKnownHostsFile /dev/null
+              LogLevel ERROR
+            EOF
+
+            chmod 600 ~/.ssh/config
+
+      - run:
+          name: Verify SSH Connection
+          command: |
+            echo "Testing SSH connection to Unraid server..."
+            ssh unraid-prod "echo 'SSH connection successful'"


### PR DESCRIPTION
## Summary
Adds the missing deployment step to the main branch workflow. When images are tagged with , the deployment to Unraid automatically triggers.

## Changes
- Add `deploy_to_unraid` job that runs after `tag_version_images` completes
- Extract `notify_discord` and `setup_ssh_config` commands to shared-config.yml for reuse
- Deploy job uses the `deployment-production` context for SSH and Discord credentials
- Includes post-deployment health checks and cleanup

## Deployment Flow
```
build_apps → publish_* → semantic_release → tag_version_images → deploy_to_unraid
```

## Triggers
✅ Only on `main` branch
✅ Automatically after Docker images are tagged with `:main`
✅ Uses :main tagged images for deployment (not version-specific)

## Testing
Next push to main will trigger the full pipeline including deployment.

Fixes #560