### PR TITLE
fix(djcova): await voice subscription and register it for cleanup

### DIFF
--- a/src/djcova/src/services/dj-cova-service.ts
+++ b/src/djcova/src/services/dj-cova-service.ts
@@ -61,12 +61,13 @@ export class DJCovaService {
 
     // Subscribe player to connection
     logger.debug('Subscribing player to connection...');
-    const subscription = subscribePlayerToConnection(connection, this.djCova.getPlayer());
+    const subscription = await subscribePlayerToConnection(connection, this.djCova.getPlayer());
     if (!subscription) {
       const errorMsg = 'Failed to connect audio player to voice channel';
       logger.error(errorMsg);
       throw new Error(errorMsg);
     }
+    this.djCova.setSubscription(subscription);
     logger.debug('✅ Player subscribed to connection');
 
     if (!interaction.guild) {

--- a/src/djcova/src/services/dj-cova-service.ts
+++ b/src/djcova/src/services/dj-cova-service.ts
@@ -67,7 +67,6 @@ export class DJCovaService {
       logger.error(errorMsg);
       throw new Error(errorMsg);
     }
-    this.djCova.setSubscription(subscription);
     logger.debug('✅ Player subscribed to connection');
 
     if (!interaction.guild) {
@@ -97,9 +96,11 @@ export class DJCovaService {
     );
     logger.debug('✅ Idle management initialized');
 
-    // Start playback
+    // Start playback — register the subscription after play() runs its internal
+    // stop()/cleanup() so the new subscription is not immediately unsubscribed.
     logger.info('Starting playback...');
     await this.djCova.play(url);
+    this.djCova.setSubscription(subscription);
     logger.info('✅ Playback started successfully');
   }
 


### PR DESCRIPTION
## Summary
- `subscribePlayerToConnection` is async but was called without `await`, bypassing the voice connection readiness gate — the player could attempt audio playback before the connection reached Ready state
- Any voice setup errors (connection timeouts, permission failures) were silently swallowed, leaving users with no error feedback
- Added `setSubscription()` call so DJCova tracks the subscription and properly unsubscribes during stop/cleanup

## Test plan
- [ ] Post a YouTube URL with `/play` while in a voice channel — bot should join and play audio
- [ ] Post a `/play` URL while **not** in a voice channel — should get a clear error message
- [ ] Run `/stop` and confirm the bot leaves and resources are cleaned up
- [ ] All 202 existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)