### PR TITLE
fix(covabot): fix LLM provider model fallback and mention response

### DIFF
--- a/src/covabot/src/handlers/message-handler.ts
+++ b/src/covabot/src/handlers/message-handler.ts
@@ -138,7 +138,16 @@ export class MessageHandler {
     const llmResponse = await this.generateLlmResponse(profile, message, botUserId);
 
     if (llmResponse.shouldIgnore) {
-      if (VERBOSE_LOGGING) {
+      if (decision.reason === 'direct_mention') {
+        logger
+          .withMetadata({
+            profile_id: profile.id,
+            channel_id: message.channelId,
+            author: message.author.username,
+            content_preview: message.content.substring(0, 80),
+          })
+          .warn('LLM returned IGNORE for a direct @mention — this is a prompt compliance failure');
+      } else if (VERBOSE_LOGGING) {
         logger
           .withMetadata({
             profile_id: profile.id,

--- a/src/covabot/src/services/llm-service.ts
+++ b/src/covabot/src/services/llm-service.ts
@@ -268,9 +268,15 @@ export class LlmService {
 
     lines.push(`- Messages in window: ${ctx.conversationMessageCount}`);
 
-    lines.push(
-      `\nIf someone @mentioned you or referenced your name, they are almost certainly talking to you — respond. Otherwise, weigh the signals and use ${IGNORE_CONVERSATION_MARKER} when you have nothing genuine to add.`,
-    );
+    if (ctx.wasMentioned || ctx.nameReferenced) {
+      lines.push(
+        `\nYou were @mentioned or your name was used. Read the message carefully: if it contains a direct question, request, or is clearly addressed to you, respond. If you are mentioned only incidentally (e.g. someone talking about you rather than to you, or a quick "thanks @you"), use ${IGNORE_CONVERSATION_MARKER}.`,
+      );
+    } else {
+      lines.push(
+        `\nWeigh the signals above and use ${IGNORE_CONVERSATION_MARKER} when you have nothing genuine to add.`,
+      );
+    }
 
     return lines.join('\n');
   }

--- a/src/shared/src/services/llm/anthropic-provider.ts
+++ b/src/shared/src/services/llm/anthropic-provider.ts
@@ -51,10 +51,14 @@ export class AnthropicProvider implements LlmProvider {
       throw new Error('Anthropic API key not configured');
     }
 
-    const model = options.model || this.defaultModel;
+    const requestedModel = options.model;
+    const model =
+      requestedModel && requestedModel.startsWith('claude') ? requestedModel : this.defaultModel;
 
-    // Anthropic requires system prompt as a top-level field, not in the messages array
-    const systemMessage = messages.find(m => m.role === 'system')?.content;
+    // Anthropic requires system prompt as a single top-level field — concatenate all system
+    // messages so conversation history, user facts, and engagement context are all included.
+    const systemParts = messages.filter(m => m.role === 'system').map(m => m.content);
+    const systemMessage = systemParts.length > 0 ? systemParts.join('\n\n') : undefined;
     const conversationMessages: AnthropicMessage[] = messages
       .filter(m => m.role !== 'system')
       .map(m => ({ role: m.role as 'user' | 'assistant', content: m.content }));

--- a/src/shared/src/services/llm/gemini-provider.ts
+++ b/src/shared/src/services/llm/gemini-provider.ts
@@ -37,7 +37,9 @@ export class GeminiProvider implements LlmProvider {
       throw new Error('Gemini API key not configured');
     }
 
-    const model = options.model || this.defaultModel;
+    const requestedModel = options.model;
+    const model =
+      requestedModel && requestedModel.startsWith('gemini') ? requestedModel : this.defaultModel;
 
     logger
       .withMetadata({ model, messageCount: messages.length })

--- a/src/shared/src/services/llm/llm-provider.ts
+++ b/src/shared/src/services/llm/llm-provider.ts
@@ -13,7 +13,7 @@ export interface LlmMessage {
 }
 
 export interface LlmCompletionOptions {
-  model: string;
+  model?: string;
   temperature?: number;
   maxTokens?: number;
 }

--- a/src/shared/src/services/llm/openai-provider.ts
+++ b/src/shared/src/services/llm/openai-provider.ts
@@ -35,7 +35,14 @@ export class OpenAIProvider implements LlmProvider {
       throw new Error('OpenAI API key not configured');
     }
 
-    const model = options.model || this.defaultModel;
+    const requestedModel = options.model;
+    const model =
+      requestedModel &&
+      (requestedModel.startsWith('gpt-') ||
+        requestedModel.startsWith('o1') ||
+        requestedModel.startsWith('o3'))
+        ? requestedModel
+        : this.defaultModel;
 
     logger
       .withMetadata({ model, messageCount: messages.length })


### PR DESCRIPTION
## Summary

- **LLM provider model fallback**: Cloud providers (Gemini, Anthropic, OpenAI) were being passed the profile's `llm.model` value (e.g. `llama3`, `mistral`) which they rejected as unknown models — causing all fallback providers to fail when Ollama was unavailable. Each provider now validates the model name against its own prefix (`gemini-`, `claude-`, `gpt-`/`o1`/`o3`) before using it, falling back to its configured default otherwise.
- **AnthropicProvider system messages**: The Anthropic provider was only using the first `system` message and silently discarding the rest. Conversation history, user facts, and the engagement context (including direct `@mention` signals) were never reaching the model. Now concatenates all system messages into one before sending.
- **Direct mention engagement guidance**: The engagement block now gives the LLM clear, intent-based guidance — respond when it's a direct question or request, use `IGNORE` when the mention is incidental. Adds a `warn`-level log when the LLM returns `IGNORE` for a direct `@mention` so the compliance failure is visible in logs.

## Test plan

- [ ] `@mention` CovaBot with a direct question — should respond (Gemini fallback when Ollama is down)
- [ ] `@mention` CovaBot incidentally (e.g. "thanks @CovaBot") — may still choose `IGNORE`
- [ ] Check logs: no more "Provider failed, trying next" when only Ollama is down and Gemini key is configured
- [ ] `npm run check:ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)