### PR TITLE
fix(djcova): update yt-dlp to 2026.03.17 and remove dead YouTube dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -352,44 +352,6 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
-    "node_modules/@distube/yt-dlp": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@distube/yt-dlp/-/yt-dlp-2.0.1.tgz",
-      "integrity": "sha512-9c16lRU6jbyal38UUr5E36+2lp36s0DaJySOtFjuAPgaJkp2xvKvyd+s4rFZSqVQGJO5GOhBiH+HD115SKfKAw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "dargs": "^7.0.0",
-        "undici": "^6.18.2"
-      },
-      "funding": {
-        "url": "https://github.com/skick1234/DisTube?sponsor"
-      },
-      "peerDependencies": {
-        "distube": "5"
-      }
-    },
-    "node_modules/@distube/ytdl-core": {
-      "version": "4.16.12",
-      "resolved": "https://registry.npmjs.org/@distube/ytdl-core/-/ytdl-core-4.16.12.tgz",
-      "integrity": "sha512-/NR8Jur1Q4E2oD+DJta7uwWu7SkqdEkhwERt7f4iune70zg7ZlLLTOHs1+jgg3uD2jQjpdk7RGC16FqstG4RsA==",
-      "license": "MIT",
-      "dependencies": {
-        "http-cookie-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.6",
-        "m3u8stream": "^0.8.6",
-        "miniget": "^4.2.3",
-        "sax": "^1.4.1",
-        "tough-cookie": "^5.1.2",
-        "undici": "^7.8.0"
-      },
-      "engines": {
-        "node": ">=20.18.1"
-      },
-      "funding": {
-        "url": "https://github.com/distubejs/ytdl-core?sponsor"
-      }
-    },
     "node_modules/@epic-web/invariant": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
@@ -3696,6 +3658,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -4714,15 +4677,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/dargs": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
-      "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -4893,27 +4847,6 @@
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/distube": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/distube/-/distube-5.2.3.tgz",
-      "integrity": "sha512-fWdFDR3bH3fbkEthAukUKEpiRWCjt9xfgCCOkJqTCpdjkDx6zGDRFe+ETp8MlGMl7SGFjS0tntXzNF0o4NQSvg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tiny-typed-emitter": "^2.1.0",
-        "undici": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/skick1234/DisTube?sponsor"
-      },
-      "peerDependencies": {
-        "@discordjs/voice": "*",
-        "discord.js": "14"
       }
     },
     "node_modules/doctrine": {
@@ -6419,30 +6352,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/http-cookie-agent": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-7.0.3.tgz",
-      "integrity": "sha512-EeZo7CGhfqPW6R006rJa4QtZZUpBygDa2HZH3DJqsTzTjyRE6foDBVQIv/pjVsxHC8z2GIdbB1Hvn9SRorP3WQ==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.4"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/3846masa"
-      },
-      "peerDependencies": {
-        "tough-cookie": "^4.0.0 || ^5.0.0 || ^6.0.0",
-        "undici": "^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "undici": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -6476,6 +6385,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -7298,19 +7208,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/m3u8stream": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.6.tgz",
-      "integrity": "sha512-LZj8kIVf9KCphiHmH7sbFQTVe4tOemb202fWwvJwR9W5ENW/1hxJN6ksAWGhQgSBSa3jyWhnjKU1Fw1GaOdbyA==",
-      "license": "MIT",
-      "dependencies": {
-        "miniget": "^4.2.2",
-        "sax": "^1.2.4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/magic-bytes.js": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
@@ -7564,15 +7461,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/miniget": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/miniget/-/miniget-4.2.3.tgz",
-      "integrity": "sha512-SjbDPDICJ1zT+ZvQwK0hUcRY4wxlhhNpHL9nJOB2MEAXRGagTljsO8MEDzQMTFf0Q8g4QNi8P9lEm/g7e+qgzA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/minimatch": {
@@ -10636,24 +10524,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/play-audio": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/play-audio/-/play-audio-0.5.2.tgz",
-      "integrity": "sha512-ZAqHUKkQLix2Iga7pPbsf1LpUoBjcpwU93F1l3qBIfxYddQLhxS6GKmS0d3jV8kSVaUbr6NnOEcEMFvuX93SWQ==",
-      "license": "GPL-3.0"
-    },
-    "node_modules/play-dl": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/play-dl/-/play-dl-1.9.7.tgz",
-      "integrity": "sha512-KpgerWxUCY4s9Mhze2qdqPhiqd8Ve6HufpH9mBH3FN+vux55qSh6WJKDabfie8IBHN7lnrAlYcT/UdGax58c2A==",
-      "license": "GPL-3.0",
-      "dependencies": {
-        "play-audio": "^0.5.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/plimit-lit": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
@@ -11350,15 +11220,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/sax": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
-      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=11.0.0"
       }
     },
     "node_modules/secure-json-parse": {
@@ -12484,13 +12345,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/tiny-typed-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
-      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -12566,24 +12420,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tldts": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
-      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tldts-core": "^6.1.86"
-      },
-      "bin": {
-        "tldts": "bin/cli.js"
-      }
-    },
-    "node_modules/tldts-core": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-      "license": "MIT"
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -12605,18 +12441,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/tough-cookie": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tldts": "^6.1.32"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -14547,20 +14371,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ytdl-core": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.11.5.tgz",
-      "integrity": "sha512-27LwsW4n4nyNviRCO1hmr8Wr5J1wLLMawHCQvH8Fk0hiRqrxuIu028WzbJetiYH28K8XDbeinYW4/wcHQD1EXA==",
-      "license": "MIT",
-      "dependencies": {
-        "m3u8stream": "^0.8.6",
-        "miniget": "^4.2.2",
-        "sax": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/zod": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
@@ -14825,17 +14635,13 @@
         "@discordjs/builders": "^1.6.5",
         "@discordjs/rest": "^2.5.0",
         "@discordjs/voice": "^0.18.0",
-        "@distube/yt-dlp": "^2.0.1",
-        "@distube/ytdl-core": "^4.16.10",
         "@starbunk/shared": "file:../shared",
         "chalk": "^4.1.2",
         "discord-api-types": "^0.38.23",
         "discord.js": "^14.18.0",
         "dotenv": "^16.5.0",
         "ffmpeg-static": "^5.2.0",
-        "opusscript": "^0.0.8",
-        "play-dl": "^1.9.7",
-        "ytdl-core": "^4.11.5"
+        "opusscript": "^0.0.8"
       },
       "devDependencies": {
         "@types/node": "^20.17.14",

--- a/src/djcova/Dockerfile
+++ b/src/djcova/Dockerfile
@@ -58,7 +58,7 @@ RUN apk add --no-cache ffmpeg openssl dumb-init curl python3 py3-pip && \
     adduser -S -D -H -u 1001 -h /app -s /sbin/nologin -G djcova djcova && \
     mkdir -p /tmp/djcova && \
     chown -R djcova:djcova /tmp/djcova && \
-    pip3 install --no-cache-dir --break-system-packages "yt-dlp==2024.10.22"
+    pip3 install --no-cache-dir --break-system-packages "yt-dlp==2026.03.17"
 
 # Copy only production dependencies and built artifacts from builder
 COPY --from=builder --chown=djcova:djcova /app/node_modules ./node_modules

--- a/src/djcova/package.json
+++ b/src/djcova/package.json
@@ -21,17 +21,13 @@
     "@discordjs/builders": "^1.6.5",
     "@discordjs/rest": "^2.5.0",
     "@discordjs/voice": "^0.18.0",
-    "@distube/yt-dlp": "^2.0.1",
-    "@distube/ytdl-core": "^4.16.10",
     "@starbunk/shared": "file:../shared",
     "chalk": "^4.1.2",
     "discord-api-types": "^0.38.23",
     "discord.js": "^14.18.0",
     "dotenv": "^16.5.0",
     "ffmpeg-static": "^5.2.0",
-    "opusscript": "^0.0.8",
-    "play-dl": "^1.9.7",
-    "ytdl-core": "^4.11.5"
+    "opusscript": "^0.0.8"
   },
   "devDependencies": {
     "@types/node": "^20.17.14",


### PR DESCRIPTION
## Summary
- Updates yt-dlp from 2024.10.22 → 2026.03.17 (fixes broken /play command)
- Removes unused npm packages: ytdl-core, @distube/ytdl-core, @distube/yt-dlp, play-dl
- DJCova uses the yt-dlp binary directly, not these npm wrappers