### PR TITLE
fix(cd): configure git identity before creating build tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -242,6 +242,8 @@ jobs:
       - name: Create build tag (no semantic release)
         if: steps.semrel.outputs.new_version == ''
         run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
           BUILD_TAG="build-$(date +%Y%m%d)-${GITHUB_SHA:0:7}"
           git tag "$BUILD_TAG" -m "CI build ${GITHUB_RUN_NUMBER} from ${GITHUB_SHA:0:7}"
           git push origin "$BUILD_TAG"


### PR DESCRIPTION
## Summary

- The CD "Publish Releases" job was failing with exit code 128 on the "Create build tag (no semantic release)" step
- Root cause: `git tag` requires a committer identity (`user.email` + `user.name`), but GitHub Actions runners have no default git identity configured
- Fix: add `git config user.email` and `git config user.name` before the `git tag` command

## Error

```
fatal: empty ident name (for <runner@...>) not allowed
Process completed with exit code 128.
```

## Test plan

- [ ] CD "Publish Releases" → "Create build tag" step succeeds on next main merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)