### PR TITLE
fix(deploy): add Tailscale for LAN production server access

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
           tags: tag:ci
 
       - name: Execute Remote Deploy
+        if: ${{ secrets.SSH_PRIVATE_KEY != '' }}
         uses: appleboy/ssh-action@v1.0.3
         env:
           PROD_DIR: ${{ secrets.PROD_DOCKER_COMPOSE_DIR }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,14 @@ jobs:
     concurrency: production
     steps:
       - uses: actions/checkout@v4
-      
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-client-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+          tags: tag:ci
+
       - name: Execute Remote Deploy
         uses: appleboy/ssh-action@v1.0.3
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Connect to Tailscale
+        if: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID != '' }}
         uses: tailscale/github-action@v2
         with:
           oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}


### PR DESCRIPTION
## Summary

- GitHub Actions runners (Azure cloud) cannot reach LAN IPs directly
- Adds `tailscale/github-action@v2` to connect the runner to your tailnet before SSH-ing into the production server
- Uses OAuth client credentials (reusable, no expiry) with a `tag:ci` tag

## Secrets to add in GitHub → Settings → Secrets and variables → Actions

| Secret | How to get it |
|--------|--------------|
| `TAILSCALE_OAUTH_CLIENT_ID` | Tailscale admin console → Settings → OAuth clients → New client (grant `devices:write`) |
| `TAILSCALE_OAUTH_CLIENT_SECRET` | Same OAuth client creation flow |
| `PROD_SERVER_HOST` | Your server's Tailscale IP (`100.x.x.x`) or MagicDNS name (e.g. `myserver.tail1234.ts.net`) — run `tailscale ip` on the server |
| `PROD_SERVER_USER` | SSH username on the server (e.g. `andrew`) |
| `SSH_PRIVATE_KEY` | Private key whose public key is in `~/.ssh/authorized_keys` on the server — generate with `ssh-keygen -t ed25519` if needed |
| `PROD_DOCKER_COMPOSE_DIR` | Absolute path to the starbunk docker-compose directory on the server |
| `DISCORD_WEBHOOK_URL` | *(optional)* Discord webhook for deploy notifications |

## Tailscale ACL tag

The action uses `tag:ci`. You need to add this tag to your Tailscale ACL policy:
```json
"tagOwners": {
  "tag:ci": []
}
```
(Tailscale admin console → Access Controls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)