### PR TITLE
fix(health): return 503 during startup to prevent false-positive health checks

### DIFF
--- a/src/bluebot/src/index.ts
+++ b/src/bluebot/src/index.ts
@@ -5,6 +5,7 @@ import { logger } from '@/observability/logger';
 import { BlueBot } from '@/blue-bot';
 import { runSmokeTest } from '@starbunk/shared/health/smoke-test';
 import { initializeHealthServer } from '@starbunk/shared/health/health-server-init';
+import { setApplicationHealth } from '@starbunk/shared/observability/health-server';
 import { shutdownObservability } from '@starbunk/shared/observability/shutdown';
 import { getMetricsService } from '@starbunk/shared/observability/metrics-service';
 
@@ -60,6 +61,7 @@ async function main(): Promise<void> {
 
   const bot = new BlueBot(client);
   await bot.start();
+  setApplicationHealth('healthy');
 
   // Set up graceful shutdown handlers
   const shutdown = async (signal: string) => {

--- a/src/bunkbot/src/index.ts
+++ b/src/bunkbot/src/index.ts
@@ -7,6 +7,7 @@ import { BunkBot } from '@/bunk-bot';
 import { runSmokeTest } from '@starbunk/shared/health/smoke-test';
 import { getMetricsService } from '@starbunk/shared/observability/metrics-service';
 import { initializeHealthServer } from '@starbunk/shared/health/health-server-init';
+import { setApplicationHealth } from '@starbunk/shared/observability/health-server';
 
 // Setup logging mixins before any logging occurs
 setupBunkBotLogging();
@@ -67,6 +68,7 @@ async function main() {
   // Create and initialize BunkBot
   const bunkBot = new BunkBot(client, metricsService, healthServer);
   await bunkBot.initialize();
+  setApplicationHealth('healthy');
 
   // Graceful shutdown
   const shutdown = async (signal: string) => {

--- a/src/covabot/src/index.ts
+++ b/src/covabot/src/index.ts
@@ -15,6 +15,7 @@ import { config } from 'dotenv';
 import { logLayer } from '@starbunk/shared/observability/log-layer';
 import { runSmokeMode } from '@starbunk/shared/health/smoke-mode';
 import { initializeHealthServer } from '@starbunk/shared/health/health-server-init';
+import { setApplicationHealth } from '@starbunk/shared/observability/health-server';
 import { shutdownObservability } from '@starbunk/shared/observability/shutdown';
 import { CovaBot, CovaBotConfig } from './cova-bot';
 
@@ -94,9 +95,11 @@ async function main(): Promise<void> {
 
   try {
     await bot.start();
+    setApplicationHealth('healthy');
     logger.info('CovaBot v2 is now running');
   } catch (error) {
     logger.withError(error).error('Failed to start CovaBot');
+    setApplicationHealth('unhealthy', error instanceof Error ? error.message : String(error));
     process.exit(1);
   }
 }

--- a/src/djcova/src/index.ts
+++ b/src/djcova/src/index.ts
@@ -4,6 +4,7 @@ import { setupDJCovaLogging } from './observability/setup-logging';
 import { logger } from './observability/logger';
 import { Client, Events, GatewayIntentBits, Message, VoiceChannel } from 'discord.js';
 import { initializeHealthServer } from '@starbunk/shared/health/health-server-init';
+import { setApplicationHealth } from '@starbunk/shared/observability/health-server';
 import { shutdownObservability } from '@starbunk/shared/observability/shutdown';
 import { initializeCommands } from '@starbunk/shared/discord/command-registry';
 import { getMetricsService } from '@starbunk/shared/observability/metrics-service';
@@ -80,6 +81,7 @@ async function main(): Promise<void> {
     logger.info('Initializing commands...');
     await initializeCommands(client, commands);
     logger.info('✅ DJCova commands initialized successfully');
+    setApplicationHealth('healthy');
 
     // E2E text command handler — only active when E2E_MODE=true
     if (isE2eMode) {

--- a/src/shared/src/index.ts
+++ b/src/shared/src/index.ts
@@ -32,6 +32,7 @@ export type {
 // Health and smoke testing
 export { runSmokeMode } from './health/smoke-mode';
 export { initializeHealthServer } from './health/health-server-init';
+export { setApplicationHealth } from './observability/health-server';
 export { shutdownObservability } from './observability/shutdown';
 
 // Types

--- a/src/shared/src/observability/health-server.ts
+++ b/src/shared/src/observability/health-server.ts
@@ -4,8 +4,27 @@ import { logLayer } from './log-layer';
 
 const logger = logLayer.withPrefix('HealthServer');
 
+type ApplicationHealthState = 'starting' | 'healthy' | 'unhealthy';
+
+interface ApplicationHealthInfo {
+  state: ApplicationHealthState;
+  reason?: string;
+}
+
+// Module-level health state — starts as 'starting' to prevent false positives during init.
+// Containers must call setApplicationHealth('healthy') after successful startup.
+let applicationHealth: ApplicationHealthInfo = { state: 'starting' };
+
 /**
- * Health and metrics HTTP server for BunkBot
+ * Update the application health state.
+ * Call with 'healthy' after successful startup, 'unhealthy' if startup fails.
+ */
+export function setApplicationHealth(state: ApplicationHealthState, reason?: string): void {
+  applicationHealth = { state, reason };
+}
+
+/**
+ * Health and metrics HTTP server
  * Provides endpoints for Prometheus scraping and health checks
  */
 export class HealthServer {
@@ -86,15 +105,31 @@ export class HealthServer {
 
   private handleHealth(req: http.IncomingMessage, res: http.ServerResponse): void {
     const uptime = Date.now() - this.startTime;
-    const health = {
-      status: 'healthy',
-      uptime: uptime,
-      timestamp: new Date().toISOString(),
-      service: 'bunkbot',
-    };
+    const serviceName = process.env.SERVICE_NAME || 'unknown';
+
+    if (applicationHealth.state !== 'healthy') {
+      res.writeHead(503, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          status: applicationHealth.state,
+          reason: applicationHealth.reason,
+          uptime,
+          timestamp: new Date().toISOString(),
+          service: serviceName,
+        }),
+      );
+      return;
+    }
 
     res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify(health));
+    res.end(
+      JSON.stringify({
+        status: 'healthy',
+        uptime,
+        timestamp: new Date().toISOString(),
+        service: serviceName,
+      }),
+    );
   }
 
   private handleLiveness(req: http.IncomingMessage, res: http.ServerResponse): void {


### PR DESCRIPTION
## Summary
- **Root cause of false-positive health checks**: The shared `HealthServer` returned `{ status: 'healthy', 200 }` unconditionally — even before the bot finished initializing. Docker would poll `/health` during the brief window when the health server was up but CovaBot had not yet (or could not) connect to the database, see 200, and mark the container healthy.
- **Fix**: Added startup state tracking to `health-server.ts`. The `/health` and `/ready` endpoints now return **503** with `{ status: 'starting' }` until a container explicitly calls `setApplicationHealth('healthy')` after successful startup. On startup failure, CovaBot calls `setApplicationHealth('unhealthy', error.message)` before `process.exit(1)`.
- **All four containers updated**: `covabot`, `bunkbot`, `bluebot`, and `djcova` now call `setApplicationHealth('healthy')` after their initialization completes. This means no container will ever report healthy before it's actually ready.
- **`/live` unchanged**: The liveness endpoint still returns 200 while the process is running — it's only a liveness probe, not a readiness/health probe.
- **Fixed hardcoded `service: 'bunkbot'`**: The health response now uses `process.env.SERVICE_NAME` so each container reports its own name.

## How this fixes the CovaBot crash loop
Before: health server starts → returns 200 → bot crashes (DB unreachable) → container restarts → health server returns 200 again during brief up window → Docker never marks it unhealthy.

After: health server starts → returns 503 (`starting`) → bot crashes → container restarts → still returns 503 → Docker accumulates failures → marks container **unhealthy** after `retries: 3`.

## Test plan
- [ ] Deploy CovaBot with a bad `POSTGRES_HOST` value and verify `/health` returns 503 throughout the crash loop
- [ ] Deploy CovaBot normally and verify `/health` returns 200 after successful startup
- [ ] Verify `/live` still returns 200 while process is running (liveness not affected)
- [ ] Verify other containers (bunkbot, bluebot, djcova) still report healthy after normal startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)