### PR TITLE
fix(djcova): destroy Disconnected connections before retrying voice join

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+echo "🔍 Running pre-commit validation checks..."
+
+# Repository structure validation
+echo "📁 Validating repository structure..."
+bash scripts/validation/check-root-directory.sh
+bash scripts/validation/check-naming-conventions.sh
+bash scripts/validation/check-temporary-files.sh
+
+echo "🧹 Running lint-staged (ESLint + Prettier on staged files)..."
+npx lint-staged
+
+echo "✅ Pre-commit checks completed successfully!"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+echo "🚀 Running pre-push validation..."
+echo "  • Type checking..."
+npm run type-check
+
+echo "  • Linting..."
+npm run lint
+
+echo "  • Running tests..."
+npm run test
+
+echo "✅ Pre-push checks passed!"

--- a/src/djcova/src/core/dj-cova.ts
+++ b/src/djcova/src/core/dj-cova.ts
@@ -2,6 +2,7 @@ import {
   createAudioPlayer,
   createAudioResource,
   AudioPlayerStatus,
+  VoiceConnectionStatus,
   demuxProbe,
   NoSubscriberBehavior,
   joinVoiceChannel,
@@ -80,15 +81,20 @@ export class DJCova {
 
     this.player.on(AudioPlayerStatus.Playing, () => {
       logger.info('▶️ Playback started');
-      // Diagnostic: use currentSubscription to detect "no subscription = silence" bugs
+      // Diagnostic: detect conditions that cause silent playback
       if (!this.currentSubscription) {
         logger.error(
           '❌ Player started but has no active voice subscription — audio will be silent! Check subscription setup.',
         );
       } else {
-        logger.debug(
-          `Voice subscription active at playback start (connection status: ${this.currentSubscription.connection.state.status})`,
-        );
+        const connStatus = this.currentSubscription.connection.state.status;
+        if (connStatus !== VoiceConnectionStatus.Ready) {
+          logger.error(
+            `❌ Player started but voice connection is not Ready (state: ${connStatus}) — audio will be silent!`,
+          );
+        } else {
+          logger.debug('✅ Voice subscription active and connection Ready at playback start');
+        }
       }
       logger.debug('Resetting idle timer due to playback start');
       this.idleManager?.resetIdleTimer();

--- a/src/djcova/src/core/dj-cova.ts
+++ b/src/djcova/src/core/dj-cova.ts
@@ -103,7 +103,11 @@ export class DJCova {
     this.player.on('error', (error: Error) => {
       logger.withError(error).error('❌ Audio player error');
       logger.debug('Triggering cleanup due to player error');
-      this.notificationCallback?.(`❌ Playback error: ${error.message}`).catch(() => {});
+      this.notificationCallback?.(`❌ Playback error: ${error.message}`).catch(err => {
+        logger
+          .withError(err instanceof Error ? err : new Error(String(err)))
+          .warn('⚠️ Failed to send error notification to user');
+      });
       this.cleanup();
     });
 

--- a/src/djcova/src/utils/voice-utils.ts
+++ b/src/djcova/src/utils/voice-utils.ts
@@ -77,8 +77,10 @@ export function createVoiceConnection(
   connection.on(VoiceConnectionStatus.Disconnected, async () => {
     logger.warn(`⚠️ Voice connection disconnected from channel: ${channel.name}`);
     try {
-      // Wait up to 5 seconds to see if the library starts reconnecting on its own
-      await Promise.race([
+      // Wait up to 5 seconds to see if the library starts reconnecting on its own.
+      // Promise.any is used so that both entersState() rejections are consumed
+      // internally — the losing promise doesn't surface as an unhandled rejection.
+      await Promise.any([
         entersState(connection, VoiceConnectionStatus.Signalling, 5_000),
         entersState(connection, VoiceConnectionStatus.Connecting, 5_000),
       ]);

--- a/src/djcova/src/utils/voice-utils.ts
+++ b/src/djcova/src/utils/voice-utils.ts
@@ -41,13 +41,32 @@ export function createVoiceConnection(
   const existingConnection = getVoiceConnection(channel.guild.id);
   if (existingConnection) {
     const currentChannelId = existingConnection.joinConfig?.channelId;
+    const existingStatus = existingConnection.state.status;
     if (currentChannelId === channel.id) {
-      logger.info(`✅ Reusing existing voice connection for guild ${channel.guild.id}`);
-      return existingConnection;
+      // Only reuse the connection if it is in a state that can still reach Ready.
+      // A Disconnected connection is unusable: returning it causes waitForConnectionReady()
+      // to time out (or see "destroyed") because the Disconnected handler will destroy it
+      // within 5 seconds — leaving the bot visually in the channel but unable to play audio,
+      // and preventing the caller from creating a fresh connection via joinVoiceChannel().
+      if (
+        existingStatus === VoiceConnectionStatus.Ready ||
+        existingStatus === VoiceConnectionStatus.Connecting ||
+        existingStatus === VoiceConnectionStatus.Signalling
+      ) {
+        logger.info(
+          `✅ Reusing existing voice connection (state: ${existingStatus}) for guild ${channel.guild.id}`,
+        );
+        return existingConnection;
+      }
+      logger.warn(
+        `Existing connection for same channel is in unusable state '${existingStatus}'; destroying and recreating`,
+      );
+      // Fall through to destroy + recreate below
+    } else {
+      logger.debug(
+        `Existing connection is in channel ${currentChannelId}; switching to ${channel.id} for guild ${channel.guild.id}`,
+      );
     }
-    logger.debug(
-      `Existing connection is in ${currentChannelId}; switching to ${channel.id} for guild ${channel.guild.id}`,
-    );
     try {
       logger.debug('Destroying existing connection...');
       existingConnection.destroy();

--- a/src/djcova/src/utils/ytdlp.ts
+++ b/src/djcova/src/utils/ytdlp.ts
@@ -111,7 +111,12 @@ export function getYouTubeAudioStream(url: string): {
     // Only treat a non-zero exit CODE as an error; intentional kills are not errors.
     if (code !== null && code !== 0) {
       const stderrOutput = stderrBuffer.trim();
-      const errorMessage = stderrOutput || `yt-dlp process failed with code ${code}`;
+      // Truncate to 1000 chars so the message stays within Discord's 2000-char limit
+      // when it is eventually forwarded to the user via notificationCallback.
+      const errorMessage = (stderrOutput || `yt-dlp process failed with code ${code}`).slice(
+        0,
+        1000,
+      );
       logger.error(`yt-dlp exited with error: ${errorMessage}`);
       // Destroy the stream regardless of whether data was already emitted —
       // a partial stream produces silence rather than a user-visible error.

--- a/src/djcova/src/utils/ytdlp.ts
+++ b/src/djcova/src/utils/ytdlp.ts
@@ -107,17 +107,25 @@ export function getYouTubeAudioStream(url: string): {
       `yt-dlp process exited: code=${code}, signal=${signal}, hasEmittedData=${hasEmittedData}`,
     );
 
-    // code === null means the process was killed by a signal (e.g. our own SIGKILL).
-    // Only treat a non-zero exit CODE as an error; intentional kills are not errors.
-    if (code !== null && code !== 0) {
+    // Treat as an error if yt-dlp exited with a non-zero code OR was killed by
+    // an unexpected signal.  We specifically exclude SIGKILL because that is the
+    // signal DJCova uses when intentionally terminating the process; treating it
+    // as an error here would cause spurious notifications on every track change.
+    // Note: we cannot distinguish our own SIGKILL from a system OOM-kill (both
+    // appear as signal='SIGKILL'), but that edge-case is acceptable — the stale
+    // state will be cleaned up on the next /play invocation.
+    const isUnexpectedExit =
+      (code !== null && code !== 0) || (code === null && signal !== null && signal !== 'SIGKILL');
+
+    if (isUnexpectedExit) {
       const stderrOutput = stderrBuffer.trim();
       // Truncate to 1000 chars so the message stays within Discord's 2000-char limit
       // when it is eventually forwarded to the user via notificationCallback.
-      const errorMessage = (stderrOutput || `yt-dlp process failed with code ${code}`).slice(
-        0,
-        1000,
-      );
-      logger.error(`yt-dlp exited with error: ${errorMessage}`);
+      const errorMessage = (
+        stderrOutput ||
+        `yt-dlp process terminated unexpectedly (code=${code ?? 'null'}, signal=${signal ?? 'none'})`
+      ).slice(0, 1000);
+      logger.error(`yt-dlp terminated unexpectedly: ${errorMessage}`);
       // Destroy the stream regardless of whether data was already emitted —
       // a partial stream produces silence rather than a user-visible error.
       stream.destroy(new Error(errorMessage));

--- a/src/djcova/tests/voice-utils.subscription.test.ts
+++ b/src/djcova/tests/voice-utils.subscription.test.ts
@@ -213,6 +213,7 @@ describe('voice-utils subscription lifecycle', () => {
   it('createVoiceConnection reuses existing connection in same channel', () => {
     const existingConnection = {
       joinConfig: { channelId: 'channel-1' },
+      state: { status: Voice.VoiceConnectionStatus.Ready },
       destroy: vi.fn(),
       on: vi.fn(),
     } as any;
@@ -233,9 +234,39 @@ describe('voice-utils subscription lifecycle', () => {
     expect(result).toBe(existingConnection);
   });
 
+  it('createVoiceConnection destroys Disconnected connection in same channel and creates fresh one', () => {
+    const existingConnection = {
+      joinConfig: { channelId: 'channel-1' },
+      state: { status: Voice.VoiceConnectionStatus.Disconnected },
+      destroy: vi.fn(),
+      on: vi.fn(),
+    } as any;
+
+    const newConnection = {
+      on: vi.fn(),
+    } as any;
+
+    vi.mocked(Voice.getVoiceConnection).mockReturnValue(existingConnection as any);
+    vi.mocked(Voice.joinVoiceChannel).mockReturnValue(newConnection as any);
+
+    const channel = {
+      id: 'channel-1',
+      name: 'Music',
+      guild: { id: 'guild-1', voiceAdapterCreator: {} },
+      permissionsFor: vi.fn(),
+    } as any;
+
+    const result = createVoiceConnection(channel, channel.guild.voiceAdapterCreator);
+
+    expect(existingConnection.destroy).toHaveBeenCalledTimes(1);
+    expect(Voice.joinVoiceChannel).toHaveBeenCalledTimes(1);
+    expect(result).toBe(newConnection);
+  });
+
   it('createVoiceConnection destroys existing connection in different channel before joining new one', () => {
     const existingConnection = {
       joinConfig: { channelId: 'other-channel' },
+      state: { status: Voice.VoiceConnectionStatus.Ready },
       destroy: vi.fn(),
       on: vi.fn(),
     } as any;


### PR DESCRIPTION
## Summary

- **Root cause:** `createVoiceConnection()` returned a `Disconnected` connection for the same channel without checking its state. When the UDP handshake fails, the bot visually joins the channel (Signalling phase) but the connection gets stuck. `waitForConnectionReady()` then times out or sees "destroyed" (when the Disconnected handler's 5-second timer fires), resulting in "Failed to connect audio player to voice channel".
- **Second-summons failure:** because the bad connection was reused instead of recreated, `joinVoiceChannel()` was never called again — so the bot didn't re-appear and failed the same way.
- **Fix:** only reuse an existing connection if its state is `Ready`, `Connecting`, or `Signalling`. Any other state (e.g. `Disconnected`) is destroyed immediately so a fresh `joinVoiceChannel()` call creates a clean connection.
- **Improved diagnostic:** the `Playing` event handler now also checks whether the subscription's connection is `Ready` at playback start, surfacing the "subscribed to non-Ready connection = silence" case in logs.

## Test plan

- [ ] Existing voice-utils subscription tests pass (mocks updated with `state` property)
- [ ] New test: `createVoiceConnection` with a `Disconnected` same-channel connection destroys it and creates a fresh one
- [ ] Manual: `/play` after being disconnected/kicked now rejoins and plays correctly
- [ ] Manual: second `/play` summons no longer silently reuses a bad connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)