### PR TITLE
chore: point wiki to repo-local wiki/ and gitignore it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,6 +258,12 @@ actionlint
 !src/covabot/config/personalities/**/*.md
 
 # ==========================================
+# PROJECT-SPECIFIC: WIKI
+# ==========================================
+# Local wiki (Obsidian second brain — not committed)
+wiki/
+
+# ==========================================
 # MISC
 # ==========================================
 # Optional REPL history

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ The project is split into four isolated containers, each under `src/`:
 4. **BlueBot** (`src/bluebot`): Pattern matching bot for "blue" references.
 
 ## Second Brain / Wiki
-- Location: `~/wiki/starbunk-js`
+- Location: `wiki/` (repo root)
 - **Always** check relevant wiki pages before starting any task
 - **Always** update the relevant page after completing a task
 - Wiki uses markdown files organized by topic


### PR DESCRIPTION
## Summary
- Updates `CLAUDE.md` wiki location from `~/wiki/starbunk-js` to `wiki/` at the repo root
- Adds `wiki/` to `.gitignore` so the Obsidian second brain stays local-only and is never accidentally committed

## Test plan
- [ ] Verify `wiki/` is ignored by git (`git check-ignore -v wiki/`)
- [ ] Confirm CLAUDE.md reflects the correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)