### PR TITLE
feat(covabot): add verbose logging mode for decision visibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,6 +197,11 @@ services:
       - COVA_USER_ID=${COVA_USER_ID:-}
       - TESTING_SERVER_IDS=${TESTING_SERVER_IDS:-}
       - TESTING_CHANNEL_IDS=${TESTING_CHANNEL_IDS:-}
+
+      # Verbose decision logging (set to true to see why the bot speaks/stays silent at INFO level)
+      - COVABOT_VERBOSE=${COVABOT_VERBOSE:-false}
+      # Prompt-level logging (set to true to log raw LLM responses — very noisy)
+      - COVABOT_LOG_PROMPTS=${COVABOT_LOG_PROMPTS:-false}
     volumes:
       - ${HOST_WORKDIR}/config/covabot:/app/config:ro
       - ${HOST_WORKDIR}/data/covabot:/app/data

--- a/src/covabot/src/cova-bot.ts
+++ b/src/covabot/src/cova-bot.ts
@@ -29,6 +29,7 @@ import {
   getDefaultPersonalitiesPath,
 } from '@/serialization/personality-parser';
 import { EmbeddingManager } from '@/services/llm';
+import { VERBOSE_LOGGING } from '@/utils/verbose-mode';
 
 const logger = logLayer.withPrefix('CovaBot');
 
@@ -155,6 +156,59 @@ export class CovaBot {
     logger
       .withMetadata({ count: this.profiles.size, path: personalitiesPath })
       .info('Profiles loaded');
+
+    // Always audit personality data completeness — warns on startup if data is missing
+    for (const profile of this.profiles.values()) {
+      const issues: string[] = [];
+
+      if (
+        !profile.personality.systemPrompt ||
+        profile.personality.systemPrompt.trim().length < 50
+      ) {
+        issues.push(
+          `system_prompt too short or missing (${profile.personality.systemPrompt.length} chars)`,
+        );
+      }
+      if (profile.personality.traits.length === 0) {
+        issues.push('no traits defined');
+      }
+      if (profile.personality.topicAffinities.length === 0) {
+        issues.push('no topic_affinities defined');
+      }
+      if (profile.nameAliases.length === 0) {
+        issues.push('no name_aliases — bot will never detect name mentions');
+      }
+
+      if (issues.length > 0) {
+        logger
+          .withMetadata({
+            profile_id: profile.id,
+            display_name: profile.displayName,
+            issues,
+          })
+          .warn('Personality data incomplete');
+      } else if (VERBOSE_LOGGING) {
+        logger
+          .withMetadata({
+            profile_id: profile.id,
+            display_name: profile.displayName,
+            system_prompt_length: profile.personality.systemPrompt.length,
+            traits: profile.personality.traits,
+            topic_affinities: profile.personality.topicAffinities,
+            background_facts_count: profile.personality.backgroundFacts.length,
+            name_aliases: profile.nameAliases,
+            social_battery: profile.socialBattery,
+            llm_model: profile.llmConfig.model,
+          })
+          .info('Personality loaded OK');
+      }
+    }
+
+    if (VERBOSE_LOGGING) {
+      logger
+        .withMetadata({ verbose: true, log_prompts: process.env.COVABOT_LOG_PROMPTS === 'true' })
+        .info('COVABOT_VERBOSE=true — decision logging enabled at INFO level');
+    }
   }
 
   private async initializeServices(): Promise<void> {

--- a/src/covabot/src/handlers/message-handler.ts
+++ b/src/covabot/src/handlers/message-handler.ts
@@ -24,6 +24,7 @@ import {
   EngagementContext,
   LlmContext,
 } from '@/models/memory-types';
+import { VERBOSE_LOGGING } from '@/utils/verbose-mode';
 
 const logger = logLayer.withPrefix('MessageHandler');
 
@@ -115,12 +116,21 @@ export class MessageHandler {
     const decision = await this.decisionService.shouldRespond(ctx);
 
     if (!decision.shouldRespond) {
-      logger
-        .withMetadata({
-          profile_id: profile.id,
-          reason: decision.reason,
-        })
-        .debug('Decided not to respond');
+      if (VERBOSE_LOGGING) {
+        logger
+          .withMetadata({
+            profile_id: profile.id,
+            reason: decision.reason,
+            channel_id: message.channelId,
+            author: message.author.username,
+            content_preview: message.content.substring(0, 80),
+          })
+          .info('Not responding to message');
+      } else {
+        logger
+          .withMetadata({ profile_id: profile.id, reason: decision.reason })
+          .debug('Decided not to respond');
+      }
       return;
     }
 
@@ -128,7 +138,18 @@ export class MessageHandler {
     const llmResponse = await this.generateLlmResponse(profile, message, botUserId);
 
     if (llmResponse.shouldIgnore) {
-      logger.withMetadata({ profile_id: profile.id }).debug('LLM decided to ignore');
+      if (VERBOSE_LOGGING) {
+        logger
+          .withMetadata({
+            profile_id: profile.id,
+            channel_id: message.channelId,
+            author: message.author.username,
+            content_preview: message.content.substring(0, 80),
+          })
+          .info('LLM chose to stay silent (IGNORE)');
+      } else {
+        logger.withMetadata({ profile_id: profile.id }).debug('LLM decided to ignore');
+      }
       return;
     }
 
@@ -228,6 +249,28 @@ export class MessageHandler {
       channelContext,
       botUserId,
     );
+
+    if (VERBOSE_LOGGING) {
+      logger
+        .withMetadata({
+          profile_id: profile.id,
+          channel_id: message.channelId,
+          history_messages: channelContext.messages.length,
+          user_facts_length: userFactsStr.length,
+          has_trait_modifiers: !!traitModifiers,
+          was_mentioned: engagementContext.wasMentioned,
+          name_referenced: engagementContext.nameReferenced,
+          is_direct_exchange: engagementContext.isDirectExchange,
+          participants: engagementContext.activeParticipants,
+          seconds_since_last_response: engagementContext.secondsSinceLastResponse,
+          convo_message_count: engagementContext.conversationMessageCount,
+          system_prompt_length: profile.personality.systemPrompt.length,
+          traits_count: profile.personality.traits.length,
+          topic_affinities_count: profile.personality.topicAffinities.length,
+          background_facts_count: profile.personality.backgroundFacts.length,
+        })
+        .info('LLM context built — sending to model');
+    }
 
     return {
       systemPrompt: profile.personality.systemPrompt,

--- a/src/covabot/src/serialization/personality-parser.ts
+++ b/src/covabot/src/serialization/personality-parser.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as yaml from 'js-yaml';
 import { logLayer } from '@starbunk/shared/observability/log-layer';
 import type { CovaProfile } from '@/models/memory-types';
+import { VERBOSE_LOGGING } from '@/utils/verbose-mode';
 import {
   readDirectory,
   directoryExists,
@@ -105,15 +106,34 @@ const PERSONALITY_SECTIONS: Array<{ file: string; heading: string }> = [
  */
 function loadMarkdownSystemPrompt(dirPath: string): string {
   const sections: string[] = [];
+  const loaded: string[] = [];
+  const skipped: string[] = [];
 
   for (const { file, heading } of PERSONALITY_SECTIONS) {
     const filePath = path.join(dirPath, file);
-    if (!fileExists(filePath)) continue;
+    if (!fileExists(filePath)) {
+      skipped.push(file);
+      continue;
+    }
 
     const content = readFileUtf8(filePath).trim();
-    if (!content) continue;
+    if (!content) {
+      skipped.push(`${file} (empty)`);
+      continue;
+    }
 
     sections.push(heading ? `${heading}\n${content}` : content);
+    loaded.push(file);
+  }
+
+  if (VERBOSE_LOGGING) {
+    logger
+      .withMetadata({ dir: path.basename(dirPath), loaded, skipped })
+      .info('Markdown personality files loaded');
+  } else if (skipped.length > 0) {
+    logger
+      .withMetadata({ dir: path.basename(dirPath), skipped })
+      .debug('Some personality markdown files not found (optional)');
   }
 
   return sections.join('\n\n');

--- a/src/covabot/src/services/llm-service.ts
+++ b/src/covabot/src/services/llm-service.ts
@@ -17,6 +17,7 @@ import {
   IGNORE_CONVERSATION_MARKER,
 } from '@/models/memory-types';
 import { LlmProviderManager, LlmProviderConfig, LlmMessage } from '@starbunk/shared';
+import { VERBOSE_LOGGING, LOG_PROMPTS } from '@/utils/verbose-mode';
 
 const logger = logLayer.withPrefix('LlmService');
 
@@ -46,13 +47,29 @@ export class LlmService {
   ): Promise<LlmResponse> {
     const startTime = Date.now();
 
-    logger
-      .withMetadata({
-        profile_id: profile.id,
-        model: profile.llmConfig.model,
-        user_message_length: userMessage.length,
-      })
-      .debug('Generating LLM response');
+    if (VERBOSE_LOGGING) {
+      logger
+        .withMetadata({
+          profile_id: profile.id,
+          model: profile.llmConfig.model,
+          temperature: profile.llmConfig.temperature,
+          max_tokens: profile.llmConfig.max_tokens,
+          user: userName,
+          user_message_preview: userMessage.substring(0, 80),
+          has_system_prompt: profile.personality.systemPrompt.length > 0,
+          traits: profile.personality.traits,
+          topic_affinities: profile.personality.topicAffinities,
+        })
+        .info('Calling LLM');
+    } else {
+      logger
+        .withMetadata({
+          profile_id: profile.id,
+          model: profile.llmConfig.model,
+          user_message_length: userMessage.length,
+        })
+        .debug('Generating LLM response');
+    }
 
     // Build the full system prompt
     const systemPrompt = this.buildSystemPrompt(profile, context);
@@ -105,17 +122,52 @@ export class LlmService {
       // Apply speech pattern transformations
       const finalContent = shouldIgnore ? '' : this.applySpeechPatterns(responseContent, profile);
 
-      logger
-        .withMetadata({
-          profile_id: profile.id,
-          model: result.model,
-          provider: result.provider,
-          tokens_used: tokensUsed,
-          duration_ms: duration,
-          should_ignore: shouldIgnore,
-          response_length: finalContent.length,
-        })
-        .debug('LLM response generated');
+      if (VERBOSE_LOGGING) {
+        if (shouldIgnore) {
+          logger
+            .withMetadata({
+              profile_id: profile.id,
+              model: result.model,
+              provider: result.provider,
+              tokens_used: tokensUsed,
+              duration_ms: duration,
+            })
+            .info('LLM returned IGNORE — bot will stay silent');
+        } else {
+          logger
+            .withMetadata({
+              profile_id: profile.id,
+              model: result.model,
+              provider: result.provider,
+              tokens_used: tokensUsed,
+              duration_ms: duration,
+              response_length: finalContent.length,
+              response_preview: finalContent.substring(0, 100),
+            })
+            .info('LLM generated response');
+        }
+      } else {
+        logger
+          .withMetadata({
+            profile_id: profile.id,
+            model: result.model,
+            provider: result.provider,
+            tokens_used: tokensUsed,
+            duration_ms: duration,
+            should_ignore: shouldIgnore,
+            response_length: finalContent.length,
+          })
+          .debug('LLM response generated');
+      }
+
+      if (LOG_PROMPTS) {
+        logger
+          .withMetadata({
+            profile_id: profile.id,
+            raw_response: responseContent.substring(0, 500),
+          })
+          .info('[LOG_PROMPTS] Raw LLM response');
+      }
 
       return {
         content: finalContent,

--- a/src/covabot/src/services/response-decision-service.ts
+++ b/src/covabot/src/services/response-decision-service.ts
@@ -11,6 +11,7 @@ import { Message } from 'discord.js';
 import { logLayer } from '@starbunk/shared/observability/log-layer';
 import { SocialBatteryService, SocialBatteryConfig } from './social-battery-service';
 import { CovaProfile, ResponseDecision } from '@/models/memory-types';
+import { VERBOSE_LOGGING } from '@/utils/verbose-mode';
 
 const logger = logLayer.withPrefix('ResponseDecisionService');
 
@@ -52,7 +53,9 @@ export class ResponseDecisionService {
 
     // Step 2: Direct @mention — bypass rate limits, the user explicitly addressed us
     if (this.isDirectMention(message, botUserId)) {
-      logger.withMetadata({ profile_id: profile.id }).debug('Direct mention detected');
+      logger
+        .withMetadata({ profile_id: profile.id, channel_id: message.channelId })
+        .info('Direct mention — will respond');
       return { shouldRespond: true, reason: 'direct_mention' };
     }
 
@@ -70,18 +73,37 @@ export class ResponseDecisionService {
     );
 
     if (!batteryCheck.canSpeak) {
-      logger
-        .withMetadata({
-          profile_id: profile.id,
-          reason: batteryCheck.reason,
-          current_count: batteryCheck.currentCount,
-        })
-        .debug('Social battery depleted');
+      const meta = {
+        profile_id: profile.id,
+        channel_id: message.channelId,
+        battery_reason: batteryCheck.reason,
+        current_count: batteryCheck.currentCount,
+        max_allowed: batteryCheck.maxAllowed,
+        reset_in_seconds: batteryCheck.windowResetSeconds,
+      };
+      if (VERBOSE_LOGGING) {
+        logger.withMetadata(meta).info('Social battery depleted — not responding');
+      } else {
+        logger.withMetadata(meta).debug('Social battery depleted');
+      }
       return { shouldRespond: false, reason: 'ignored' };
     }
 
     // Step 4: Everything else — LLM decides via IGNORE marker with full context signals
-    logger.withMetadata({ profile_id: profile.id }).debug('Passing to LLM for engagement decision');
+    if (VERBOSE_LOGGING) {
+      logger
+        .withMetadata({
+          profile_id: profile.id,
+          channel_id: message.channelId,
+          battery_count: batteryCheck.currentCount,
+          battery_max: batteryCheck.maxAllowed,
+        })
+        .info('Battery OK — passing to LLM for engagement decision');
+    } else {
+      logger
+        .withMetadata({ profile_id: profile.id })
+        .debug('Passing to LLM for engagement decision');
+    }
     return { shouldRespond: true, reason: 'llm_response' };
   }
 
@@ -101,6 +123,17 @@ export class ResponseDecisionService {
     if (!message.content || message.content.trim().length === 0) {
       logger.withMetadata({ profile_id: profile.id }).debug('Ignoring empty message');
       return true;
+    }
+
+    if (VERBOSE_LOGGING) {
+      logger
+        .withMetadata({
+          profile_id: profile.id,
+          author: message.author.username,
+          channel_id: message.channelId,
+          content_preview: message.content.substring(0, 80),
+        })
+        .info('Message passed hard filters — evaluating');
     }
 
     return false;

--- a/src/covabot/src/services/social-battery-service.ts
+++ b/src/covabot/src/services/social-battery-service.ts
@@ -13,6 +13,7 @@
 import { logLayer } from '@starbunk/shared/observability/log-layer';
 import { SocialBatteryStateRow, SocialBatteryCheck } from '@/models/memory-types';
 import { SocialBatteryRepository } from '@/repositories/social-battery-repository';
+import { VERBOSE_LOGGING } from '@/utils/verbose-mode';
 
 const logger = logLayer.withPrefix('SocialBatteryService');
 
@@ -62,20 +63,27 @@ export class SocialBatteryService {
       const secondsSinceLastMessage = (now.getTime() - lastMessage.getTime()) / 1000;
 
       if (secondsSinceLastMessage < config.cooldownSeconds) {
-        logger
-          .withMetadata({
-            profile_id: profileId,
-            channel_id: channelId,
-            seconds_remaining: config.cooldownSeconds - secondsSinceLastMessage,
-          })
-          .debug('Cooldown active');
+        const secondsRemaining = Math.ceil(config.cooldownSeconds - secondsSinceLastMessage);
+        const meta = {
+          profile_id: profileId,
+          channel_id: channelId,
+          cooldown_seconds: config.cooldownSeconds,
+          seconds_remaining: secondsRemaining,
+        };
+        if (VERBOSE_LOGGING) {
+          logger
+            .withMetadata(meta)
+            .info(`Cooldown active — ${secondsRemaining}s remaining before next response`);
+        } else {
+          logger.withMetadata(meta).debug('Cooldown active');
+        }
 
         return {
           canSpeak: false,
           currentCount: state.message_count,
           maxAllowed: config.maxMessages,
           reason: 'cooldown',
-          windowResetSeconds: Math.ceil(config.cooldownSeconds - secondsSinceLastMessage),
+          windowResetSeconds: secondsRemaining,
         };
       }
     }
@@ -101,15 +109,23 @@ export class SocialBatteryService {
           config.windowMinutes * 60 - minutesSinceWindowStart * 60,
         );
 
-        logger
-          .withMetadata({
-            profile_id: profileId,
-            channel_id: channelId,
-            message_count: state.message_count,
-            max_messages: config.maxMessages,
-            window_reset_seconds: windowResetSeconds,
-          })
-          .debug('Rate limited');
+        const meta = {
+          profile_id: profileId,
+          channel_id: channelId,
+          message_count: state.message_count,
+          max_messages: config.maxMessages,
+          window_minutes: config.windowMinutes,
+          window_reset_seconds: windowResetSeconds,
+        };
+        if (VERBOSE_LOGGING) {
+          logger
+            .withMetadata(meta)
+            .info(
+              `Rate limited — sent ${state.message_count}/${config.maxMessages} messages this window, resets in ${windowResetSeconds}s`,
+            );
+        } else {
+          logger.withMetadata(meta).debug('Rate limited');
+        }
 
         return {
           canSpeak: false,

--- a/src/covabot/src/utils/verbose-mode.ts
+++ b/src/covabot/src/utils/verbose-mode.ts
@@ -1,0 +1,12 @@
+/**
+ * Verbose logging mode for CovaBot.
+ *
+ * Set COVABOT_VERBOSE=true to promote key decision logs from debug → info.
+ * This makes CovaBot's sociability reasoning visible without full debug noise.
+ *
+ * Additionally, set COVABOT_LOG_PROMPTS=true to log the raw LLM responses
+ * (very verbose — for deep prompt debugging only).
+ */
+
+export const VERBOSE_LOGGING = process.env.COVABOT_VERBOSE === 'true';
+export const LOG_PROMPTS = process.env.COVABOT_LOG_PROMPTS === 'true';


### PR DESCRIPTION
## Summary
- Adds `COVABOT_VERBOSE=true` env var that promotes CovaBot's silent decision-making logs from `debug` → `info`, making it visible why the bot is speaking or staying silent
- Adds `COVABOT_LOG_PROMPTS=true` for raw LLM response logging (deep debugging)
- Personality data completeness is always audited on startup — warns at `WARN` level if system prompt is too short, traits/topic affinities are missing, or name aliases aren't configured
- Both env vars are wired into `docker-compose.yml` defaulting to `false`

**What's now visible with `COVABOT_VERBOSE=true`:**
- Personality audit per profile at startup (traits, aliases, model, social battery config)
- Which markdown files (`core.md`, `speech.md`, etc.) loaded vs skipped
- Every \"not responding\" decision with reason, channel, author, message preview
- Social battery blocking with current count, max, and reset countdown
- Engagement context signals sent to the LLM (mentioned, name referenced, participants, seconds since last response)
- LLM IGNORE decisions (previously completely invisible)
- LLM response previews when the bot does speak

## Test plan
- [x] `npm run check:ci` passes (type-check, lint, 110 tests)
- [ ] Deploy with `COVABOT_VERBOSE=true` and confirm decision logs appear at INFO level in the log stream
- [ ] Confirm `COVABOT_VERBOSE=false` (default) keeps behavior unchanged — only debug logs
- [ ] Check startup logs for personality completeness warnings if any profile is missing data

🤖 Generated with [Claude Code](https://claude.com/claude-code)