### PR TITLE
fix(covabot): fix ENOTFOUND starbunk-db and false-positive health checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -353,7 +353,9 @@ services:
     volumes:
       - ${HOST_WORKDIR}/data/postgres:/var/lib/postgresql/data
     networks:
-      - starbunk-network
+      starbunk-network:
+        aliases:
+          - starbunk-db  # backward-compat alias for deployments that still reference the old container name
     # No ports exposed - internal access only
     logging:
       driver: "json-file"

--- a/infrastructure/docker/docker-compose.yml
+++ b/infrastructure/docker/docker-compose.yml
@@ -372,7 +372,9 @@ services:
     volumes:
       - ${HOST_WORKDIR}/data/postgres:/var/lib/postgresql/data
     networks:
-      - starbunk-network
+      starbunk-network:
+        aliases:
+          - starbunk-db  # backward-compat alias for deployments that still reference the old container name
     # No ports exposed - internal access only
     logging:
       driver: "json-file"

--- a/src/bluebot/Dockerfile
+++ b/src/bluebot/Dockerfile
@@ -82,9 +82,9 @@ LABEL prometheus.io/path="/metrics"
 LABEL prometheus.io/port="3000"
 
 # Health check (prefers HEALTH_PORT, then METRICS_PORT, else defaults)
-# Uses /live endpoint for simpler health check (doesn't require Discord connection)
+# Uses /health endpoint to verify startup completed successfully (returns 503 during init or if startup failed)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD sh -c 'PORT="${METRICS_PORT:-3000}"; curl -fsS "http://127.0.0.1:${PORT}/live" || exit 1'
+    CMD sh -c 'PORT="${METRICS_PORT:-3000}"; curl -fsS "http://127.0.0.1:${PORT}/health" || exit 1'
 
 EXPOSE 3000
 

--- a/src/bluebot/src/index.ts
+++ b/src/bluebot/src/index.ts
@@ -5,6 +5,7 @@ import { logger } from '@/observability/logger';
 import { BlueBot } from '@/blue-bot';
 import { runSmokeTest } from '@starbunk/shared/health/smoke-test';
 import { initializeHealthServer } from '@starbunk/shared/health/health-server-init';
+import { setApplicationHealth } from '@starbunk/shared/observability/health-server';
 import { shutdownObservability } from '@starbunk/shared/observability/shutdown';
 import { getMetricsService } from '@starbunk/shared/observability/metrics-service';
 
@@ -60,6 +61,7 @@ async function main(): Promise<void> {
 
   const bot = new BlueBot(client);
   await bot.start();
+  setApplicationHealth('healthy');
 
   // Set up graceful shutdown handlers
   const shutdown = async (signal: string) => {

--- a/src/bunkbot/Dockerfile
+++ b/src/bunkbot/Dockerfile
@@ -79,8 +79,9 @@ LABEL prometheus.io/path="/metrics"
 LABEL prometheus.io/port="3000"
 
 # Health check using HTTP endpoint
+# Uses /health endpoint to verify startup completed successfully (returns 503 during init or if startup failed)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD sh -c 'PORT="${METRICS_PORT:-3000}"; curl -fsS "http://127.0.0.1:${PORT}/live" || exit 1'
+    CMD sh -c 'PORT="${METRICS_PORT:-3000}"; curl -fsS "http://127.0.0.1:${PORT}/health" || exit 1'
 
 # Expose metrics port
 EXPOSE 3000

--- a/src/bunkbot/src/index.ts
+++ b/src/bunkbot/src/index.ts
@@ -7,6 +7,7 @@ import { BunkBot } from '@/bunk-bot';
 import { runSmokeTest } from '@starbunk/shared/health/smoke-test';
 import { getMetricsService } from '@starbunk/shared/observability/metrics-service';
 import { initializeHealthServer } from '@starbunk/shared/health/health-server-init';
+import { setApplicationHealth } from '@starbunk/shared/observability/health-server';
 
 // Setup logging mixins before any logging occurs
 setupBunkBotLogging();
@@ -67,6 +68,7 @@ async function main() {
   // Create and initialize BunkBot
   const bunkBot = new BunkBot(client, metricsService, healthServer);
   await bunkBot.initialize();
+  setApplicationHealth('healthy');
 
   // Graceful shutdown
   const shutdown = async (signal: string) => {

--- a/src/covabot/Dockerfile
+++ b/src/covabot/Dockerfile
@@ -94,9 +94,9 @@ LABEL prometheus.io/path="/metrics"
 LABEL prometheus.io/port="3000"
 
 # Health check (prefers HEALTH_PORT, then METRICS_PORT, else defaults)
-# Uses /live endpoint for simpler health check (doesn't require Discord connection)
+# Uses /health endpoint to verify startup completed successfully (returns 503 during init or if startup failed)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD sh -c 'PORT="${HEALTH_PORT:-${METRICS_PORT:-3000}}"; curl -fsS "http://127.0.0.1:${PORT}/live" || exit 1'
+    CMD sh -c 'PORT="${HEALTH_PORT:-${METRICS_PORT:-3000}}"; curl -fsS "http://127.0.0.1:${PORT}/health" || exit 1'
 
 EXPOSE 3000 7080
 

--- a/src/covabot/src/index.ts
+++ b/src/covabot/src/index.ts
@@ -15,6 +15,7 @@ import { config } from 'dotenv';
 import { logLayer } from '@starbunk/shared/observability/log-layer';
 import { runSmokeMode } from '@starbunk/shared/health/smoke-mode';
 import { initializeHealthServer } from '@starbunk/shared/health/health-server-init';
+import { setApplicationHealth } from '@starbunk/shared/observability/health-server';
 import { shutdownObservability } from '@starbunk/shared/observability/shutdown';
 import { CovaBot, CovaBotConfig } from './cova-bot';
 
@@ -94,9 +95,11 @@ async function main(): Promise<void> {
 
   try {
     await bot.start();
+    setApplicationHealth('healthy');
     logger.info('CovaBot v2 is now running');
   } catch (error) {
     logger.withError(error).error('Failed to start CovaBot');
+    setApplicationHealth('unhealthy', error instanceof Error ? error.message : String(error));
     process.exit(1);
   }
 }

--- a/src/djcova/Dockerfile
+++ b/src/djcova/Dockerfile
@@ -94,9 +94,9 @@ LABEL prometheus.io/path="/metrics"
 LABEL prometheus.io/port="3000"
 
 # Health check (prefers HEALTH_PORT, then METRICS_PORT, else defaults)
-# Using /live endpoint for liveness check (simpler, doesn't fail on Discord connection issues)
+# Uses /health endpoint to verify startup completed successfully (returns 503 during init or if startup failed)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD sh -c 'PORT="${METRICS_PORT:-3000}"; curl -fsS "http://127.0.0.1:${PORT}/live" || exit 1'
+    CMD sh -c 'PORT="${METRICS_PORT:-3000}"; curl -fsS "http://127.0.0.1:${PORT}/health" || exit 1'
 
 EXPOSE 3000
 

--- a/src/djcova/src/index.ts
+++ b/src/djcova/src/index.ts
@@ -4,6 +4,7 @@ import { setupDJCovaLogging } from './observability/setup-logging';
 import { logger } from './observability/logger';
 import { Client, Events, GatewayIntentBits, Message, VoiceChannel } from 'discord.js';
 import { initializeHealthServer } from '@starbunk/shared/health/health-server-init';
+import { setApplicationHealth } from '@starbunk/shared/observability/health-server';
 import { shutdownObservability } from '@starbunk/shared/observability/shutdown';
 import { initializeCommands } from '@starbunk/shared/discord/command-registry';
 import { getMetricsService } from '@starbunk/shared/observability/metrics-service';
@@ -80,6 +81,7 @@ async function main(): Promise<void> {
     logger.info('Initializing commands...');
     await initializeCommands(client, commands);
     logger.info('✅ DJCova commands initialized successfully');
+    setApplicationHealth('healthy');
 
     // E2E text command handler — only active when E2E_MODE=true
     if (isE2eMode) {

--- a/src/shared/src/index.ts
+++ b/src/shared/src/index.ts
@@ -32,6 +32,7 @@ export type {
 // Health and smoke testing
 export { runSmokeMode } from './health/smoke-mode';
 export { initializeHealthServer } from './health/health-server-init';
+export { setApplicationHealth } from './observability/health-server';
 export { shutdownObservability } from './observability/shutdown';
 
 // Types

--- a/src/shared/src/observability/health-server.ts
+++ b/src/shared/src/observability/health-server.ts
@@ -4,8 +4,27 @@ import { logLayer } from './log-layer';
 
 const logger = logLayer.withPrefix('HealthServer');
 
+type ApplicationHealthState = 'starting' | 'healthy' | 'unhealthy';
+
+interface ApplicationHealthInfo {
+  state: ApplicationHealthState;
+  reason?: string;
+}
+
+// Module-level health state — starts as 'starting' to prevent false positives during init.
+// Containers must call setApplicationHealth('healthy') after successful startup.
+let applicationHealth: ApplicationHealthInfo = { state: 'starting' };
+
 /**
- * Health and metrics HTTP server for BunkBot
+ * Update the application health state.
+ * Call with 'healthy' after successful startup, 'unhealthy' if startup fails.
+ */
+export function setApplicationHealth(state: ApplicationHealthState, reason?: string): void {
+  applicationHealth = { state, reason };
+}
+
+/**
+ * Health and metrics HTTP server
  * Provides endpoints for Prometheus scraping and health checks
  */
 export class HealthServer {
@@ -86,15 +105,31 @@ export class HealthServer {
 
   private handleHealth(req: http.IncomingMessage, res: http.ServerResponse): void {
     const uptime = Date.now() - this.startTime;
-    const health = {
-      status: 'healthy',
-      uptime: uptime,
-      timestamp: new Date().toISOString(),
-      service: 'bunkbot',
-    };
+    const serviceName = process.env.SERVICE_NAME || 'unknown';
+
+    if (applicationHealth.state !== 'healthy') {
+      res.writeHead(503, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          status: applicationHealth.state,
+          reason: applicationHealth.reason,
+          uptime,
+          timestamp: new Date().toISOString(),
+          service: serviceName,
+        }),
+      );
+      return;
+    }
 
     res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify(health));
+    res.end(
+      JSON.stringify({
+        status: 'healthy',
+        uptime,
+        timestamp: new Date().toISOString(),
+        service: serviceName,
+      }),
+    );
   }
 
   private handleLiveness(req: http.IncomingMessage, res: http.ServerResponse): void {


### PR DESCRIPTION
## Summary

- **Add `starbunk-db` network alias** to the `starbunk-postgres` service in both `docker-compose.yml` and `infrastructure/docker/docker-compose.yml`. CovaBot containers still connecting with `POSTGRES_HOST=starbunk-db` (e.g. saved in Portainer from before PR #659 renamed the container) now resolve correctly without requiring a Portainer config update.

- **Fix Docker health check endpoint** in all 4 bot Dockerfiles: changed from `/live` → `/health`. The `/live` endpoint always returns 200 while the process is running, so Docker was showing containers as healthy even when CovaBot was stuck in a database-error crash loop. The `/health` endpoint returns 503 until `setApplicationHealth('healthy')` is called after successful startup (added in the previous commit on this branch).

## Root cause

`ENOTFOUND starbunk-db` — After PR #659 renamed the container from `starbunk-db` to `starbunk-postgres`, any deployment with the old hostname cached (e.g. Portainer stack environment) got DNS failures. The network alias makes `starbunk-db` resolvable again as a backward-compat bridge.

## Test plan
- [ ] Deploy updated stack — verify `starbunk-db` resolves to postgres container (no ENOTFOUND)
- [ ] Verify `curl http://localhost:3000/health` returns 503 during startup, 200 after bot is ready
- [ ] Verify Docker shows container status as `unhealthy` when CovaBot cannot connect to Postgres
- [ ] All CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)