### PR TITLE
feat(observability): standardized error codes and DJCova play funnel metrics

### DIFF
--- a/src/djcova/src/commands/play.ts
+++ b/src/djcova/src/commands/play.ts
@@ -40,6 +40,7 @@ export default {
 
     if (!url) {
       logger.warn('No URL provided in play command');
+      getDJCovaMetrics().trackPlayCommand(interaction.guild?.id ?? 'unknown', 'error');
       await sendErrorResponse(interaction, 'Please provide a YouTube URL!');
       return;
     }
@@ -48,6 +49,7 @@ export default {
 
     if (!guildId) {
       logger.warn('Play command used outside of guild context');
+      getDJCovaMetrics().trackPlayCommand('unknown', 'error');
       await sendErrorResponse(interaction, 'This command can only be used in a server.');
       return;
     }
@@ -63,7 +65,7 @@ export default {
       getDJCovaMetrics().trackPlayCommand(guildId, 'success');
       await sendSuccessResponse(interaction, `🎶 Now playing!`);
     } catch (error) {
-      logError(logger, DJCovaErrorCode.DJCOVA_AUDIO_STREAM_ERROR, 'Play command failed', {
+      logError(logger, DJCovaErrorCode.DJCOVA_PLAY_COMMAND_FAILED, 'Play command failed', {
         cause: error,
         guild_id: guildId,
       });

--- a/src/djcova/src/commands/play.ts
+++ b/src/djcova/src/commands/play.ts
@@ -5,6 +5,8 @@ import { logger } from '@/observability/logger';
 import { getDJCovaService } from '@/core/djcova-factory';
 import { getDJCovaMetrics } from '@/observability/djcova-metrics';
 import { DJCovaErrorCode } from '@/errors';
+import { logError } from '@starbunk/shared/errors';
+import { SharedErrorCode } from '@starbunk/shared/errors';
 
 const commandBuilder = new SlashCommandBuilder()
   .setName('play')
@@ -27,9 +29,9 @@ export default {
         logger.debug('✅ Reply deferred');
       }
     } catch (deferError) {
-      logger
-        .withError(deferError instanceof Error ? deferError : new Error(String(deferError)))
-        .error('Failed to defer interaction');
+      logError(logger, SharedErrorCode.DISCORD_API_ERROR, 'Failed to defer interaction', {
+        cause: deferError,
+      });
       return;
     }
 
@@ -61,12 +63,10 @@ export default {
       getDJCovaMetrics().trackPlayCommand(guildId, 'success');
       await sendSuccessResponse(interaction, `🎶 Now playing!`);
     } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error));
-      logger
-        .withError(err)
-        .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_AUDIO_STREAM_ERROR, guild_id: guildId })
-        .error('Play command failed');
-
+      logError(logger, DJCovaErrorCode.DJCOVA_AUDIO_STREAM_ERROR, 'Play command failed', {
+        cause: error,
+        guild_id: guildId,
+      });
       getDJCovaMetrics().trackPlayCommand(guildId, 'error');
 
       const errorMessage =

--- a/src/djcova/src/commands/play.ts
+++ b/src/djcova/src/commands/play.ts
@@ -3,6 +3,8 @@ import type { ChatInputCommandInteraction } from 'discord.js';
 import { sendErrorResponse, sendSuccessResponse } from '../utils/discord-utils';
 import { logger } from '@/observability/logger';
 import { getDJCovaService } from '@/core/djcova-factory';
+import { getDJCovaMetrics } from '@/observability/djcova-metrics';
+import { DJCovaErrorCode } from '@/errors';
 
 const commandBuilder = new SlashCommandBuilder()
   .setName('play')
@@ -40,25 +42,32 @@ export default {
       return;
     }
 
-    try {
-      // Get or create per-guild DJCovaService instance
-      if (!interaction.guild?.id) {
-        logger.warn('Play command used outside of guild context');
-        await sendErrorResponse(interaction, 'This command can only be used in a server.');
-        return;
-      }
+    const guildId = interaction.guild?.id;
 
-      logger.debug(`Getting DJCova service for guild: ${interaction.guild.id}`);
-      const service = getDJCovaService(interaction.guild.id);
+    if (!guildId) {
+      logger.warn('Play command used outside of guild context');
+      await sendErrorResponse(interaction, 'This command can only be used in a server.');
+      return;
+    }
+
+    try {
+      logger.debug(`Getting DJCova service for guild: ${guildId}`);
+      const service = getDJCovaService(guildId);
       logger.debug('DJCova service retrieved, calling play method...');
 
       await service.play(interaction, url);
       logger.info('✅ Play command completed successfully');
 
+      getDJCovaMetrics().trackPlayCommand(guildId, 'success');
       await sendSuccessResponse(interaction, `🎶 Now playing!`);
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
-      logger.withError(err).error('❌ Error executing play command');
+      logger
+        .withError(err)
+        .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_AUDIO_STREAM_ERROR, guild_id: guildId })
+        .error('Play command failed');
+
+      getDJCovaMetrics().trackPlayCommand(guildId, 'error');
 
       const errorMessage =
         error instanceof Error

--- a/src/djcova/src/commands/set-volume.ts
+++ b/src/djcova/src/commands/set-volume.ts
@@ -3,7 +3,7 @@ import { ChatInputCommandInteraction } from 'discord.js';
 import { sendErrorResponse, sendSuccessResponse } from '../utils/discord-utils';
 import { logger } from '../observability/logger';
 import { getDJCovaService } from '@/core/djcova-factory';
-import { SharedErrorCode } from '@starbunk/shared/errors';
+import { SharedErrorCode, logError } from '@starbunk/shared/errors';
 
 const commandBuilder = new SlashCommandBuilder()
   .setName('volume')
@@ -33,10 +33,9 @@ export default {
       await sendSuccessResponse(interaction, `Volume set to ${vol}%`);
       logger.info(`Volume changed to ${vol}%`);
     } catch (error) {
-      logger
-        .withError(error instanceof Error ? error : new Error(String(error)))
-        .withMetadata({ error_code: SharedErrorCode.VALIDATION_FAILED })
-        .error('Error executing volume command');
+      logError(logger, SharedErrorCode.VALIDATION_FAILED, 'Error executing volume command', {
+        cause: error,
+      });
 
       const errorMessage =
         error instanceof Error ? error.message : 'An error occurred while changing the volume.';

--- a/src/djcova/src/commands/set-volume.ts
+++ b/src/djcova/src/commands/set-volume.ts
@@ -3,6 +3,7 @@ import { ChatInputCommandInteraction } from 'discord.js';
 import { sendErrorResponse, sendSuccessResponse } from '../utils/discord-utils';
 import { logger } from '../observability/logger';
 import { getDJCovaService } from '@/core/djcova-factory';
+import { SharedErrorCode } from '@starbunk/shared/errors';
 
 const commandBuilder = new SlashCommandBuilder()
   .setName('volume')
@@ -34,6 +35,7 @@ export default {
     } catch (error) {
       logger
         .withError(error instanceof Error ? error : new Error(String(error)))
+        .withMetadata({ error_code: SharedErrorCode.VALIDATION_FAILED })
         .error('Error executing volume command');
 
       const errorMessage =

--- a/src/djcova/src/core/dj-cova.ts
+++ b/src/djcova/src/core/dj-cova.ts
@@ -14,6 +14,7 @@ import { getMusicConfig } from '../config/music-config';
 import ffmpegPath from 'ffmpeg-static';
 import { logger } from '../observability/logger';
 import { DJCovaErrorCode } from '../errors';
+import { logError } from '@starbunk/shared/errors';
 
 type AudioPlayerLike = ReturnType<typeof createAudioPlayer>;
 type AudioResourceLike = ReturnType<typeof createAudioResource>;
@@ -67,10 +68,14 @@ export class DJCova {
       });
       logger.debug('Audio player created successfully');
     } catch (error) {
-      logger
-        .withError(error instanceof Error ? error : new Error(String(error)))
-        .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_AUDIO_PLAYER_FAILED })
-        .error('Failed to create audio player');
+      logError(
+        logger,
+        DJCovaErrorCode.DJCOVA_AUDIO_PLAYER_FAILED,
+        'Failed to create audio player',
+        {
+          cause: error,
+        },
+      );
       throw error;
     }
 
@@ -109,10 +114,9 @@ export class DJCova {
     });
 
     this.player.on('error', (error: Error) => {
-      logger
-        .withError(error)
-        .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_AUDIO_STREAM_ERROR })
-        .error('Audio player error');
+      logError(logger, DJCovaErrorCode.DJCOVA_AUDIO_STREAM_ERROR, 'Audio player error', {
+        cause: error,
+      });
       logger.debug('Triggering cleanup due to player error');
       this.notificationCallback?.(`❌ Playback error: ${error.message}`).catch(err => {
         logger
@@ -175,16 +179,16 @@ export class DJCova {
       this.player.play(this.currentResource);
       logger.info('✅ Audio playback started');
     } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error));
-      logger
-        .withError(err)
-        .withMetadata({
-          error_code: DJCovaErrorCode.DJCOVA_AUDIO_STREAM_ERROR,
-          stack: err.stack,
+      logError(
+        logger,
+        DJCovaErrorCode.DJCOVA_AUDIO_STREAM_ERROR,
+        'Failed to start audio playback',
+        {
+          cause: error,
           url,
           ytdlpProcessPid: this.ytdlpProcess?.pid,
-        })
-        .error('Failed to start audio playback');
+        },
+      );
       // Only run full cleanup if this play() call is still the active one.
       // If a concurrent play() has already called stopAudioOnly() and replaced
       // ytdlpProcess, running cleanup() here would unsubscribe the new call's

--- a/src/djcova/src/core/dj-cova.ts
+++ b/src/djcova/src/core/dj-cova.ts
@@ -13,6 +13,7 @@ import { IdleManager, createIdleManager, IdleManagerConfig } from '../services/i
 import { getMusicConfig } from '../config/music-config';
 import ffmpegPath from 'ffmpeg-static';
 import { logger } from '../observability/logger';
+import { DJCovaErrorCode } from '../errors';
 
 type AudioPlayerLike = ReturnType<typeof createAudioPlayer>;
 type AudioResourceLike = ReturnType<typeof createAudioResource>;
@@ -68,6 +69,7 @@ export class DJCova {
     } catch (error) {
       logger
         .withError(error instanceof Error ? error : new Error(String(error)))
+        .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_AUDIO_PLAYER_FAILED })
         .error('Failed to create audio player');
       throw error;
     }
@@ -107,12 +109,15 @@ export class DJCova {
     });
 
     this.player.on('error', (error: Error) => {
-      logger.withError(error).error('❌ Audio player error');
+      logger
+        .withError(error)
+        .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_AUDIO_STREAM_ERROR })
+        .error('Audio player error');
       logger.debug('Triggering cleanup due to player error');
       this.notificationCallback?.(`❌ Playback error: ${error.message}`).catch(err => {
         logger
           .withError(err instanceof Error ? err : new Error(String(err)))
-          .warn('⚠️ Failed to send error notification to user');
+          .warn('Failed to send error notification to user');
       });
       this.cleanup();
     });
@@ -174,11 +179,12 @@ export class DJCova {
       logger
         .withError(err)
         .withMetadata({
+          error_code: DJCovaErrorCode.DJCOVA_AUDIO_STREAM_ERROR,
           stack: err.stack,
           url,
           ytdlpProcessPid: this.ytdlpProcess?.pid,
         })
-        .error('❌ Failed to play audio');
+        .error('Failed to start audio playback');
       // Only run full cleanup if this play() call is still the active one.
       // If a concurrent play() has already called stopAudioOnly() and replaced
       // ytdlpProcess, running cleanup() here would unsubscribe the new call's

--- a/src/djcova/src/core/dj-cova.ts
+++ b/src/djcova/src/core/dj-cova.ts
@@ -15,6 +15,7 @@ import ffmpegPath from 'ffmpeg-static';
 import { logger } from '../observability/logger';
 import { DJCovaErrorCode } from '../errors';
 import { logError } from '@starbunk/shared/errors';
+import { getDJCovaMetrics } from '../observability/djcova-metrics';
 
 type AudioPlayerLike = ReturnType<typeof createAudioPlayer>;
 type AudioResourceLike = ReturnType<typeof createAudioResource>;
@@ -28,6 +29,7 @@ type PlayerSubscriptionLike = ReturnType<VoiceConnectionLike['subscribe']>;
 export class DJCova {
   private readonly player: AudioPlayerLike;
   private currentResource: AudioResourceLike | undefined;
+  private guildId: string | null = null;
 
   /**
    * Backwards-compatible alias for the old `resource` property name.
@@ -105,6 +107,11 @@ export class DJCova {
       }
       logger.debug('Resetting idle timer due to playback start');
       this.idleManager?.resetIdleTimer();
+      // Record the metric here — at this point Discord Voice has actually started
+      // consuming audio frames, not just when player.play() was called.
+      if (this.guildId) {
+        getDJCovaMetrics().trackAudioPlaybackStarted(this.guildId);
+      }
     });
 
     this.player.on(AudioPlayerStatus.Idle, () => {
@@ -199,7 +206,7 @@ export class DJCova {
       } else {
         logger.debug('Skipping cleanup — concurrent play() call has taken over');
       }
-      throw err;
+      throw error;
     }
   }
 
@@ -278,6 +285,7 @@ export class DJCova {
     notificationCallback?: (message: string) => Promise<void>,
   ): void {
     logger.debug(`Initializing idle management for guild ${guildId}, channel ${channelId}`);
+    this.guildId = guildId;
 
     if (this.idleManager) {
       logger.debug(`Destroying existing idle manager for guild ${guildId}`);

--- a/src/djcova/src/errors/codes.ts
+++ b/src/djcova/src/errors/codes.ts
@@ -1,0 +1,29 @@
+/**
+ * DJCova error codes
+ *
+ * All codes are prefixed with DJCOVA_ to make them unambiguous in logs and
+ * Prometheus label values when mixed with codes from other containers.
+ */
+export const DJCovaErrorCode = {
+  // yt-dlp / media extraction
+  DJCOVA_YTDLP_NOT_FOUND: 'DJCOVA_YTDLP_NOT_FOUND',
+  DJCOVA_YTDLP_SPAWN_FAILED: 'DJCOVA_YTDLP_SPAWN_FAILED',
+  DJCOVA_YTDLP_CONTENT_ERROR: 'DJCOVA_YTDLP_CONTENT_ERROR',
+  DJCOVA_YTDLP_TIMEOUT: 'DJCOVA_YTDLP_TIMEOUT',
+  DJCOVA_YTDLP_EXIT_ERROR: 'DJCOVA_YTDLP_EXIT_ERROR',
+
+  // Audio player / stream
+  DJCOVA_AUDIO_PLAYER_FAILED: 'DJCOVA_AUDIO_PLAYER_FAILED',
+  DJCOVA_AUDIO_STREAM_ERROR: 'DJCOVA_AUDIO_STREAM_ERROR',
+
+  // Voice connection
+  DJCOVA_VOICE_JOIN_FAILED: 'DJCOVA_VOICE_JOIN_FAILED',
+  DJCOVA_VOICE_CONNECTION_LOST: 'DJCOVA_VOICE_CONNECTION_LOST',
+  DJCOVA_VOICE_RECONNECT_FAILED: 'DJCOVA_VOICE_RECONNECT_FAILED',
+
+  // Command / input
+  DJCOVA_INVALID_URL: 'DJCOVA_INVALID_URL',
+  DJCOVA_QUEUE_EMPTY: 'DJCOVA_QUEUE_EMPTY',
+} as const;
+
+export type DJCovaErrorCode = (typeof DJCovaErrorCode)[keyof typeof DJCovaErrorCode];

--- a/src/djcova/src/errors/codes.ts
+++ b/src/djcova/src/errors/codes.ts
@@ -24,6 +24,7 @@ export const DJCovaErrorCode = {
   // Command / input
   DJCOVA_INVALID_URL: 'DJCOVA_INVALID_URL',
   DJCOVA_QUEUE_EMPTY: 'DJCOVA_QUEUE_EMPTY',
+  DJCOVA_PLAY_COMMAND_FAILED: 'DJCOVA_PLAY_COMMAND_FAILED',
 } as const;
 
 export type DJCovaErrorCode = (typeof DJCovaErrorCode)[keyof typeof DJCovaErrorCode];

--- a/src/djcova/src/errors/index.ts
+++ b/src/djcova/src/errors/index.ts
@@ -1,0 +1,2 @@
+export { DJCovaErrorCode } from './codes';
+export type { DJCovaErrorCode as DJCovaErrorCodeType } from './codes';

--- a/src/djcova/src/index.ts
+++ b/src/djcova/src/index.ts
@@ -7,10 +7,19 @@ import { Client, Events, GatewayIntentBits } from 'discord.js';
 import { initializeHealthServer } from '@starbunk/shared/health/health-server-init';
 import { shutdownObservability } from '@starbunk/shared/observability/shutdown';
 import { initializeCommands } from '@starbunk/shared/discord/command-registry';
+import { getMetricsService } from '@starbunk/shared/observability/metrics-service';
+import { getDJCovaMetrics } from './observability/djcova-metrics';
 import { commands } from '@/commands';
 
 // Setup logging mixins before creating any logger instances
 setupDJCovaLogging();
+
+// Initialize MetricsService with the DJCova service name before anything else
+// creates the singleton with the wrong name (health server calls getMetricsService()
+// internally). DJCovaMetrics will share this same registry.
+const serviceName = process.env.SERVICE_NAME || 'djcova';
+getMetricsService(serviceName);
+getDJCovaMetrics();
 // Main execution
 async function main(): Promise<void> {
   logger.info('DJCova main() function starting...');

--- a/src/djcova/src/index.ts
+++ b/src/djcova/src/index.ts
@@ -9,6 +9,7 @@ import { shutdownObservability } from '@starbunk/shared/observability/shutdown';
 import { initializeCommands } from '@starbunk/shared/discord/command-registry';
 import { getMetricsService } from '@starbunk/shared/observability/metrics-service';
 import { getDJCovaMetrics } from './observability/djcova-metrics';
+import { SharedErrorCode } from '@starbunk/shared/errors';
 import { commands } from '@/commands';
 
 // Setup logging mixins before creating any logger instances
@@ -34,7 +35,10 @@ async function main(): Promise<void> {
   const token = process.env.DISCORD_TOKEN;
   if (!token) {
     const error = new Error('DISCORD_TOKEN environment variable is required');
-    logger.withError(error).error('DISCORD_TOKEN not found - aborting startup');
+    logger
+      .withError(error)
+      .withMetadata({ error_code: SharedErrorCode.CONFIG_MISSING, config_key: 'DISCORD_TOKEN' })
+      .error('DISCORD_TOKEN not found - aborting startup');
     throw error;
   }
   logger.debug('DISCORD_TOKEN found (length: ' + token.length + ' chars)');
@@ -47,6 +51,7 @@ async function main(): Promise<void> {
   } catch (error) {
     logger
       .withError(error instanceof Error ? error : new Error(String(error)))
+      .withMetadata({ error_code: SharedErrorCode.UNKNOWN })
       .error('Failed to initialize health server');
     throw error;
   }
@@ -77,7 +82,7 @@ async function main(): Promise<void> {
     const err = error instanceof Error ? error : new Error(String(error));
     logger
       .withError(err)
-      .withMetadata({ stack: err.stack })
+      .withMetadata({ error_code: SharedErrorCode.DISCORD_API_ERROR, stack: err.stack })
       .error('Failed to initialize Discord client or commands');
     throw err;
   }

--- a/src/djcova/src/index.ts
+++ b/src/djcova/src/index.ts
@@ -2,14 +2,13 @@
 import { runSmokeMode } from '@starbunk/shared/health/smoke-mode';
 import { setupDJCovaLogging } from './observability/setup-logging';
 import { logger } from './observability/logger';
-import { ensureError } from './utils';
 import { Client, Events, GatewayIntentBits } from 'discord.js';
 import { initializeHealthServer } from '@starbunk/shared/health/health-server-init';
 import { shutdownObservability } from '@starbunk/shared/observability/shutdown';
 import { initializeCommands } from '@starbunk/shared/discord/command-registry';
 import { getMetricsService } from '@starbunk/shared/observability/metrics-service';
 import { getDJCovaMetrics } from './observability/djcova-metrics';
-import { SharedErrorCode } from '@starbunk/shared/errors';
+import { SharedErrorCode, logError } from '@starbunk/shared/errors';
 import { commands } from '@/commands';
 
 // Setup logging mixins before creating any logger instances
@@ -35,10 +34,9 @@ async function main(): Promise<void> {
   const token = process.env.DISCORD_TOKEN;
   if (!token) {
     const error = new Error('DISCORD_TOKEN environment variable is required');
-    logger
-      .withError(error)
-      .withMetadata({ error_code: SharedErrorCode.CONFIG_MISSING, config_key: 'DISCORD_TOKEN' })
-      .error('DISCORD_TOKEN not found - aborting startup');
+    logError(logger, SharedErrorCode.CONFIG_MISSING, 'DISCORD_TOKEN not found - aborting startup', {
+      config_key: 'DISCORD_TOKEN',
+    });
     throw error;
   }
   logger.debug('DISCORD_TOKEN found (length: ' + token.length + ' chars)');
@@ -49,10 +47,9 @@ async function main(): Promise<void> {
     globalHealthServer = await initializeHealthServer();
     logger.info('✅ Health/metrics server started');
   } catch (error) {
-    logger
-      .withError(error instanceof Error ? error : new Error(String(error)))
-      .withMetadata({ error_code: SharedErrorCode.UNKNOWN })
-      .error('Failed to initialize health server');
+    logError(logger, SharedErrorCode.UNKNOWN, 'Failed to initialize health server', {
+      cause: error,
+    });
     throw error;
   }
 
@@ -79,12 +76,15 @@ async function main(): Promise<void> {
     await initializeCommands(client, commands);
     logger.info('✅ DJCova commands initialized successfully');
   } catch (error) {
-    const err = error instanceof Error ? error : new Error(String(error));
-    logger
-      .withError(err)
-      .withMetadata({ error_code: SharedErrorCode.DISCORD_API_ERROR, stack: err.stack })
-      .error('Failed to initialize Discord client or commands');
-    throw err;
+    logError(
+      logger,
+      SharedErrorCode.DISCORD_API_ERROR,
+      'Failed to initialize Discord client or commands',
+      {
+        cause: error,
+      },
+    );
+    throw error instanceof Error ? error : new Error(String(error));
   }
 }
 
@@ -107,34 +107,25 @@ process.on('SIGTERM', async () => {
 
 // Global error handlers to properly log unhandled errors with structured logging
 process.on('uncaughtException', (error: Error) => {
-  logger
-    .withError(error)
-    .withMetadata({
-      stack: error.stack,
-    })
-    .error('Uncaught exception - process will exit');
+  logError(logger, SharedErrorCode.UNKNOWN, 'Uncaught exception - process will exit', {
+    cause: error,
+  });
   process.exit(1);
 });
 
 process.on('unhandledRejection', (reason: unknown) => {
-  const error = ensureError(reason);
-  logger
-    .withError(error)
-    .withMetadata({
-      reason: String(reason),
-    })
-    .error('Unhandled promise rejection - process will exit');
+  logError(logger, SharedErrorCode.UNKNOWN, 'Unhandled promise rejection - process will exit', {
+    cause: reason,
+    reason: String(reason),
+  });
   process.exit(1);
 });
 
 if (require.main === module) {
   main().catch(error => {
-    logger
-      .withError(ensureError(error))
-      .withMetadata({
-        stack: error.stack,
-      })
-      .error('Fatal error in main - process will exit');
+    logError(logger, SharedErrorCode.UNKNOWN, 'Fatal error in main - process will exit', {
+      cause: error,
+    });
     process.exit(1);
   });
 }

--- a/src/djcova/src/observability/djcova-metrics.ts
+++ b/src/djcova/src/observability/djcova-metrics.ts
@@ -1,0 +1,72 @@
+import * as promClient from 'prom-client';
+import { getMetricsService } from '@starbunk/shared/observability/metrics-service';
+
+/**
+ * DJCova-specific Prometheus metrics.
+ *
+ * Tracks the three-step play funnel so Grafana can immediately show where
+ * the pipeline breaks down:
+ *
+ *   /play invoked → voice channel joined → audio actually streaming
+ *
+ * All counters share the MetricsService registry so they are exposed through
+ * the same /metrics endpoint as the generic bot metrics.
+ */
+export class DJCovaMetrics {
+  private playCommandTotal: promClient.Counter<string>;
+  private voiceJoinTotal: promClient.Counter<string>;
+  private audioPlaybackStartedTotal: promClient.Counter<string>;
+
+  constructor(registry: promClient.Registry) {
+    this.playCommandTotal = new promClient.Counter({
+      name: 'djcova_play_command_total',
+      help: 'Total /play command invocations by outcome',
+      labelNames: ['guild_id', 'status'],
+      registers: [registry],
+    });
+
+    this.voiceJoinTotal = new promClient.Counter({
+      name: 'djcova_voice_join_total',
+      help: 'Total voice channel join attempts by outcome',
+      labelNames: ['guild_id', 'status'],
+      registers: [registry],
+    });
+
+    this.audioPlaybackStartedTotal = new promClient.Counter({
+      name: 'djcova_audio_playback_started_total',
+      help: 'Total times audio playback successfully reached the streaming stage',
+      labelNames: ['guild_id'],
+      registers: [registry],
+    });
+  }
+
+  /** Record a /play command invocation. */
+  trackPlayCommand(guildId: string, status: 'success' | 'error'): void {
+    this.playCommandTotal.inc({ guild_id: guildId, status });
+  }
+
+  /** Record a voice channel join attempt. */
+  trackVoiceJoin(guildId: string, status: 'joined' | 'failed'): void {
+    this.voiceJoinTotal.inc({ guild_id: guildId, status });
+  }
+
+  /** Record that audio actually began streaming (yt-dlp → ffmpeg → Discord). */
+  trackAudioPlaybackStarted(guildId: string): void {
+    this.audioPlaybackStartedTotal.inc({ guild_id: guildId });
+  }
+}
+
+let instance: DJCovaMetrics | undefined;
+
+/**
+ * Returns the singleton DJCovaMetrics instance.
+ * Must be called after getMetricsService() has been initialized with the
+ * correct service name (done in src/djcova/src/index.ts).
+ */
+export function getDJCovaMetrics(): DJCovaMetrics {
+  if (!instance) {
+    const registry = getMetricsService().getRegistry();
+    instance = new DJCovaMetrics(registry);
+  }
+  return instance;
+}

--- a/src/djcova/src/services/connection-health-monitor.ts
+++ b/src/djcova/src/services/connection-health-monitor.ts
@@ -1,5 +1,7 @@
 import { VoiceConnectionStatus } from '@discordjs/voice';
 import { logger } from '../observability/logger';
+import { DJCovaErrorCode } from '../errors';
+import { getMetricsService } from '@starbunk/shared/observability/metrics-service';
 
 /**
  * Interface for voice connection - uses Discord.js connection type
@@ -152,6 +154,7 @@ export class ConnectionHealthMonitor {
   private async triggerReconnect(): Promise<void> {
     try {
       logger.debug(`Auto-reconnecting due to health check for guild: ${this.guildId}`);
+      getMetricsService().trackReconnection('health_monitor');
 
       if (this.connection?.rejoin && typeof this.connection.rejoin === 'function') {
         this.connection.rejoin();
@@ -161,7 +164,11 @@ export class ConnectionHealthMonitor {
     } catch (error) {
       logger
         .withError(error instanceof Error ? error : new Error(String(error)))
-        .debug(`Reconnect attempt failed for guild: ${this.guildId}`);
+        .withMetadata({
+          error_code: DJCovaErrorCode.DJCOVA_VOICE_RECONNECT_FAILED,
+          guild_id: this.guildId,
+        })
+        .warn(`Reconnect attempt failed for guild: ${this.guildId}`);
     }
   }
 
@@ -174,10 +181,22 @@ export class ConnectionHealthMonitor {
       if (this.failureCount >= this.failureThreshold && !this.notificationSent) {
         this.notificationSent = true;
 
-        logger.debug(`Connection health threshold exceeded for guild: ${this.guildId}`, {
-          failureCount: this.failureCount,
-          threshold: this.failureThreshold,
-        } as any);
+        logger
+          .withMetadata({
+            error_code: DJCovaErrorCode.DJCOVA_VOICE_CONNECTION_LOST,
+            guild_id: this.guildId,
+            failure_count: this.failureCount,
+            threshold: this.failureThreshold,
+          })
+          .error(
+            `Voice connection lost for guild: ${this.guildId} (${this.failureCount} consecutive failures)`,
+          );
+
+        getMetricsService().trackBotError(
+          'djcova',
+          DJCovaErrorCode.DJCOVA_VOICE_CONNECTION_LOST,
+          this.guildId,
+        );
 
         if (this.onThresholdExceeded) {
           const message =

--- a/src/djcova/src/services/connection-health-monitor.ts
+++ b/src/djcova/src/services/connection-health-monitor.ts
@@ -2,6 +2,7 @@ import { VoiceConnectionStatus } from '@discordjs/voice';
 import { logger } from '../observability/logger';
 import { DJCovaErrorCode } from '../errors';
 import { getMetricsService } from '@starbunk/shared/observability/metrics-service';
+import { logError } from '@starbunk/shared/errors';
 
 /**
  * Interface for voice connection - uses Discord.js connection type
@@ -181,16 +182,16 @@ export class ConnectionHealthMonitor {
       if (this.failureCount >= this.failureThreshold && !this.notificationSent) {
         this.notificationSent = true;
 
-        logger
-          .withMetadata({
-            error_code: DJCovaErrorCode.DJCOVA_VOICE_CONNECTION_LOST,
+        logError(
+          logger,
+          DJCovaErrorCode.DJCOVA_VOICE_CONNECTION_LOST,
+          `Voice connection lost for guild: ${this.guildId} (${this.failureCount} consecutive failures)`,
+          {
             guild_id: this.guildId,
             failure_count: this.failureCount,
             threshold: this.failureThreshold,
-          })
-          .error(
-            `Voice connection lost for guild: ${this.guildId} (${this.failureCount} consecutive failures)`,
-          );
+          },
+        );
 
         getMetricsService().trackBotError(
           'djcova',

--- a/src/djcova/src/services/dj-cova-service.ts
+++ b/src/djcova/src/services/dj-cova-service.ts
@@ -7,6 +7,9 @@ import {
   disconnectVoiceConnection,
 } from '../utils/voice-utils';
 import { logger } from '../observability/logger';
+import { getDJCovaMetrics } from '../observability/djcova-metrics';
+import { DJCovaErrorCode } from '../errors';
+import { getMetricsService } from '@starbunk/shared/observability/metrics-service';
 
 /**
  * DJCovaService - Business logic layer
@@ -23,8 +26,9 @@ export class DJCovaService {
    * Play a YouTube URL in a voice channel
    */
   async play(interaction: ChatInputCommandInteraction, url: string): Promise<void> {
+    const guildId = interaction.guild?.id ?? 'unknown';
     logger.info(`Play request received for URL: ${url}`);
-    logger.debug(`Guild: ${interaction.guild?.id}, Channel: ${interaction.channelId}`);
+    logger.debug(`Guild: ${guildId}, Channel: ${interaction.channelId}`);
 
     // Validate voice channel access
     logger.debug('Validating voice channel access...');
@@ -48,9 +52,10 @@ export class DJCovaService {
     // Validate YouTube URL
     logger.debug('Validating YouTube URL...');
     if (!this.isValidYouTubeUrl(url)) {
-      const errorMsg = 'Please provide a valid YouTube URL (youtube.com or youtu.be)';
-      logger.warn(`URL validation failed: ${url}`);
-      throw new Error(errorMsg);
+      logger
+        .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_INVALID_URL, url, guild_id: guildId })
+        .warn('Invalid YouTube URL provided');
+      throw new Error('Please provide a valid YouTube URL (youtube.com or youtu.be)');
     }
     logger.debug('✅ YouTube URL validation passed');
 
@@ -63,10 +68,18 @@ export class DJCovaService {
     logger.debug('Subscribing player to connection...');
     const subscription = await subscribePlayerToConnection(connection, this.djCova.getPlayer());
     if (!subscription) {
-      const errorMsg = 'Failed to connect audio player to voice channel';
-      logger.error(errorMsg);
-      throw new Error(errorMsg);
+      logger
+        .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_VOICE_JOIN_FAILED, guild_id: guildId })
+        .error('Failed to connect audio player to voice channel');
+      getDJCovaMetrics().trackVoiceJoin(guildId, 'failed');
+      getMetricsService().trackBotError(
+        'djcova',
+        DJCovaErrorCode.DJCOVA_VOICE_JOIN_FAILED,
+        guildId,
+      );
+      throw new Error('Failed to connect audio player to voice channel');
     }
+    getDJCovaMetrics().trackVoiceJoin(guildId, 'joined');
     logger.debug('✅ Player subscribed to connection');
 
     if (!interaction.guild) {
@@ -102,6 +115,7 @@ export class DJCovaService {
     this.djCova.setSubscription(subscription);
     logger.info('Starting playback...');
     await this.djCova.play(url);
+    getDJCovaMetrics().trackAudioPlaybackStarted(guildId);
     logger.info('✅ Playback started successfully');
   }
 

--- a/src/djcova/src/services/dj-cova-service.ts
+++ b/src/djcova/src/services/dj-cova-service.ts
@@ -121,7 +121,6 @@ export class DJCovaService {
     this.djCova.setSubscription(subscription);
     logger.info('Starting playback...');
     await this.djCova.play(url);
-    getDJCovaMetrics().trackAudioPlaybackStarted(guildId);
     logger.info('✅ Playback started successfully');
   }
 

--- a/src/djcova/src/services/dj-cova-service.ts
+++ b/src/djcova/src/services/dj-cova-service.ts
@@ -10,6 +10,7 @@ import { logger } from '../observability/logger';
 import { getDJCovaMetrics } from '../observability/djcova-metrics';
 import { DJCovaErrorCode } from '../errors';
 import { getMetricsService } from '@starbunk/shared/observability/metrics-service';
+import { logError } from '@starbunk/shared/errors';
 
 /**
  * DJCovaService - Business logic layer
@@ -68,9 +69,14 @@ export class DJCovaService {
     logger.debug('Subscribing player to connection...');
     const subscription = await subscribePlayerToConnection(connection, this.djCova.getPlayer());
     if (!subscription) {
-      logger
-        .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_VOICE_JOIN_FAILED, guild_id: guildId })
-        .error('Failed to connect audio player to voice channel');
+      logError(
+        logger,
+        DJCovaErrorCode.DJCOVA_VOICE_JOIN_FAILED,
+        'Failed to connect audio player to voice channel',
+        {
+          guild_id: guildId,
+        },
+      );
       getDJCovaMetrics().trackVoiceJoin(guildId, 'failed');
       getMetricsService().trackBotError(
         'djcova',

--- a/src/djcova/src/services/idle-manager.ts
+++ b/src/djcova/src/services/idle-manager.ts
@@ -1,6 +1,7 @@
 // Idle Manager Service for DJCova auto-disconnect functionality
 import { disconnectVoiceConnection } from '../utils/voice-utils';
 import { logger } from '../observability/logger';
+import { SharedErrorCode, logError } from '@starbunk/shared/errors';
 
 export interface IdleManagerConfig {
   timeoutSeconds: number;
@@ -115,9 +116,10 @@ export class IdleManager {
         `Successfully disconnected from voice channel in guild ${this.config.guildId} due to inactivity`,
       );
     } catch (error) {
-      logger
-        .withError(error instanceof Error ? error : new Error(String(error)))
-        .error('Error handling idle timeout');
+      logError(logger, SharedErrorCode.UNKNOWN, 'Error handling idle timeout', {
+        cause: error,
+        guild_id: this.config.guildId,
+      });
 
       // Still clean up timer state even if disconnect failed
       this.timer = null;

--- a/src/djcova/src/utils/discord-utils.ts
+++ b/src/djcova/src/utils/discord-utils.ts
@@ -1,6 +1,7 @@
 // Discord utilities for DJCova
 import { CommandInteraction, ChatInputCommandInteraction } from 'discord.js';
 import { logger } from '../observability/logger';
+import { SharedErrorCode } from '@starbunk/shared/errors';
 
 // Type alias for any command interaction type
 type AnyCommandInteraction = CommandInteraction | ChatInputCommandInteraction;
@@ -21,6 +22,7 @@ export async function sendErrorResponse(
   } catch (error) {
     logger
       .withError(error instanceof Error ? error : new Error(String(error)))
+      .withMetadata({ error_code: SharedErrorCode.DISCORD_API_ERROR })
       .error('Failed to send error response');
   }
 }
@@ -41,6 +43,7 @@ export async function sendSuccessResponse(
   } catch (error) {
     logger
       .withError(error instanceof Error ? error : new Error(String(error)))
+      .withMetadata({ error_code: SharedErrorCode.DISCORD_API_ERROR })
       .error('Failed to send success response');
   }
 }

--- a/src/djcova/src/utils/discord-utils.ts
+++ b/src/djcova/src/utils/discord-utils.ts
@@ -1,7 +1,7 @@
 // Discord utilities for DJCova
 import { CommandInteraction, ChatInputCommandInteraction } from 'discord.js';
 import { logger } from '../observability/logger';
-import { SharedErrorCode } from '@starbunk/shared/errors';
+import { SharedErrorCode, logError } from '@starbunk/shared/errors';
 
 // Type alias for any command interaction type
 type AnyCommandInteraction = CommandInteraction | ChatInputCommandInteraction;
@@ -20,10 +20,9 @@ export async function sendErrorResponse(
       await interaction.reply({ content: `❌ ${message}`, ephemeral: true });
     }
   } catch (error) {
-    logger
-      .withError(error instanceof Error ? error : new Error(String(error)))
-      .withMetadata({ error_code: SharedErrorCode.DISCORD_API_ERROR })
-      .error('Failed to send error response');
+    logError(logger, SharedErrorCode.DISCORD_API_ERROR, 'Failed to send error response', {
+      cause: error,
+    });
   }
 }
 
@@ -41,9 +40,8 @@ export async function sendSuccessResponse(
       await interaction.reply({ content: `✅ ${message}`, ephemeral: false });
     }
   } catch (error) {
-    logger
-      .withError(error instanceof Error ? error : new Error(String(error)))
-      .withMetadata({ error_code: SharedErrorCode.DISCORD_API_ERROR })
-      .error('Failed to send success response');
+    logError(logger, SharedErrorCode.DISCORD_API_ERROR, 'Failed to send success response', {
+      cause: error,
+    });
   }
 }

--- a/src/djcova/src/utils/voice-utils.ts
+++ b/src/djcova/src/utils/voice-utils.ts
@@ -21,6 +21,7 @@ import { getVoiceConnection, VoiceConnectionStatus, entersState } from '@discord
 import { logger } from '../observability/logger';
 import { getMusicConfig } from '../config/music-config';
 import { DJCovaErrorCode } from '../errors';
+import { logError } from '@starbunk/shared/errors';
 import {
   ConnectionHealthMonitor,
   ConnectionHealthMonitorConfig,
@@ -127,15 +128,17 @@ export function createVoiceConnection(
   });
 
   connection.on('error', (error: Error) => {
-    logger
-      .withError(error)
-      .withMetadata({
-        error_code: DJCovaErrorCode.DJCOVA_VOICE_CONNECTION_LOST,
+    logError(
+      logger,
+      DJCovaErrorCode.DJCOVA_VOICE_CONNECTION_LOST,
+      'Voice connection error in channel',
+      {
+        cause: error,
         channel_name: channel.name,
         channel_id: channel.id,
         guild_id: channel.guild.id,
-      })
-      .error('Voice connection error in channel');
+      },
+    );
   });
 
   connection.on('stateChange', (oldState: { status: string }, newState: { status: string }) => {
@@ -167,13 +170,15 @@ export function disconnectVoiceConnection(guildId: string): void {
       connection.destroy();
       logger.debug(`Voice connection destroyed for guild: ${guildId}`);
     } catch (error) {
-      logger
-        .withError(error instanceof Error ? error : new Error(String(error)))
-        .withMetadata({
-          error_code: DJCovaErrorCode.DJCOVA_VOICE_CONNECTION_LOST,
+      logError(
+        logger,
+        DJCovaErrorCode.DJCOVA_VOICE_CONNECTION_LOST,
+        'Error destroying voice connection',
+        {
+          cause: error,
           guild_id: guildId,
-        })
-        .error('Error destroying voice connection');
+        },
+      );
     }
   }
 }
@@ -197,10 +202,14 @@ export async function subscribePlayerToConnection(
     }
     return subscription;
   } catch (error) {
-    logger
-      .withError(error instanceof Error ? error : new Error(String(error)))
-      .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_VOICE_JOIN_FAILED })
-      .error('Error subscribing player to connection');
+    logError(
+      logger,
+      DJCovaErrorCode.DJCOVA_VOICE_JOIN_FAILED,
+      'Error subscribing player to connection',
+      {
+        cause: error,
+      },
+    );
     return undefined;
   }
 }
@@ -362,18 +371,20 @@ export async function waitForConnectionReady(
     } else {
       errorType = 'error';
       errorMessage = `Voice connection failed: ${typedError.message}`;
-      logger
-        .withError(typedError)
-        .withMetadata({
-          error_code: DJCovaErrorCode.DJCOVA_VOICE_JOIN_FAILED,
+      logError(
+        logger,
+        DJCovaErrorCode.DJCOVA_VOICE_JOIN_FAILED,
+        'Voice connection error while waiting for Ready state',
+        {
+          cause: typedError,
           connection_id: connectionId,
           wait_duration_ms: elapsed,
           timeout_ms: timeoutMs,
           final_state: connection.state.status,
           error_type: errorType,
           trace_id: connectionId,
-        })
-        .error('Voice connection error while waiting for Ready state');
+        },
+      );
     }
 
     span.setAttributes({

--- a/src/djcova/src/utils/voice-utils.ts
+++ b/src/djcova/src/utils/voice-utils.ts
@@ -20,6 +20,7 @@ type InteractionLike = { member?: unknown; guild?: { id: string } | null; channe
 import { getVoiceConnection, VoiceConnectionStatus, entersState } from '@discordjs/voice';
 import { logger } from '../observability/logger';
 import { getMusicConfig } from '../config/music-config';
+import { DJCovaErrorCode } from '../errors';
 import {
   ConnectionHealthMonitor,
   ConnectionHealthMonitorConfig,
@@ -70,7 +71,7 @@ export function createVoiceConnection(
     try {
       logger.debug('Destroying existing connection...');
       existingConnection.destroy();
-      logger.debug('✅ Existing connection destroyed');
+      logger.debug('Existing connection destroyed');
     } catch (error) {
       logger
         .withError(error instanceof Error ? error : new Error(String(error)))
@@ -129,11 +130,12 @@ export function createVoiceConnection(
     logger
       .withError(error)
       .withMetadata({
+        error_code: DJCovaErrorCode.DJCOVA_VOICE_CONNECTION_LOST,
         channel_name: channel.name,
         channel_id: channel.id,
         guild_id: channel.guild.id,
       })
-      .error('❌ Voice connection error in channel');
+      .error('Voice connection error in channel');
   });
 
   connection.on('stateChange', (oldState: { status: string }, newState: { status: string }) => {
@@ -167,6 +169,10 @@ export function disconnectVoiceConnection(guildId: string): void {
     } catch (error) {
       logger
         .withError(error instanceof Error ? error : new Error(String(error)))
+        .withMetadata({
+          error_code: DJCovaErrorCode.DJCOVA_VOICE_CONNECTION_LOST,
+          guild_id: guildId,
+        })
         .error('Error destroying voice connection');
     }
   }
@@ -193,7 +199,8 @@ export async function subscribePlayerToConnection(
   } catch (error) {
     logger
       .withError(error instanceof Error ? error : new Error(String(error)))
-      .error('❌ Error subscribing player to connection');
+      .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_VOICE_JOIN_FAILED })
+      .error('Error subscribing player to connection');
     return undefined;
   }
 }
@@ -358,6 +365,7 @@ export async function waitForConnectionReady(
       logger
         .withError(typedError)
         .withMetadata({
+          error_code: DJCovaErrorCode.DJCOVA_VOICE_JOIN_FAILED,
           connection_id: connectionId,
           wait_duration_ms: elapsed,
           timeout_ms: timeoutMs,
@@ -365,7 +373,7 @@ export async function waitForConnectionReady(
           error_type: errorType,
           trace_id: connectionId,
         })
-        .error('❌ Voice connection error while waiting for Ready state');
+        .error('Voice connection error while waiting for Ready state');
     }
 
     span.setAttributes({

--- a/src/djcova/src/utils/ytdlp.ts
+++ b/src/djcova/src/utils/ytdlp.ts
@@ -147,7 +147,10 @@ export function getYouTubeAudioStream(url: string): {
 
   // Propagate stdout errors for better diagnostics
   (ytdlpProcess.stdout as Readable).on('error', (e: Error) => {
-    logger.withError(e).error('yt-dlp stdout error');
+    logger
+      .withError(e)
+      .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_AUDIO_STREAM_ERROR, url })
+      .error('yt-dlp stdout error');
   });
 
   // Track when data starts flowing

--- a/src/djcova/src/utils/ytdlp.ts
+++ b/src/djcova/src/utils/ytdlp.ts
@@ -9,6 +9,7 @@ import { homedir } from 'os';
 import { join } from 'path';
 import { logger } from '../observability/logger';
 import { DJCovaErrorCode } from '../errors';
+import { logError } from '@starbunk/shared/errors';
 
 /**
  * Find yt-dlp binary path
@@ -77,9 +78,12 @@ export function getYouTubeAudioStream(url: string): {
   });
 
   if (!ytdlpProcess.pid) {
-    logger
-      .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_YTDLP_SPAWN_FAILED, url })
-      .error('yt-dlp process failed to spawn (no PID assigned)');
+    logError(
+      logger,
+      DJCovaErrorCode.DJCOVA_YTDLP_SPAWN_FAILED,
+      'yt-dlp process failed to spawn (no PID assigned)',
+      { url },
+    );
   } else {
     logger.debug(`yt-dlp process spawned successfully with PID: ${ytdlpProcess.pid}`);
   }
@@ -100,10 +104,10 @@ export function getYouTubeAudioStream(url: string): {
 
   // Handle process spawn errors
   ytdlpProcess.on('error', (error: Error) => {
-    logger
-      .withError(error)
-      .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_YTDLP_SPAWN_FAILED, url })
-      .error('yt-dlp process spawn error');
+    logError(logger, DJCovaErrorCode.DJCOVA_YTDLP_SPAWN_FAILED, 'yt-dlp process spawn error', {
+      cause: error,
+      url,
+    });
     stream.destroy(error);
   });
 
@@ -131,14 +135,16 @@ export function getYouTubeAudioStream(url: string): {
         stderrOutput ||
         `yt-dlp process terminated unexpectedly (code=${code ?? 'null'}, signal=${signal ?? 'none'})`
       ).slice(0, 1000);
-      logger
-        .withMetadata({
-          error_code: DJCovaErrorCode.DJCOVA_YTDLP_EXIT_ERROR,
+      logError(
+        logger,
+        DJCovaErrorCode.DJCOVA_YTDLP_EXIT_ERROR,
+        `yt-dlp terminated unexpectedly: ${errorMessage}`,
+        {
           url,
           exit_code: code,
           signal,
-        })
-        .error(`yt-dlp terminated unexpectedly: ${errorMessage}`);
+        },
+      );
       // Destroy the stream regardless of whether data was already emitted —
       // a partial stream produces silence rather than a user-visible error.
       stream.destroy(new Error(errorMessage));
@@ -147,10 +153,10 @@ export function getYouTubeAudioStream(url: string): {
 
   // Propagate stdout errors for better diagnostics
   (ytdlpProcess.stdout as Readable).on('error', (e: Error) => {
-    logger
-      .withError(e)
-      .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_AUDIO_STREAM_ERROR, url })
-      .error('yt-dlp stdout error');
+    logError(logger, DJCovaErrorCode.DJCOVA_AUDIO_STREAM_ERROR, 'yt-dlp stdout error', {
+      cause: e,
+      url,
+    });
   });
 
   // Track when data starts flowing
@@ -184,13 +190,15 @@ export async function getVideoInfo(url: string): Promise<{
       try {
         ytdlpProcess.kill('SIGKILL');
       } catch {}
-      logger
-        .withMetadata({
-          error_code: DJCovaErrorCode.DJCOVA_YTDLP_TIMEOUT,
+      logError(
+        logger,
+        DJCovaErrorCode.DJCOVA_YTDLP_TIMEOUT,
+        `yt-dlp info timed out after ${timeoutMs}ms`,
+        {
           url,
           timeout_ms: timeoutMs,
-        })
-        .error(`yt-dlp info timed out after ${timeoutMs}ms`);
+        },
+      );
       reject(new Error(`yt-dlp info timeout after ${timeoutMs}ms`));
     }, timeoutMs);
 
@@ -206,10 +214,10 @@ export async function getVideoInfo(url: string): Promise<{
 
     ytdlpProcess.on('error', (error: Error) => {
       clearTimeout(timer);
-      logger
-        .withError(error)
-        .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_YTDLP_SPAWN_FAILED, url })
-        .error('Failed to get video info');
+      logError(logger, DJCovaErrorCode.DJCOVA_YTDLP_SPAWN_FAILED, 'Failed to get video info', {
+        cause: error,
+        url,
+      });
       reject(error);
     });
 
@@ -228,10 +236,12 @@ export async function getVideoInfo(url: string): Promise<{
         });
       } catch (error) {
         const parseError = error instanceof Error ? error : new Error(String(error));
-        logger
-          .withError(parseError)
-          .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_YTDLP_CONTENT_ERROR, url })
-          .error('Failed to parse yt-dlp JSON output');
+        logError(
+          logger,
+          DJCovaErrorCode.DJCOVA_YTDLP_CONTENT_ERROR,
+          'Failed to parse yt-dlp JSON output',
+          { cause: parseError, url },
+        );
         reject(parseError);
       }
     });

--- a/src/djcova/src/utils/ytdlp.ts
+++ b/src/djcova/src/utils/ytdlp.ts
@@ -8,6 +8,7 @@ import { existsSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
 import { logger } from '../observability/logger';
+import { DJCovaErrorCode } from '../errors';
 
 /**
  * Find yt-dlp binary path
@@ -76,7 +77,9 @@ export function getYouTubeAudioStream(url: string): {
   });
 
   if (!ytdlpProcess.pid) {
-    logger.error('yt-dlp process failed to spawn (no PID assigned)');
+    logger
+      .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_YTDLP_SPAWN_FAILED, url })
+      .error('yt-dlp process failed to spawn (no PID assigned)');
   } else {
     logger.debug(`yt-dlp process spawned successfully with PID: ${ytdlpProcess.pid}`);
   }
@@ -97,7 +100,10 @@ export function getYouTubeAudioStream(url: string): {
 
   // Handle process spawn errors
   ytdlpProcess.on('error', (error: Error) => {
-    logger.withError(error).error('yt-dlp process spawn error');
+    logger
+      .withError(error)
+      .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_YTDLP_SPAWN_FAILED, url })
+      .error('yt-dlp process spawn error');
     stream.destroy(error);
   });
 
@@ -125,7 +131,14 @@ export function getYouTubeAudioStream(url: string): {
         stderrOutput ||
         `yt-dlp process terminated unexpectedly (code=${code ?? 'null'}, signal=${signal ?? 'none'})`
       ).slice(0, 1000);
-      logger.error(`yt-dlp terminated unexpectedly: ${errorMessage}`);
+      logger
+        .withMetadata({
+          error_code: DJCovaErrorCode.DJCOVA_YTDLP_EXIT_ERROR,
+          url,
+          exit_code: code,
+          signal,
+        })
+        .error(`yt-dlp terminated unexpectedly: ${errorMessage}`);
       // Destroy the stream regardless of whether data was already emitted —
       // a partial stream produces silence rather than a user-visible error.
       stream.destroy(new Error(errorMessage));
@@ -168,6 +181,13 @@ export async function getVideoInfo(url: string): Promise<{
       try {
         ytdlpProcess.kill('SIGKILL');
       } catch {}
+      logger
+        .withMetadata({
+          error_code: DJCovaErrorCode.DJCOVA_YTDLP_TIMEOUT,
+          url,
+          timeout_ms: timeoutMs,
+        })
+        .error(`yt-dlp info timed out after ${timeoutMs}ms`);
       reject(new Error(`yt-dlp info timeout after ${timeoutMs}ms`));
     }, timeoutMs);
 
@@ -183,7 +203,10 @@ export async function getVideoInfo(url: string): Promise<{
 
     ytdlpProcess.on('error', (error: Error) => {
       clearTimeout(timer);
-      logger.withError(error).error('Failed to get video info');
+      logger
+        .withError(error)
+        .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_YTDLP_SPAWN_FAILED, url })
+        .error('Failed to get video info');
       reject(error);
     });
 
@@ -202,7 +225,10 @@ export async function getVideoInfo(url: string): Promise<{
         });
       } catch (error) {
         const parseError = error instanceof Error ? error : new Error(String(error));
-        logger.withError(parseError).error('Failed to parse yt-dlp JSON output');
+        logger
+          .withError(parseError)
+          .withMetadata({ error_code: DJCovaErrorCode.DJCOVA_YTDLP_CONTENT_ERROR, url })
+          .error('Failed to parse yt-dlp JSON output');
         reject(parseError);
       }
     });

--- a/src/djcova/tests/djcova-idle.test.ts
+++ b/src/djcova/tests/djcova-idle.test.ts
@@ -8,27 +8,28 @@ import { DJCova } from '../src/core/dj-cova';
 
 // Mock dependencies
 vi.mock('../src/observability/logger', () => ({
-	logger: {
-		debug: vi.fn(),
-		info: vi.fn(),
-		warn: vi.fn(),
-		error: vi.fn(),
-		withError: vi.fn().mockReturnThis(),
-	},
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withError: vi.fn().mockReturnThis(),
+    withMetadata: vi.fn().mockReturnThis(),
+  },
 }));
 
 vi.mock('../src/utils/voice-utils', () => ({
-	disconnectVoiceConnection: vi.fn(),
+  disconnectVoiceConnection: vi.fn(),
 }));
 
 vi.mock('../src/config/music-config', () => ({
-	getMusicConfig: vi.fn().mockReturnValue({
-		idleTimeoutSeconds: 2, // Short timeout for testing
-	}),
+  getMusicConfig: vi.fn().mockReturnValue({
+    idleTimeoutSeconds: 2, // Short timeout for testing
+  }),
 }));
 
 vi.mock('../src/utils/ytdlp', () => ({
-	getYouTubeAudioStream: vi.fn(),
+  getYouTubeAudioStream: vi.fn(),
 }));
 
 import { disconnectVoiceConnection } from '../src/utils/voice-utils';
@@ -39,234 +40,234 @@ const mockedDisconnectVoiceConnection = vi.mocked(disconnectVoiceConnection);
 const mockedGetMusicConfig = vi.mocked(getMusicConfig);
 
 describe('DJCova Idle Management Integration', () => {
-	let djCova: DJCova;
-	let mockNotificationCallback: Mock<(message: string) => Promise<void>>;
+  let djCova: DJCova;
+  let mockNotificationCallback: Mock<(message: string) => Promise<void>>;
 
-	beforeEach(() => {
-		vi.clearAllMocks();
-		vi.useFakeTimers();
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
 
-		djCova = new DJCova();
-		mockNotificationCallback = vi.fn().mockResolvedValue(undefined);
-	});
+    djCova = new DJCova();
+    mockNotificationCallback = vi.fn().mockResolvedValue(undefined);
+  });
 
-	afterEach(() => {
-		djCova.destroy();
-		vi.useRealTimers();
-	});
+  afterEach(() => {
+    djCova.destroy();
+    vi.useRealTimers();
+  });
 
-	describe('Idle Management Initialization', () => {
-		it('should initialize idle management correctly', () => {
-			djCova.initializeIdleManagement('test-guild-id', 'test-channel-id', mockNotificationCallback);
+  describe('Idle Management Initialization', () => {
+    it('should initialize idle management correctly', () => {
+      djCova.initializeIdleManagement('test-guild-id', 'test-channel-id', mockNotificationCallback);
 
-			// Access private property to verify idle manager was created
-			const djCovaAny = djCova as any;
-			expect(djCovaAny.idleManager).not.toBeNull();
-			expect(djCovaAny.notificationCallback).toBe(mockNotificationCallback);
-		});
+      // Access private property to verify idle manager was created
+      const djCovaAny = djCova as any;
+      expect(djCovaAny.idleManager).not.toBeNull();
+      expect(djCovaAny.notificationCallback).toBe(mockNotificationCallback);
+    });
 
-		it('should work without notification callback', () => {
-			djCova.initializeIdleManagement('test-guild-id', 'test-channel-id');
-			// Access private property to verify idle manager was created
-			const djCovaAny = djCova as any;
-			expect(djCovaAny.idleManager).not.toBeNull();
-			expect(djCovaAny.notificationCallback).toBeNull();
-		});
+    it('should work without notification callback', () => {
+      djCova.initializeIdleManagement('test-guild-id', 'test-channel-id');
+      // Access private property to verify idle manager was created
+      const djCovaAny = djCova as any;
+      expect(djCovaAny.idleManager).not.toBeNull();
+      expect(djCovaAny.notificationCallback).toBeNull();
+    });
 
-		it('should replace existing idle manager when re-initialized', () => {
-			djCova.initializeIdleManagement('guild-1', 'channel-1', mockNotificationCallback);
-			const djCovaAny = djCova as any;
-			const firstManager = djCovaAny.idleManager;
+    it('should replace existing idle manager when re-initialized', () => {
+      djCova.initializeIdleManagement('guild-1', 'channel-1', mockNotificationCallback);
+      const djCovaAny = djCova as any;
+      const firstManager = djCovaAny.idleManager;
 
-			djCova.initializeIdleManagement('guild-2', 'channel-2', mockNotificationCallback);
-			const secondManager = djCovaAny.idleManager;
+      djCova.initializeIdleManagement('guild-2', 'channel-2', mockNotificationCallback);
+      const secondManager = djCovaAny.idleManager;
 
-			expect(firstManager).not.toBeNull();
-			expect(secondManager).not.toBeNull();
-			expect(secondManager).not.toBe(firstManager);
-		});
-	});
+      expect(firstManager).not.toBeNull();
+      expect(secondManager).not.toBeNull();
+      expect(secondManager).not.toBe(firstManager);
+    });
+  });
 
-	describe('Audio Player Status Integration', () => {
-		beforeEach(() => {
-			djCova.initializeIdleManagement('test-guild-id', 'test-channel-id', mockNotificationCallback);
-		});
+  describe('Audio Player Status Integration', () => {
+    beforeEach(() => {
+      djCova.initializeIdleManagement('test-guild-id', 'test-channel-id', mockNotificationCallback);
+    });
 
-		it('should start idle timer when audio player becomes idle', () => {
-			// Simulate audio player becoming idle
-			const player = djCova.getPlayer();
-			const djCovaAny = djCova as any;
-			const idleManager = djCovaAny.idleManager;
-			const startTimerSpy = vi.spyOn(idleManager, 'startIdleTimer');
+    it('should start idle timer when audio player becomes idle', () => {
+      // Simulate audio player becoming idle
+      const player = djCova.getPlayer();
+      const djCovaAny = djCova as any;
+      const idleManager = djCovaAny.idleManager;
+      const startTimerSpy = vi.spyOn(idleManager, 'startIdleTimer');
 
-			player.emit(AudioPlayerStatus.Idle);
+      player.emit(AudioPlayerStatus.Idle);
 
-			expect(startTimerSpy).toHaveBeenCalled();
-		});
+      expect(startTimerSpy).toHaveBeenCalled();
+    });
 
-		it('should reset idle timer when audio player starts playing', () => {
-			// Start idle timer
-			const player = djCova.getPlayer();
-			const djCovaAny = djCova as any;
-			const idleManager = djCovaAny.idleManager;
-			const resetTimerSpy = vi.spyOn(idleManager, 'resetIdleTimer');
+    it('should reset idle timer when audio player starts playing', () => {
+      // Start idle timer
+      const player = djCova.getPlayer();
+      const djCovaAny = djCova as any;
+      const idleManager = djCovaAny.idleManager;
+      const resetTimerSpy = vi.spyOn(idleManager, 'resetIdleTimer');
 
-			// Reset timer by starting playback
-			player.emit(AudioPlayerStatus.Playing);
-			expect(resetTimerSpy).toHaveBeenCalled();
-		});
+      // Reset timer by starting playback
+      player.emit(AudioPlayerStatus.Playing);
+      expect(resetTimerSpy).toHaveBeenCalled();
+    });
 
-		it('should cleanup on audio player error', () => {
-			const player = djCova.getPlayer();
-			const djCovaAny = djCova as any;
+    it('should cleanup on audio player error', () => {
+      const player = djCova.getPlayer();
+      const djCovaAny = djCova as any;
 
-			// Set up a mock ytdlp process
-			const mockProcess = { kill: vi.fn() };
-			djCovaAny.ytdlpProcess = mockProcess;
+      // Set up a mock ytdlp process
+      const mockProcess = { kill: vi.fn() };
+      djCovaAny.ytdlpProcess = mockProcess;
 
-			player.emit('error', new Error('Test error'));
+      player.emit('error', new Error('Test error'));
 
-			// Verify cleanup was called
-			expect(mockProcess.kill).toHaveBeenCalledWith('SIGKILL');
-		});
-	});
+      // Verify cleanup was called
+      expect(mockProcess.kill).toHaveBeenCalledWith('SIGKILL');
+    });
+  });
 
-	describe('Auto-disconnect Flow', () => {
-		beforeEach(() => {
-			djCova.initializeIdleManagement('test-guild-id', 'test-channel-id', mockNotificationCallback);
-		});
+  describe('Auto-disconnect Flow', () => {
+    beforeEach(() => {
+      djCova.initializeIdleManagement('test-guild-id', 'test-channel-id', mockNotificationCallback);
+    });
 
-		it('should auto-disconnect after idle timeout', async () => {
-			// Trigger idle state
-			const player = djCova.getPlayer();
-			player.emit(AudioPlayerStatus.Idle);
+    it('should auto-disconnect after idle timeout', async () => {
+      // Trigger idle state
+      const player = djCova.getPlayer();
+      player.emit(AudioPlayerStatus.Idle);
 
-			// Fast-forward past timeout
-			vi.advanceTimersByTime(2000);
-			await Promise.resolve();
+      // Fast-forward past timeout
+      vi.advanceTimersByTime(2000);
+      await Promise.resolve();
 
-			expect(mockedDisconnectVoiceConnection).toHaveBeenCalledWith('test-guild-id');
-			expect(mockNotificationCallback).toHaveBeenCalledWith(
-				'Disconnected from voice channel due to 2 seconds of inactivity',
-			);
-		});
+      expect(mockedDisconnectVoiceConnection).toHaveBeenCalledWith('test-guild-id');
+      expect(mockNotificationCallback).toHaveBeenCalledWith(
+        'Disconnected from voice channel due to 2 seconds of inactivity',
+      );
+    });
 
-		it('should not auto-disconnect if music starts playing before timeout', async () => {
-			// Trigger idle state
-			const player = djCova.getPlayer();
-			player.emit(AudioPlayerStatus.Idle);
+    it('should not auto-disconnect if music starts playing before timeout', async () => {
+      // Trigger idle state
+      const player = djCova.getPlayer();
+      player.emit(AudioPlayerStatus.Idle);
 
-			// Start playing before timeout
-			vi.advanceTimersByTime(1000);
-			player.emit(AudioPlayerStatus.Playing);
+      // Start playing before timeout
+      vi.advanceTimersByTime(1000);
+      player.emit(AudioPlayerStatus.Playing);
 
-			// Advance past original timeout
-			vi.advanceTimersByTime(2000);
-			await Promise.resolve();
+      // Advance past original timeout
+      vi.advanceTimersByTime(2000);
+      await Promise.resolve();
 
-			expect(mockedDisconnectVoiceConnection).not.toHaveBeenCalled();
-			expect(mockNotificationCallback).not.toHaveBeenCalled();
-		});
+      expect(mockedDisconnectVoiceConnection).not.toHaveBeenCalled();
+      expect(mockNotificationCallback).not.toHaveBeenCalled();
+    });
 
-		it('should handle notification callback errors gracefully', async () => {
-			const error = new Error('Notification failed');
-			mockNotificationCallback.mockRejectedValue(error);
+    it('should handle notification callback errors gracefully', async () => {
+      const error = new Error('Notification failed');
+      mockNotificationCallback.mockRejectedValue(error);
 
-			// Trigger idle state and timeout
-			const player = djCova.getPlayer();
-			player.emit(AudioPlayerStatus.Idle);
-			vi.advanceTimersByTime(2000);
-			await Promise.resolve();
+      // Trigger idle state and timeout
+      const player = djCova.getPlayer();
+      player.emit(AudioPlayerStatus.Idle);
+      vi.advanceTimersByTime(2000);
+      await Promise.resolve();
 
-			expect(mockedDisconnectVoiceConnection).toHaveBeenCalledWith('test-guild-id');
-			expect(mockNotificationCallback).toHaveBeenCalled();
-		});
-	});
+      expect(mockedDisconnectVoiceConnection).toHaveBeenCalledWith('test-guild-id');
+      expect(mockNotificationCallback).toHaveBeenCalled();
+    });
+  });
 
-	describe('Manual Stop', () => {
-		beforeEach(() => {
-			djCova.initializeIdleManagement('test-guild-id', 'test-channel-id', mockNotificationCallback);
-		});
+  describe('Manual Stop', () => {
+    beforeEach(() => {
+      djCova.initializeIdleManagement('test-guild-id', 'test-channel-id', mockNotificationCallback);
+    });
 
-		it('should cleanup resources on manual stop', () => {
-			const djCovaAny = djCova as any;
+    it('should cleanup resources on manual stop', () => {
+      const djCovaAny = djCova as any;
 
-			// Set up a mock ytdlp process
-			const mockProcess = { kill: vi.fn() };
-			djCovaAny.ytdlpProcess = mockProcess;
+      // Set up a mock ytdlp process
+      const mockProcess = { kill: vi.fn() };
+      djCovaAny.ytdlpProcess = mockProcess;
 
-			// Manual stop
-			djCova.stop();
+      // Manual stop
+      djCova.stop();
 
-			expect(mockProcess.kill).toHaveBeenCalledWith('SIGKILL');
-			expect(djCovaAny.ytdlpProcess).toBeNull();
-		});
+      expect(mockProcess.kill).toHaveBeenCalledWith('SIGKILL');
+      expect(djCovaAny.ytdlpProcess).toBeNull();
+    });
 
-		it('should not trigger auto-disconnect after manual stop', async () => {
-			// Start idle timer
-			const player = djCova.getPlayer();
-			player.emit(AudioPlayerStatus.Idle);
+    it('should not trigger auto-disconnect after manual stop', async () => {
+      // Start idle timer
+      const player = djCova.getPlayer();
+      player.emit(AudioPlayerStatus.Idle);
 
-			// Manual stop before timeout
-			vi.advanceTimersByTime(1000);
-			djCova.stop();
+      // Manual stop before timeout
+      vi.advanceTimersByTime(1000);
+      djCova.stop();
 
-			// Advance past original timeout
-			vi.advanceTimersByTime(2000);
-			await Promise.resolve();
+      // Advance past original timeout
+      vi.advanceTimersByTime(2000);
+      await Promise.resolve();
 
-			// Should still disconnect (idle timer was already started)
-			// But we verify the stop was called
-			const djCovaAny = djCova as any;
-			expect(djCovaAny.resource).toBeUndefined();
-		});
-	});
+      // Should still disconnect (idle timer was already started)
+      // But we verify the stop was called
+      const djCovaAny = djCova as any;
+      expect(djCovaAny.resource).toBeUndefined();
+    });
+  });
 
-	describe('Volume Management', () => {
-		it('should set and get volume correctly', () => {
-			djCova.setVolume(75);
-			expect(djCova.getVolume()).toBe(75);
-		});
+  describe('Volume Management', () => {
+    it('should set and get volume correctly', () => {
+      djCova.setVolume(75);
+      expect(djCova.getVolume()).toBe(75);
+    });
 
-		it('should clamp volume to valid range', () => {
-			djCova.setVolume(150);
-			expect(djCova.getVolume()).toBe(100);
+    it('should clamp volume to valid range', () => {
+      djCova.setVolume(150);
+      expect(djCova.getVolume()).toBe(100);
 
-			djCova.setVolume(-10);
-			expect(djCova.getVolume()).toBe(0);
-		});
-	});
+      djCova.setVolume(-10);
+      expect(djCova.getVolume()).toBe(0);
+    });
+  });
 
-	describe('Cleanup', () => {
-		it('should cleanup idle management on destroy', () => {
-			djCova.initializeIdleManagement('test-guild-id', 'test-channel-id', mockNotificationCallback);
+  describe('Cleanup', () => {
+    it('should cleanup idle management on destroy', () => {
+      djCova.initializeIdleManagement('test-guild-id', 'test-channel-id', mockNotificationCallback);
 
-			const djCovaAny = djCova as any;
-			expect(djCovaAny.idleManager).not.toBeNull();
+      const djCovaAny = djCova as any;
+      expect(djCovaAny.idleManager).not.toBeNull();
 
-			// Destroy should cleanup
-			djCova.destroy();
+      // Destroy should cleanup
+      djCova.destroy();
 
-			// Idle manager should be null after destroy
-			expect(djCovaAny.idleManager).toBeNull();
-		});
+      // Idle manager should be null after destroy
+      expect(djCovaAny.idleManager).toBeNull();
+    });
 
-		it('should cleanup all resources on destroy', () => {
-			const djCovaAny = djCova as any;
+    it('should cleanup all resources on destroy', () => {
+      const djCovaAny = djCova as any;
 
-			// Set up resources
-			const mockProcess = { kill: vi.fn() };
-			djCovaAny.ytdlpProcess = mockProcess;
+      // Set up resources
+      const mockProcess = { kill: vi.fn() };
+      djCovaAny.ytdlpProcess = mockProcess;
 
-			djCova.initializeIdleManagement('test-guild-id', 'test-channel-id', mockNotificationCallback);
+      djCova.initializeIdleManagement('test-guild-id', 'test-channel-id', mockNotificationCallback);
 
-			// Destroy
-			djCova.destroy();
+      // Destroy
+      djCova.destroy();
 
-			// Verify cleanup
-			expect(mockProcess.kill).toHaveBeenCalledWith('SIGKILL');
-			expect(djCovaAny.ytdlpProcess).toBeNull();
-			expect(djCovaAny.idleManager).toBeNull();
-		});
-	});
+      // Verify cleanup
+      expect(mockProcess.kill).toHaveBeenCalledWith('SIGKILL');
+      expect(djCovaAny.ytdlpProcess).toBeNull();
+      expect(djCovaAny.idleManager).toBeNull();
+    });
+  });
 });

--- a/src/djcova/tests/idle-manager.test.ts
+++ b/src/djcova/tests/idle-manager.test.ts
@@ -7,18 +7,19 @@ import { IdleManager, createIdleManager, IdleManagerConfig } from '../src/servic
 
 // Mock the voice utils
 vi.mock('../src/utils/voice-utils', () => ({
-	disconnectVoiceConnection: vi.fn(),
+  disconnectVoiceConnection: vi.fn(),
 }));
 
 // Mock the logger
 vi.mock('../src/observability/logger', () => ({
-	logger: {
-		debug: vi.fn(),
-		info: vi.fn(),
-		warn: vi.fn(),
-		error: vi.fn(),
-		withError: vi.fn().mockReturnThis(),
-	},
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withError: vi.fn().mockReturnThis(),
+    withMetadata: vi.fn().mockReturnThis(),
+  },
 }));
 
 import { disconnectVoiceConnection } from '../src/utils/voice-utils';
@@ -29,176 +30,179 @@ const mockedDisconnectVoiceConnection = vi.mocked(disconnectVoiceConnection);
 const mockedLogger = vi.mocked(logger);
 
 describe('IdleManager', () => {
-	let idleManager: IdleManager;
-	let mockOnDisconnect: (reason: string) => Promise<void>;
-	let config: IdleManagerConfig;
+  let idleManager: IdleManager;
+  let mockOnDisconnect: (reason: string) => Promise<void>;
+  let config: IdleManagerConfig;
 
-	beforeEach(() => {
-		vi.clearAllMocks();
-		vi.useFakeTimers();
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
 
-		mockOnDisconnect = vi.fn().mockResolvedValue(undefined) as any;
+    mockOnDisconnect = vi.fn().mockResolvedValue(undefined) as any;
 
-		config = {
-			timeoutSeconds: 2, // Short timeout for testing
-			guildId: 'test-guild-id',
-			channelId: 'test-channel-id',
-			onDisconnect: mockOnDisconnect,
-		};
+    config = {
+      timeoutSeconds: 2, // Short timeout for testing
+      guildId: 'test-guild-id',
+      channelId: 'test-channel-id',
+      onDisconnect: mockOnDisconnect,
+    };
 
-		idleManager = new IdleManager(config);
-	});
+    idleManager = new IdleManager(config);
+  });
 
-	afterEach(() => {
-		idleManager.destroy();
-		vi.useRealTimers();
-	});
+  afterEach(() => {
+    idleManager.destroy();
+    vi.useRealTimers();
+  });
 
-	describe('Timer Management', () => {
-		it('should start idle timer', () => {
-			expect(idleManager.isIdleTimerActive()).toBe(false);
+  describe('Timer Management', () => {
+    it('should start idle timer', () => {
+      expect(idleManager.isIdleTimerActive()).toBe(false);
 
-			idleManager.startIdleTimer();
+      idleManager.startIdleTimer();
 
-			expect(idleManager.isIdleTimerActive()).toBe(true);
-		});
+      expect(idleManager.isIdleTimerActive()).toBe(true);
+    });
 
-		it('should reset idle timer', () => {
-			idleManager.startIdleTimer();
-			expect(idleManager.isIdleTimerActive()).toBe(true);
+    it('should reset idle timer', () => {
+      idleManager.startIdleTimer();
+      expect(idleManager.isIdleTimerActive()).toBe(true);
 
-			idleManager.resetIdleTimer();
+      idleManager.resetIdleTimer();
 
-			expect(idleManager.isIdleTimerActive()).toBe(false);
-		});
+      expect(idleManager.isIdleTimerActive()).toBe(false);
+    });
 
-		it('should cancel idle timer', () => {
-			idleManager.startIdleTimer();
-			expect(idleManager.isIdleTimerActive()).toBe(true);
+    it('should cancel idle timer', () => {
+      idleManager.startIdleTimer();
+      expect(idleManager.isIdleTimerActive()).toBe(true);
 
-			idleManager.cancelIdleTimer();
+      idleManager.cancelIdleTimer();
 
-			expect(idleManager.isIdleTimerActive()).toBe(false);
-		});
+      expect(idleManager.isIdleTimerActive()).toBe(false);
+    });
 
-		it('should reset timer when starting while already active', () => {
-			idleManager.startIdleTimer();
-			expect(idleManager.isIdleTimerActive()).toBe(true);
+    it('should reset timer when starting while already active', () => {
+      idleManager.startIdleTimer();
+      expect(idleManager.isIdleTimerActive()).toBe(true);
 
-			idleManager.startIdleTimer(); // Should reset, not create second timer
+      idleManager.startIdleTimer(); // Should reset, not create second timer
 
-			expect(idleManager.isIdleTimerActive()).toBe(true);
-		});
-	});
+      expect(idleManager.isIdleTimerActive()).toBe(true);
+    });
+  });
 
-	describe('Auto-disconnect Functionality', () => {
-		it('should trigger auto-disconnect after timeout', async () => {
-			idleManager.startIdleTimer();
+  describe('Auto-disconnect Functionality', () => {
+    it('should trigger auto-disconnect after timeout', async () => {
+      idleManager.startIdleTimer();
 
-			// Fast-forward time to trigger timeout
-			vi.advanceTimersByTime(2000);
+      // Fast-forward time to trigger timeout
+      vi.advanceTimersByTime(2000);
 
-			// Wait for async operations to complete
-			await Promise.resolve();
+      // Wait for async operations to complete
+      await Promise.resolve();
 
-			expect(mockedDisconnectVoiceConnection).toHaveBeenCalledWith('test-guild-id');
-			expect(mockOnDisconnect).toHaveBeenCalledWith(
-				'Disconnected from voice channel due to 2 seconds of inactivity',
-			);
-			expect(idleManager.isIdleTimerActive()).toBe(false);
-		});
+      expect(mockedDisconnectVoiceConnection).toHaveBeenCalledWith('test-guild-id');
+      expect(mockOnDisconnect).toHaveBeenCalledWith(
+        'Disconnected from voice channel due to 2 seconds of inactivity',
+      );
+      expect(idleManager.isIdleTimerActive()).toBe(false);
+    });
 
-		it('should not trigger auto-disconnect if timer is reset', async () => {
-			idleManager.startIdleTimer();
+    it('should not trigger auto-disconnect if timer is reset', async () => {
+      idleManager.startIdleTimer();
 
-			// Reset timer before timeout
-			vi.advanceTimersByTime(1000);
-			idleManager.resetIdleTimer();
+      // Reset timer before timeout
+      vi.advanceTimersByTime(1000);
+      idleManager.resetIdleTimer();
 
-			// Advance past original timeout
-			vi.advanceTimersByTime(2000);
-			await Promise.resolve();
+      // Advance past original timeout
+      vi.advanceTimersByTime(2000);
+      await Promise.resolve();
 
-			expect(mockedDisconnectVoiceConnection).not.toHaveBeenCalled();
-			expect(mockOnDisconnect).not.toHaveBeenCalled();
-		});
+      expect(mockedDisconnectVoiceConnection).not.toHaveBeenCalled();
+      expect(mockOnDisconnect).not.toHaveBeenCalled();
+    });
 
-		it('should not trigger auto-disconnect if timer is cancelled', async () => {
-			idleManager.startIdleTimer();
+    it('should not trigger auto-disconnect if timer is cancelled', async () => {
+      idleManager.startIdleTimer();
 
-			// Cancel timer before timeout
-			vi.advanceTimersByTime(1000);
-			idleManager.cancelIdleTimer();
+      // Cancel timer before timeout
+      vi.advanceTimersByTime(1000);
+      idleManager.cancelIdleTimer();
 
-			// Advance past original timeout
-			vi.advanceTimersByTime(2000);
-			await Promise.resolve();
+      // Advance past original timeout
+      vi.advanceTimersByTime(2000);
+      await Promise.resolve();
 
-			expect(mockedDisconnectVoiceConnection).not.toHaveBeenCalled();
-			expect(mockOnDisconnect).not.toHaveBeenCalled();
-		});
+      expect(mockedDisconnectVoiceConnection).not.toHaveBeenCalled();
+      expect(mockOnDisconnect).not.toHaveBeenCalled();
+    });
 
-		it('should handle errors during auto-disconnect gracefully', async () => {
-			const error = new Error('Disconnect failed');
-			(mockedDisconnectVoiceConnection).mockImplementation(() => {
-				throw error;
-			});
+    it('should handle errors during auto-disconnect gracefully', async () => {
+      const error = new Error('Disconnect failed');
+      mockedDisconnectVoiceConnection.mockImplementation(() => {
+        throw error;
+      });
 
-			idleManager.startIdleTimer();
-			vi.advanceTimersByTime(2000);
-			await Promise.resolve();
+      idleManager.startIdleTimer();
+      vi.advanceTimersByTime(2000);
+      await Promise.resolve();
 
-			expect(logger.withError).toHaveBeenCalledWith(error);
-			expect(logger.error).toHaveBeenCalledWith('Error handling idle timeout');
-			expect(idleManager.isIdleTimerActive()).toBe(false); // Should still clean up
-		});
-	});
+      expect(logger.withError).toHaveBeenCalledWith(error);
+      expect(logger.withMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({ error_code: 'UNKNOWN', guild_id: 'test-guild-id' }),
+      );
+      expect(logger.error).toHaveBeenCalledWith('Error handling idle timeout');
+      expect(idleManager.isIdleTimerActive()).toBe(false); // Should still clean up
+    });
+  });
 
-	describe('Configuration', () => {
-		it('should return correct timeout seconds', () => {
-			expect(idleManager.getTimeoutSeconds()).toBe(2);
-		});
+  describe('Configuration', () => {
+    it('should return correct timeout seconds', () => {
+      expect(idleManager.getTimeoutSeconds()).toBe(2);
+    });
 
-		it('should update configuration', () => {
-			idleManager.updateConfig({ timeoutSeconds: 5 });
-			expect(idleManager.getTimeoutSeconds()).toBe(5);
-		});
+    it('should update configuration', () => {
+      idleManager.updateConfig({ timeoutSeconds: 5 });
+      expect(idleManager.getTimeoutSeconds()).toBe(5);
+    });
 
-		it('should work without onDisconnect callback', async () => {
-			const configWithoutCallback = {
-				timeoutSeconds: 1,
-				guildId: 'test-guild-id',
-			};
+    it('should work without onDisconnect callback', async () => {
+      const configWithoutCallback = {
+        timeoutSeconds: 1,
+        guildId: 'test-guild-id',
+      };
 
-			const managerWithoutCallback = new IdleManager(configWithoutCallback);
-			managerWithoutCallback.startIdleTimer();
+      const managerWithoutCallback = new IdleManager(configWithoutCallback);
+      managerWithoutCallback.startIdleTimer();
 
-			vi.advanceTimersByTime(1000);
-			await Promise.resolve();
+      vi.advanceTimersByTime(1000);
+      await Promise.resolve();
 
-			expect(mockedDisconnectVoiceConnection).toHaveBeenCalledWith('test-guild-id');
+      expect(mockedDisconnectVoiceConnection).toHaveBeenCalledWith('test-guild-id');
 
-			managerWithoutCallback.destroy();
-		});
-	});
+      managerWithoutCallback.destroy();
+    });
+  });
 
-	describe('Factory Function', () => {
-		it('should create IdleManager instance', () => {
-			const manager = createIdleManager(config);
-			expect(manager).toBeInstanceOf(IdleManager);
-			expect(manager.getTimeoutSeconds()).toBe(2);
-			manager.destroy();
-		});
-	});
+  describe('Factory Function', () => {
+    it('should create IdleManager instance', () => {
+      const manager = createIdleManager(config);
+      expect(manager).toBeInstanceOf(IdleManager);
+      expect(manager.getTimeoutSeconds()).toBe(2);
+      manager.destroy();
+    });
+  });
 
-	describe('Cleanup', () => {
-		it('should cleanup resources on destroy', () => {
-			idleManager.startIdleTimer();
-			expect(idleManager.isIdleTimerActive()).toBe(true);
+  describe('Cleanup', () => {
+    it('should cleanup resources on destroy', () => {
+      idleManager.startIdleTimer();
+      expect(idleManager.isIdleTimerActive()).toBe(true);
 
-			idleManager.destroy();
+      idleManager.destroy();
 
-			expect(idleManager.isIdleTimerActive()).toBe(false);
-		});
-	});
+      expect(idleManager.isIdleTimerActive()).toBe(false);
+    });
+  });
 });

--- a/src/djcova/tests/music-commands.test.ts
+++ b/src/djcova/tests/music-commands.test.ts
@@ -22,7 +22,14 @@ vi.mock('../src/observability/logger', () => ({
     warn: vi.fn(),
     error: vi.fn(),
     withError: vi.fn().mockReturnThis(),
+    withMetadata: vi.fn().mockReturnThis(),
   },
+}));
+
+vi.mock('@/observability/djcova-metrics', () => ({
+  getDJCovaMetrics: vi.fn().mockReturnValue({
+    trackPlayCommand: vi.fn(),
+  }),
 }));
 
 vi.mock('../src/utils/discord-utils', () => ({

--- a/src/djcova/tests/ytdlp.unit.test.ts
+++ b/src/djcova/tests/ytdlp.unit.test.ts
@@ -10,6 +10,7 @@ vi.mock('../src/observability/logger', () => ({
     warn: vi.fn(),
     error: vi.fn(),
     withError: vi.fn().mockReturnThis(),
+    withMetadata: vi.fn().mockReturnThis(),
   },
 }));
 

--- a/src/shared/package.json
+++ b/src/shared/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
+    "./errors": "./dist/errors/index.js",
     "./database": "./dist/services/database/index.js",
     "./health/smoke-mode": "./dist/health/smoke-mode.js",
     "./health/smoke-test": "./dist/health/smoke-test.js",

--- a/src/shared/src/errors/codes.ts
+++ b/src/shared/src/errors/codes.ts
@@ -1,0 +1,20 @@
+/**
+ * Starbunk shared error codes
+ *
+ * Application-agnostic codes reusable across all containers (bunkbot, djcova, covabot, bluebot).
+ * Container-specific codes must be defined in that container's own errors/ directory.
+ */
+export const SharedErrorCode = {
+  NIL_REFERENCE: 'NIL_REFERENCE',
+  NETWORK_UNAVAILABLE: 'NETWORK_UNAVAILABLE',
+  CONFIG_MISSING: 'CONFIG_MISSING',
+  TIMEOUT: 'TIMEOUT',
+  PARSE_FAILED: 'PARSE_FAILED',
+  VALIDATION_FAILED: 'VALIDATION_FAILED',
+  DATABASE_ERROR: 'DATABASE_ERROR',
+  DISCORD_API_ERROR: 'DISCORD_API_ERROR',
+  DISCORD_GATEWAY_ERROR: 'DISCORD_GATEWAY_ERROR',
+  UNKNOWN: 'UNKNOWN',
+} as const;
+
+export type SharedErrorCode = (typeof SharedErrorCode)[keyof typeof SharedErrorCode];

--- a/src/shared/src/errors/ensure-error.ts
+++ b/src/shared/src/errors/ensure-error.ts
@@ -1,0 +1,8 @@
+/**
+ * Normalizes an unknown thrown value into a proper Error object.
+ * Use this in catch blocks where the caught value may not be an Error instance.
+ */
+export function ensureError(error: unknown): Error {
+  if (error instanceof Error) return error;
+  return new Error(String(error));
+}

--- a/src/shared/src/errors/index.ts
+++ b/src/shared/src/errors/index.ts
@@ -1,0 +1,3 @@
+export { SharedErrorCode } from './codes';
+export type { SharedErrorCode as SharedErrorCodeType } from './codes';
+export { ensureError } from './ensure-error';

--- a/src/shared/src/errors/index.ts
+++ b/src/shared/src/errors/index.ts
@@ -1,3 +1,5 @@
 export { SharedErrorCode } from './codes';
 export type { SharedErrorCode as SharedErrorCodeType } from './codes';
 export { ensureError } from './ensure-error';
+export { logError } from './log-error';
+export type { LogErrorOptions } from './log-error';

--- a/src/shared/src/errors/log-error.ts
+++ b/src/shared/src/errors/log-error.ts
@@ -1,0 +1,58 @@
+import { ensureError } from './ensure-error';
+
+/**
+ * Minimal logger interface required by logError.
+ * Satisfied by any LogLayer instance (including test mocks).
+ */
+interface StructuredLogger {
+  withError(error: Error): this;
+  withMetadata(metadata: Record<string, unknown>): this;
+  error(message: string): void;
+}
+
+/**
+ * Options passed to logError.
+ * - `cause` — the underlying Error (or unknown thrown value). Attached via .withError().
+ * - any other key — forwarded as structured log metadata alongside error_code.
+ */
+export interface LogErrorOptions {
+  cause?: unknown;
+  [key: string]: unknown;
+}
+
+/**
+ * Log a structured error with a mandatory error code.
+ *
+ * This is the ONLY way errors should be logged in Starbunk. The `code`
+ * parameter is positional and required so it cannot be accidentally omitted.
+ * All error logs will carry a machine-readable `error_code` field that Loki
+ * and Grafana can filter and alert on.
+ *
+ * @example
+ * // With an underlying error:
+ * logError(logger, DJCovaErrorCode.DJCOVA_YTDLP_SPAWN_FAILED, 'yt-dlp failed to start', {
+ *   cause: error,
+ *   url,
+ * });
+ *
+ * @example
+ * // Without an underlying error (structural / logic failure):
+ * logError(logger, DJCovaErrorCode.DJCOVA_VOICE_JOIN_FAILED, 'Player subscription returned undefined', {
+ *   guild_id: guildId,
+ * });
+ */
+export function logError(
+  logger: StructuredLogger,
+  code: string,
+  message: string,
+  options?: LogErrorOptions,
+): void {
+  const { cause, ...context } = options ?? {};
+  const metadata: Record<string, unknown> = { error_code: code, ...context };
+
+  if (cause !== undefined) {
+    logger.withError(ensureError(cause)).withMetadata(metadata).error(message);
+  } else {
+    logger.withMetadata(metadata).error(message);
+  }
+}

--- a/src/shared/src/index.ts
+++ b/src/shared/src/index.ts
@@ -1,5 +1,10 @@
 // Shared utilities and services for all containers
 
+// Error codes and utilities
+export { SharedErrorCode } from './errors/codes';
+export type { SharedErrorCodeType } from './errors';
+export { ensureError } from './errors/ensure-error';
+
 // Core logger
 export { logLayer } from './observability/log-layer';
 

--- a/src/shared/src/index.ts
+++ b/src/shared/src/index.ts
@@ -4,6 +4,8 @@
 export { SharedErrorCode } from './errors/codes';
 export type { SharedErrorCodeType } from './errors';
 export { ensureError } from './errors/ensure-error';
+export { logError } from './errors/log-error';
+export type { LogErrorOptions } from './errors/log-error';
 
 // Core logger
 export { logLayer } from './observability/log-layer';


### PR DESCRIPTION
## Summary

- **Shared error codes** (`src/shared/src/errors/codes.ts`): generic `SharedErrorCode` const covering NIL_REFERENCE, NETWORK_UNAVAILABLE, CONFIG_MISSING, TIMEOUT, PARSE_FAILED, VALIDATION_FAILED, DATABASE_ERROR, DISCORD_API_ERROR, DISCORD_GATEWAY_ERROR, UNKNOWN — reusable across all four containers
- **`ensureError` utility** moved to `src/shared/src/errors/` so all apps can consume it (DJCova continues to export it from its existing path for backward compat)
- **DJCova error codes** (`src/djcova/src/errors/codes.ts`): `DJCovaErrorCode` with `DJCOVA_` prefix covering all yt-dlp failure modes, audio player/stream errors, voice connection lifecycle, and input errors
- **DJCova play funnel metrics** (`src/djcova/src/observability/djcova-metrics.ts`): three Prometheus counters sharing the MetricsService registry:
  - `djcova_play_command_total{guild_id, status}` — every `/play` invocation
  - `djcova_voice_join_total{guild_id, status}` — every voice join attempt
  - `djcova_audio_playback_started_total{guild_id}` — audio actually streaming
- **Wired into**: play command, DJCovaService, DJCova core, ytdlp utils, ConnectionHealthMonitor
- All critical error log sites now include `error_code` in structured metadata for Loki label filtering in Grafana
- `ConnectionHealthMonitor` threshold-exceeded now logs at `error` level (was `debug`) and calls `trackBotError` with `DJCOVA_VOICE_CONNECTION_LOST`

## Test plan

- [x] TypeScript type-check: `tsc --noEmit` passes on both shared and djcova
- [x] Full test suite: 203 tests pass (3 mocks updated to stub `withMetadata` chaining)
- [ ] Deploy to staging and confirm `djcova_play_command_total`, `djcova_voice_join_total`, `djcova_audio_playback_started_total` appear in Grafana at `/metrics`
- [ ] Run `/play` and verify the three funnel counters increment in the correct order
- [ ] Confirm Loki logs show `error_code` field on DJCova error events

🤖 Generated with [Claude Code](https://claude.com/claude-code)