### PR TITLE
fix(e2e): gracefully skip suite when Discord env vars are absent

### DIFF
--- a/src/e2e/src/harness/test-env.ts
+++ b/src/e2e/src/harness/test-env.ts
@@ -1,41 +1,47 @@
 /**
- * Typed, validated access to E2E environment variables.
- * Fails fast at startup if any required variable is missing.
+ * Typed access to E2E environment variables.
+ *
+ * Does NOT throw at module load time — callers that need a configured
+ * environment should check `isConfigured` first (or rely on global-setup
+ * to abort the run early with a clean exit when vars are absent).
  */
 
-const required = (name: string): string => {
-  const val = process.env[name];
-  if (!val) throw new Error(`Missing required E2E env var: ${name}`);
-  return val;
-};
+const optional = (name: string): string => process.env[name] ?? '';
+
+/**
+ * True when all required Discord env vars are present.
+ * global-setup.ts checks this and exits 0 when false so the suite is
+ * skipped rather than failing in environments that don't have the tokens.
+ */
+export const isConfigured: boolean = !!process.env.E2E_DISCORD_SENDER_TOKEN;
 
 export const env = {
   // CI sender bot (sends test messages, listens for responses)
-  SENDER_TOKEN: required('E2E_DISCORD_SENDER_TOKEN'),
-  SENDER_BOT_ID: required('E2E_DISCORD_SENDER_BOT_ID'),
+  SENDER_TOKEN: optional('E2E_DISCORD_SENDER_TOKEN'),
+  SENDER_BOT_ID: optional('E2E_DISCORD_SENDER_BOT_ID'),
 
   // "Enemy" bot account (used for BlueBot enemy tests)
-  ENEMY_TOKEN: required('E2E_DISCORD_ENEMY_TOKEN'),
-  ENEMY_BOT_ID: required('E2E_DISCORD_ENEMY_BOT_ID'),
+  ENEMY_TOKEN: optional('E2E_DISCORD_ENEMY_TOKEN'),
+  ENEMY_BOT_ID: optional('E2E_DISCORD_ENEMY_BOT_ID'),
 
   // Test Discord server
-  GUILD_ID: required('E2E_DISCORD_TEST_GUILD_ID'),
+  GUILD_ID: optional('E2E_DISCORD_TEST_GUILD_ID'),
 
   // Per-bot test channels (text)
-  CHANNEL_INFRA: required('E2E_CHANNEL_INFRASTRUCTURE'),
-  CHANNEL_BUNKBOT: required('E2E_CHANNEL_BUNKBOT'),
-  CHANNEL_BLUEBOT: required('E2E_CHANNEL_BLUEBOT'),
-  CHANNEL_COVABOT: required('E2E_CHANNEL_COVABOT'),
-  CHANNEL_DJCOVA: required('E2E_CHANNEL_DJCOVA'),
+  CHANNEL_INFRA: optional('E2E_CHANNEL_INFRASTRUCTURE'),
+  CHANNEL_BUNKBOT: optional('E2E_CHANNEL_BUNKBOT'),
+  CHANNEL_BLUEBOT: optional('E2E_CHANNEL_BLUEBOT'),
+  CHANNEL_COVABOT: optional('E2E_CHANNEL_COVABOT'),
+  CHANNEL_DJCOVA: optional('E2E_CHANNEL_DJCOVA'),
 
   // DJCova voice channel
-  VOICE_CHANNEL_DJCOVA: required('E2E_VOICE_CHANNEL_DJCOVA'),
+  VOICE_CHANNEL_DJCOVA: optional('E2E_VOICE_CHANNEL_DJCOVA'),
 
   // Bot user IDs (used to identify which messages are from which bot)
-  BUNKBOT_BOT_ID: required('E2E_BUNKBOT_BOT_ID'),
-  BLUEBOT_BOT_ID: required('E2E_BLUEBOT_BOT_ID'),
-  COVABOT_BOT_ID: required('E2E_COVABOT_BOT_ID'),
-  DJCOVA_BOT_ID: required('E2E_DJCOVA_BOT_ID'),
+  BUNKBOT_BOT_ID: optional('E2E_BUNKBOT_BOT_ID'),
+  BLUEBOT_BOT_ID: optional('E2E_BLUEBOT_BOT_ID'),
+  COVABOT_BOT_ID: optional('E2E_COVABOT_BOT_ID'),
+  DJCOVA_BOT_ID: optional('E2E_DJCOVA_BOT_ID'),
 
   // Delay between test messages (ms) — avoids Discord rate limits
   MESSAGE_DELAY_MS: parseInt(process.env.E2E_MESSAGE_DELAY_MS ?? '800') || 800,

--- a/src/e2e/src/setup/global-setup.ts
+++ b/src/e2e/src/setup/global-setup.ts
@@ -12,11 +12,16 @@
 
 import 'dotenv/config';
 import { initE2EClient } from '@/harness/discord-e2e-client';
-import { env } from '@/harness/test-env';
+import { env, isConfigured } from '@/harness/test-env';
 
 const BOT_READY_TIMEOUT_MS = 60_000;
 
 export async function setup(): Promise<void> {
+  if (!isConfigured) {
+    console.log('\n[E2E Global Setup] E2E env vars not configured — skipping suite.\n');
+    process.exit(0);
+  }
+
   console.log('\n[E2E Global Setup] Connecting to Discord...');
 
   const client = initE2EClient(env.SENDER_TOKEN, env.ENEMY_TOKEN, env.SENDER_BOT_ID);

--- a/src/e2e/vitest.config.ts
+++ b/src/e2e/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     fileParallelism: false,
     testTimeout: 30_000,
     hookTimeout: 60_000,
+    passWithNoTests: true,
     include: ['src/tests/**/*.e2e.test.ts'],
     globalSetup: ['src/setup/global-setup.ts'],
     reporters: [


### PR DESCRIPTION
## Summary

- `test-env.ts` previously called `required()` at module load time, throwing when Discord env vars were absent — vitest couldn't even collect test files, exiting 1 with "No test files found"
- All env vars now use `optional()` (returns `''`, never throws) with an exported `isConfigured` flag
- `global-setup.ts` detects `!isConfigured` early and calls `process.exit(0)` with a clear log message, skipping the suite cleanly
- `vitest.config.ts` adds `passWithNoTests: true` as a second safety net

## Test plan

- [ ] In CI (no Discord tokens): suite exits 0, logs "[E2E Global Setup] E2E env vars not configured — skipping suite."
- [ ] With Discord tokens configured: suite runs normally (no regression)
- [ ] `npm run check:ci` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)