### PR TITLE
fix(deploy): correct vars.* references and Tailscale input name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
         uses: tailscale/github-action@v2
         with:
           oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
-          oauth-client-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
           tags: tag:ci
 
       - name: Execute Remote Deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
         if: steps.preflight.outputs.run_deploy == 'true'
         uses: appleboy/ssh-action@v1.0.3
         env:
-          PROD_DIR: ${{ secrets.PROD_DOCKER_COMPOSE_DIR }}
+          PROD_DIR: ${{ vars.PROD_DOCKER_COMPOSE_DIR }}
         with:
           host: ${{ secrets.PROD_SERVER_HOST }}
           username: ${{ secrets.PROD_SERVER_USER }}
@@ -61,4 +61,4 @@ jobs:
         with:
           severity: ${{ job.status == 'success' && 'info' || 'error' }}
           details: Production deployment finished with status ${{ job.status }}
-          webhookUrl: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          webhookUrl: ${{ vars.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
- **`vars.*` for environment variables**: `PROD_DOCKER_COMPOSE_DIR` and `DISCORD_WEBHOOK_URL` are stored as GitHub Environment *variables* (not secrets) in the `production` environment — they must be referenced with `vars.*` not `secrets.*`. Using `secrets.*` returned empty strings, causing the SSH deploy to use a blank directory and the Discord notify to fail.
- **Tailscale input rename**: `tailscale/github-action@v2` expects `oauth-secret`, not `oauth-client-secret`. The wrong key name caused the action to see an empty OAuth identity and exit 1, aborting the deploy before SSH even ran.

## Test plan
- [ ] Merge and confirm the deploy workflow reaches the SSH step without Tailscale errors
- [ ] Confirm Discord notification fires on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)