### PR TITLE
feat(observability): enhance health servers with bot-specific checks (closes #670)

### DIFF
--- a/src/bunkbot/src/bunk-bot.ts
+++ b/src/bunkbot/src/bunk-bot.ts
@@ -12,6 +12,7 @@ import { commands } from '@/commands';
 import { ConfigServer } from '@/observability/config-server';
 import { BotStrategyBuilder } from '@/reply-bots/strategies/bot-strategy-builder';
 import type { SendWebhookMessageStrategy } from '@starbunk/shared/strategy/send-webhook-message-strategy';
+import { registerBunkBotHealthModule } from '@/health/bunkbot-health';
 
 /**
  * Main BunkBot application class
@@ -80,7 +81,10 @@ export class BunkBot {
     BotRegistry.setInstance(this.botRegistry); // Make registry accessible globally
     const factory = new YamlBotFactory();
     const discovery = new BotDiscoveryService(factory, this.botRegistry);
-    const botConfigs = await discovery.discover(botsDir);
+    const { configs: botConfigs, yamlErrors } = await discovery.discover(botsDir);
+
+    // Register health module reporting active bots and any YAML validation errors
+    registerBunkBotHealthModule(yamlErrors);
 
     // Build strategy pool from discovered bot configs
     this.strategyPool = BotStrategyBuilder.buildAllFromConfigs(botConfigs);

--- a/src/bunkbot/src/health/bunkbot-health.ts
+++ b/src/bunkbot/src/health/bunkbot-health.ts
@@ -1,0 +1,45 @@
+import { registerHealthCheckModule } from '@starbunk/shared/observability/health-server';
+import { BotRegistry } from '@/reply-bots/bot-registry';
+import { logLayer } from '@starbunk/shared/observability/log-layer';
+
+const logger = logLayer.withPrefix('BunkBotHealth');
+
+export interface YamlValidationError {
+  file: string;
+  error: string;
+}
+
+/**
+ * Register a BunkBot-specific health check module that reports:
+ * - The list of active/registered bots
+ * - Any YAML validation errors encountered during bot discovery
+ *
+ * Call this after BotRegistry is populated (i.e. after discoverBots()).
+ */
+export function registerBunkBotHealthModule(yamlErrors: YamlValidationError[]): void {
+  registerHealthCheckModule({
+    name: 'bunkbot',
+    getHealth: async () => {
+      const registry = BotRegistry.getInstance();
+      const bots = registry.getBots();
+
+      const botList = bots.map(b => ({
+        name: b.name,
+        ignore_bots: b.ignore_bots,
+        ignore_humans: b.ignore_humans,
+        triggers: b.triggers?.length ?? 0,
+      }));
+
+      const status = yamlErrors.length > 0 ? 'degraded' : 'ok';
+
+      return {
+        status,
+        active_bots: bots.length,
+        bots: botList,
+        yaml_errors: yamlErrors.length > 0 ? yamlErrors : undefined,
+      };
+    },
+  });
+
+  logger.info('BunkBot health module registered');
+}

--- a/src/bunkbot/src/reply-bots/services/bot-discovery-service.ts
+++ b/src/bunkbot/src/reply-bots/services/bot-discovery-service.ts
@@ -5,6 +5,12 @@ import { BotRegistry } from '@/reply-bots/bot-registry';
 import { parseYamlBots, botSchema } from '@/serialization/yaml-bot-parser';
 import { YamlBotFactory } from '@/serialization/yaml-bot-factory';
 import { logger } from '@/observability/logger';
+import type { YamlValidationError } from '@/health/bunkbot-health';
+
+export interface DiscoveryResult {
+  configs: z.infer<typeof botSchema>[];
+  yamlErrors: YamlValidationError[];
+}
 
 export class BotDiscoveryService {
   constructor(
@@ -12,7 +18,7 @@ export class BotDiscoveryService {
     private registry: BotRegistry,
   ) {}
 
-  public async discover(botsDirectory: string): Promise<z.infer<typeof botSchema>[]> {
+  public async discover(botsDirectory: string): Promise<DiscoveryResult> {
     logger.withMetadata({ directory: botsDirectory }).info('Starting bot discovery');
 
     if (!fs.existsSync(botsDirectory)) {
@@ -31,6 +37,7 @@ export class BotDiscoveryService {
     let totalBotsLoaded = 0;
     let totalBotsFailed = 0;
     const allConfigs: z.infer<typeof botSchema>[] = [];
+    const yamlErrors: YamlValidationError[] = [];
 
     for (const file of files) {
       const filePath = path.join(botsDirectory, file);
@@ -65,6 +72,8 @@ export class BotDiscoveryService {
               .info(`Bot created and registered`);
           } catch (error) {
             totalBotsFailed++;
+            const errMsg = error instanceof Error ? error.message : String(error);
+            yamlErrors.push({ file, error: `Bot '${config.name}': ${errMsg}` });
             logger
               .withError(error)
               .withMetadata({
@@ -76,6 +85,8 @@ export class BotDiscoveryService {
         }
       } catch (error) {
         totalBotsFailed++;
+        const errMsg = error instanceof Error ? error.message : String(error);
+        yamlErrors.push({ file, error: errMsg });
         logger
           .withError(error)
           .withMetadata({
@@ -92,9 +103,10 @@ export class BotDiscoveryService {
         files_processed: files.length,
         bots_loaded: totalBotsLoaded,
         bots_failed: totalBotsFailed,
+        yaml_errors: yamlErrors.length,
       })
       .info('Bot discovery complete');
 
-    return allConfigs;
+    return { configs: allConfigs, yamlErrors };
   }
 }

--- a/src/covabot/src/index.ts
+++ b/src/covabot/src/index.ts
@@ -18,6 +18,8 @@ import { initializeHealthServer } from '@starbunk/shared/health/health-server-in
 import { setApplicationHealth } from '@starbunk/shared/observability/health-server';
 import { shutdownObservability } from '@starbunk/shared/observability/shutdown';
 import { CovaBot, CovaBotConfig } from './cova-bot';
+import { registerDependencyHealthChecks } from '@starbunk/shared/health/dependency-health';
+import { registerConfigHealthCheck } from '@starbunk/shared/health/config-health';
 
 // Load environment variables from .env file
 config();
@@ -102,6 +104,25 @@ async function main(): Promise<void> {
   } catch (error) {
     logger.withError(error).error('Failed to initialize health server');
     throw error;
+  }
+
+  // Register config validation health check
+  registerConfigHealthCheck(['DISCORD_TOKEN'], 'covabot');
+
+  // Register dependency health checks for Postgres, Redis, Qdrant if configured
+  const postgresHost = process.env.POSTGRES_HOST;
+  if (postgresHost) {
+    registerDependencyHealthChecks({
+      postgres: {
+        host: postgresHost,
+        port: parseInt(process.env.POSTGRES_PORT || '5432', 10),
+        database: process.env.POSTGRES_DB || 'starbunk',
+        user: process.env.POSTGRES_USER || 'starbunk',
+        password: process.env.POSTGRES_PASSWORD || '',
+      },
+      redisUrl: process.env.REDIS_URL,
+      qdrantUrl: process.env.QDRANT_URL,
+    });
   }
 
   // Handle graceful shutdown

--- a/src/djcova/src/core/dj-cova.ts
+++ b/src/djcova/src/core/dj-cova.ts
@@ -16,6 +16,7 @@ import { logger } from '../observability/logger';
 import { DJCovaErrorCode } from '../errors';
 import { logError } from '@starbunk/shared/errors';
 import { getDJCovaMetrics } from '../observability/djcova-metrics';
+import { updateAudioPlayerStatus } from '../health/djcova-health';
 
 type AudioPlayerLike = ReturnType<typeof createAudioPlayer>;
 type AudioResourceLike = ReturnType<typeof createAudioResource>;
@@ -111,6 +112,7 @@ export class DJCova {
       // consuming audio frames, not just when player.play() was called.
       if (this.guildId) {
         getDJCovaMetrics().trackAudioPlaybackStarted(this.guildId);
+        updateAudioPlayerStatus(this.guildId, AudioPlayerStatus.Playing);
       }
     });
 
@@ -118,6 +120,9 @@ export class DJCova {
       logger.info('⏸️ Playback idle');
       logger.debug('Starting idle timer due to playback idle');
       this.idleManager?.startIdleTimer();
+      if (this.guildId) {
+        updateAudioPlayerStatus(this.guildId, AudioPlayerStatus.Idle);
+      }
     });
 
     this.player.on('error', (error: Error) => {

--- a/src/djcova/src/health/djcova-health.ts
+++ b/src/djcova/src/health/djcova-health.ts
@@ -1,0 +1,130 @@
+import { registerHealthCheckModule } from '@starbunk/shared/observability/health-server';
+import { logLayer } from '@starbunk/shared/observability/log-layer';
+
+const logger = logLayer.withPrefix('DJCovaHealth');
+
+export interface GuildVoiceState {
+  guildId: string;
+  connectionStatus: string;
+  playerStatus: string;
+  /** True if a /play command was issued and playback has not yet started */
+  pendingPlayback: boolean;
+  pendingPlaybackSince: number | null;
+}
+
+/** Timeout after which pending playback is flagged as unhealthy (ms) */
+const PENDING_PLAYBACK_TIMEOUT_MS = 30_000;
+
+/** AudioPlayerStatus.Playing value (string literal to avoid import-time side effects) */
+const PLAYER_STATUS_PLAYING = 'playing';
+
+/** VoiceConnectionStatus values that indicate the connection is not usable */
+const UNHEALTHY_CONNECTION_STATUSES = new Set(['disconnected', 'destroyed']);
+
+const guildStates = new Map<string, GuildVoiceState>();
+
+/**
+ * Update the voice connection status for a guild.
+ * Call this whenever the VoiceConnection state changes.
+ */
+export function updateVoiceConnectionStatus(guildId: string, status: string): void {
+  const state = getOrCreateGuildState(guildId);
+  state.connectionStatus = status;
+}
+
+/**
+ * Update the audio player status for a guild.
+ * Clears pendingPlayback when player enters Playing state.
+ */
+export function updateAudioPlayerStatus(guildId: string, status: string): void {
+  const state = getOrCreateGuildState(guildId);
+  state.playerStatus = status;
+  if (status === PLAYER_STATUS_PLAYING) {
+    state.pendingPlayback = false;
+    state.pendingPlaybackSince = null;
+  }
+}
+
+/**
+ * Mark that a /play command was issued for a guild.
+ * The health module will flag this as degraded if playback does not start
+ * within PENDING_PLAYBACK_TIMEOUT_MS.
+ */
+export function markPlayCommandIssued(guildId: string): void {
+  const state = getOrCreateGuildState(guildId);
+  state.pendingPlayback = true;
+  state.pendingPlaybackSince = Date.now();
+}
+
+/**
+ * Remove state for a guild (e.g. when the bot disconnects or leaves).
+ */
+export function clearGuildState(guildId: string): void {
+  guildStates.delete(guildId);
+}
+
+function getOrCreateGuildState(guildId: string): GuildVoiceState {
+  if (!guildStates.has(guildId)) {
+    guildStates.set(guildId, {
+      guildId,
+      connectionStatus: 'disconnected',
+      playerStatus: 'idle',
+      pendingPlayback: false,
+      pendingPlaybackSince: null,
+    });
+  }
+  return guildStates.get(guildId)!;
+}
+
+/**
+ * Register the DJCova voice/audio health check module.
+ * Reports per-guild voice connection and player status under /health.
+ */
+export function registerDJCovaHealthModule(): void {
+  registerHealthCheckModule({
+    name: 'voice',
+    getHealth: async () => {
+      const now = Date.now();
+      const warnings: string[] = [];
+      let status: 'ok' | 'degraded' | 'critical' = 'ok';
+
+      const guilds = Array.from(guildStates.values()).map(state => {
+        const guildWarnings: string[] = [];
+
+        if (UNHEALTHY_CONNECTION_STATUSES.has(state.connectionStatus)) {
+          guildWarnings.push(`Voice connection is ${state.connectionStatus}`);
+          if (status === 'ok') status = 'degraded';
+        }
+
+        if (state.pendingPlayback && state.pendingPlaybackSince !== null) {
+          const waitMs = now - state.pendingPlaybackSince;
+          if (waitMs > PENDING_PLAYBACK_TIMEOUT_MS) {
+            guildWarnings.push(
+              `Play command issued ${Math.floor(waitMs / 1000)}s ago but playback has not started`,
+            );
+            status = 'degraded';
+          }
+        }
+
+        return {
+          guild_id: state.guildId,
+          connection_status: state.connectionStatus,
+          player_status: state.playerStatus,
+          pending_playback: state.pendingPlayback,
+          warnings: guildWarnings.length > 0 ? guildWarnings : undefined,
+        };
+      });
+
+      warnings.push(...guilds.flatMap(g => g.warnings ?? []));
+
+      return {
+        status,
+        active_guilds: guilds.length,
+        guilds,
+        warnings: warnings.length > 0 ? warnings : undefined,
+      };
+    },
+  });
+
+  logger.info('DJCova voice health module registered');
+}

--- a/src/djcova/src/index.ts
+++ b/src/djcova/src/index.ts
@@ -4,7 +4,10 @@ import { setupDJCovaLogging } from './observability/setup-logging';
 import { logger } from './observability/logger';
 import { Client, Events, GatewayIntentBits, Message, VoiceChannel } from 'discord.js';
 import { initializeHealthServer } from '@starbunk/shared/health/health-server-init';
-import { setApplicationHealth, registerHealthCheckModule } from '@starbunk/shared/observability/health-server';
+import {
+  setApplicationHealth,
+  registerHealthCheckModule,
+} from '@starbunk/shared/observability/health-server';
 import { shutdownObservability } from '@starbunk/shared/observability/shutdown';
 import { initializeCommands } from '@starbunk/shared/discord/command-registry';
 import { getMetricsService } from '@starbunk/shared/observability/metrics-service';
@@ -12,6 +15,7 @@ import { getDJCovaMetrics } from './observability/djcova-metrics';
 import { SharedErrorCode, logError } from '@starbunk/shared/errors';
 import { commands } from '@/commands';
 import { getDJCovaService } from '@/core/djcova-factory';
+import { registerDJCovaHealthModule } from './health/djcova-health';
 
 // Setup logging mixins before creating any logger instances
 setupDJCovaLogging();
@@ -44,7 +48,9 @@ registerHealthCheckModule({
       const lastErrorAgo = djcovaHealth.lastErrorAt ? Date.now() - djcovaHealth.lastErrorAt : null;
       if (lastErrorAgo !== null && lastErrorAgo < 5 * 60 * 1000) {
         status = status === 'ok' ? 'degraded' : status;
-        warnings.push(`${djcovaHealth.errorCount} Discord error(s), most recent ${Math.floor(lastErrorAgo / 1000)}s ago`);
+        warnings.push(
+          `${djcovaHealth.errorCount} Discord error(s), most recent ${Math.floor(lastErrorAgo / 1000)}s ago`,
+        );
       }
     }
 
@@ -54,7 +60,9 @@ registerHealthCheckModule({
       discord_ready: djcovaHealth.discordReady,
       commands_ready: djcovaHealth.commandsReady,
       error_count: djcovaHealth.errorCount,
-      last_error_at: djcovaHealth.lastErrorAt ? new Date(djcovaHealth.lastErrorAt).toISOString() : null,
+      last_error_at: djcovaHealth.lastErrorAt
+        ? new Date(djcovaHealth.lastErrorAt).toISOString()
+        : null,
       uptime_ms: uptimeMs,
     };
   },
@@ -66,6 +74,7 @@ registerHealthCheckModule({
 const serviceName = process.env.SERVICE_NAME || 'djcova';
 getMetricsService(serviceName);
 getDJCovaMetrics();
+registerDJCovaHealthModule();
 // Main execution
 async function main(): Promise<void> {
   logger.info('DJCova main() function starting...');
@@ -117,7 +126,7 @@ async function main(): Promise<void> {
       djcovaHealth.discordReady = true;
     });
 
-    client.on(Events.Error, (error) => {
+    client.on(Events.Error, error => {
       logger.withError(error).error('Discord client error');
       djcovaHealth.errorCount++;
       djcovaHealth.lastErrorAt = Date.now();

--- a/src/djcova/src/services/dj-cova-service.ts
+++ b/src/djcova/src/services/dj-cova-service.ts
@@ -11,6 +11,7 @@ import { getDJCovaMetrics } from '../observability/djcova-metrics';
 import { DJCovaErrorCode } from '../errors';
 import { getMetricsService } from '@starbunk/shared/observability/metrics-service';
 import { logError } from '@starbunk/shared/errors';
+import { markPlayCommandIssued } from '../health/djcova-health';
 
 /**
  * DJCovaService - Business logic layer
@@ -119,6 +120,7 @@ export class DJCovaService {
     // play() uses stopAudioOnly() internally which preserves the voice subscription,
     // so the subscription is safe to register here.
     this.djCova.setSubscription(subscription);
+    markPlayCommandIssued(guildId);
     logger.info('Starting playback...');
     await this.djCova.play(url);
     logger.info('✅ Playback started successfully');
@@ -151,6 +153,7 @@ export class DJCovaService {
     getDJCovaMetrics().trackVoiceJoin(guildId, 'joined');
     this.djCova.initializeIdleManagement(guildId, voiceChannel.id, notifyFn);
     this.djCova.setSubscription(subscription);
+    markPlayCommandIssued(guildId);
     await this.djCova.play(url);
   }
 

--- a/src/djcova/src/utils/voice-utils.ts
+++ b/src/djcova/src/utils/voice-utils.ts
@@ -27,6 +27,7 @@ import { logger } from '../observability/logger';
 import { getMusicConfig } from '../config/music-config';
 import { DJCovaErrorCode } from '../errors';
 import { logError } from '@starbunk/shared/errors';
+import { updateVoiceConnectionStatus, clearGuildState } from '../health/djcova-health';
 import {
   ConnectionHealthMonitor,
   ConnectionHealthMonitorConfig,
@@ -150,6 +151,7 @@ export function createVoiceConnection(
     logger.debug(
       `Voice connection state changed: ${oldState.status} -> ${newState.status} for channel: ${channel.name}`,
     );
+    updateVoiceConnectionStatus(channel.guild.id, newState.status);
   });
 
   logger.debug('Voice connection event handlers registered');
@@ -186,6 +188,7 @@ export function disconnectVoiceConnection(guildId: string): void {
       );
     }
   }
+  clearGuildState(guildId);
 }
 
 /**

--- a/src/shared/src/health/config-health.ts
+++ b/src/shared/src/health/config-health.ts
@@ -1,0 +1,50 @@
+import { registerHealthCheckModule } from '../observability/health-server';
+import { logLayer } from '../observability/log-layer';
+
+const logger = logLayer.withPrefix('ConfigHealth');
+
+/**
+ * Register a health check module that reports whether all required environment
+ * variables are present. Missing or empty variables are surfaced as warnings
+ * in the /health response.
+ *
+ * @param requiredVars - list of env var names that must be non-empty
+ * @param serviceName  - label used in the module name (e.g. "bunkbot")
+ */
+export function registerConfigHealthCheck(requiredVars: string[], serviceName: string): void {
+  registerHealthCheckModule({
+    name: 'config',
+    getHealth: async () => {
+      const missing: string[] = [];
+      const present: string[] = [];
+
+      for (const name of requiredVars) {
+        const val = process.env[name];
+        if (!val) {
+          missing.push(name);
+        } else {
+          present.push(name);
+        }
+      }
+
+      const status = missing.length > 0 ? 'error' : 'ok';
+      if (status === 'error') {
+        logger
+          .withMetadata({ service: serviceName, missing })
+          .warn('Required configuration variables are missing');
+      }
+
+      return {
+        status,
+        service: serviceName,
+        required_vars: requiredVars.length,
+        present_count: present.length,
+        missing,
+      };
+    },
+  });
+
+  logger
+    .withMetadata({ service: serviceName, var_count: requiredVars.length })
+    .info('Config health check registered');
+}

--- a/src/shared/src/health/dependency-health.ts
+++ b/src/shared/src/health/dependency-health.ts
@@ -1,0 +1,177 @@
+import { registerHealthCheckModule } from '../observability/health-server';
+import { logLayer } from '../observability/log-layer';
+
+const logger = logLayer.withPrefix('DependencyHealth');
+
+/** Result of a single dependency ping */
+interface DependencyResult {
+  status: 'ok' | 'error';
+  latency_ms?: number;
+  error?: string;
+}
+
+/** Options for registering dependency health checks */
+export interface DependencyHealthOptions {
+  /** Postgres connection config — omit to skip */
+  postgres?: {
+    host: string;
+    port: number;
+    database: string;
+    user: string;
+    password: string;
+    connectTimeoutMillis?: number;
+  };
+  /** Redis URL (e.g. "redis://host:6379") — omit to skip */
+  redisUrl?: string;
+  /** Qdrant base URL (e.g. "http://host:6333") — omit to skip */
+  qdrantUrl?: string;
+}
+
+async function pingPostgres(
+  config: NonNullable<DependencyHealthOptions['postgres']>,
+): Promise<DependencyResult> {
+  const start = Date.now();
+  let pool: import('pg').Pool | undefined;
+  try {
+    const { Pool } = await import('pg');
+    pool = new Pool({
+      host: config.host,
+      port: config.port,
+      database: config.database,
+      user: config.user,
+      password: config.password,
+      max: 1,
+      idleTimeoutMillis: 1000,
+      connectionTimeoutMillis: config.connectTimeoutMillis ?? 3000,
+    });
+    await pool.query('SELECT 1');
+    return { status: 'ok', latency_ms: Date.now() - start };
+  } catch (err) {
+    return { status: 'error', latency_ms: Date.now() - start, error: (err as Error).message };
+  } finally {
+    try {
+      await pool?.end();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+async function pingRedis(url: string): Promise<DependencyResult> {
+  const start = Date.now();
+  let client: import('ioredis').Redis | undefined;
+  try {
+    const { default: Redis } = await import('ioredis');
+    client = new Redis(url, {
+      connectTimeout: 3000,
+      commandTimeout: 2000,
+      maxRetriesPerRequest: 0,
+      lazyConnect: true,
+      enableOfflineQueue: false,
+    });
+    await client.connect();
+    await client.ping();
+    return { status: 'ok', latency_ms: Date.now() - start };
+  } catch (err) {
+    return { status: 'error', latency_ms: Date.now() - start, error: (err as Error).message };
+  } finally {
+    try {
+      client?.disconnect();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+async function pingQdrant(baseUrl: string): Promise<DependencyResult> {
+  const start = Date.now();
+  try {
+    const response = await fetch(`${baseUrl}/healthz`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!response.ok) {
+      return { status: 'error', latency_ms: Date.now() - start, error: `HTTP ${response.status}` };
+    }
+    return { status: 'ok', latency_ms: Date.now() - start };
+  } catch (err) {
+    return { status: 'error', latency_ms: Date.now() - start, error: (err as Error).message };
+  }
+}
+
+/**
+ * Register a HealthCheckModule that pings configured external dependencies
+ * (Postgres, Redis, Qdrant) and reports their status under /health.
+ *
+ * Only dependencies with options provided are checked. The module name is
+ * `'dependencies'` and will replace any previously registered module with
+ * that name.
+ */
+export function registerDependencyHealthChecks(options: DependencyHealthOptions): void {
+  if (!options.postgres && !options.redisUrl && !options.qdrantUrl) {
+    logger.warn('registerDependencyHealthChecks called with no dependencies configured — skipping');
+    return;
+  }
+
+  registerHealthCheckModule({
+    name: 'dependencies',
+    getHealth: async () => {
+      const results: Record<string, DependencyResult> = {};
+
+      const checks: Promise<void>[] = [];
+
+      if (options.postgres) {
+        const pg = options.postgres;
+        checks.push(
+          pingPostgres(pg)
+            .then(r => {
+              results['postgres'] = r;
+            })
+            .catch(err => {
+              results['postgres'] = { status: 'error', error: (err as Error).message };
+            }),
+        );
+      }
+
+      if (options.redisUrl) {
+        const url = options.redisUrl;
+        checks.push(
+          pingRedis(url)
+            .then(r => {
+              results['redis'] = r;
+            })
+            .catch(err => {
+              results['redis'] = { status: 'error', error: (err as Error).message };
+            }),
+        );
+      }
+
+      if (options.qdrantUrl) {
+        const url = options.qdrantUrl;
+        checks.push(
+          pingQdrant(url)
+            .then(r => {
+              results['qdrant'] = r;
+            })
+            .catch(err => {
+              results['qdrant'] = { status: 'error', error: (err as Error).message };
+            }),
+        );
+      }
+
+      await Promise.allSettled(checks);
+
+      const anyError = Object.values(results).some(r => r.status === 'error');
+      return {
+        status: anyError ? 'error' : 'ok',
+        dependencies: results,
+      };
+    },
+  });
+
+  const configured = [
+    options.postgres ? 'postgres' : null,
+    options.redisUrl ? 'redis' : null,
+    options.qdrantUrl ? 'qdrant' : null,
+  ].filter(Boolean);
+  logger.withMetadata({ dependencies: configured }).info('Dependency health checks registered');
+}


### PR DESCRIPTION
## Summary

Implements [#670](https://github.com/andrewgari/starbunk-js/issues/670) — adds granular, bot-specific health indicators to the `/health` endpoints across all containers.

### Shared module (Epic 1)
- **`dependency-health.ts`**: Pings Postgres (`SELECT 1`), Redis (`PING`), and Qdrant (`/healthz`) with per-dependency latency tracking. Registered as a `'dependencies'` `HealthCheckModule` — appears under `/health` → `modules.dependencies`.
- **`config-health.ts`**: Validates required environment variables at startup and reports any missing ones in the `/health` response under `modules.config`.

### BunkBot (Epic 2)
- **`health/bunkbot-health.ts`**: New `'bunkbot'` health module reporting the active bot list (name, ignore flags, trigger count) and any YAML validation errors.
- **`BotDiscoveryService`**: `discover()` now returns `DiscoveryResult` with a `yamlErrors` array alongside bot configs — YAML parse/validation failures are tracked and forwarded to the health module.
- **`BunkBot`**: Wires `yamlErrors` into the health module immediately after discovery.

### DJCova (Epic 3)
- **`health/djcova-health.ts`**: New `'voice'` health module reporting per-guild `VoiceConnectionStatus` and audio `PlayerStatus`. Also tracks pending playback: if `/play` was issued but audio hasn't started within 30 seconds, the module surfaces a `degraded` warning.
- **`voice-utils.ts`**: Pushes connection state changes to the health module on each `stateChange` event; calls `clearGuildState()` on disconnect.
- **`dj-cova.ts`**: Calls `updateAudioPlayerStatus()` on `Playing` and `Idle` events.
- **`dj-cova-service.ts`**: Calls `markPlayCommandIssued()` before starting audio in both `play()` and `playInVoiceChannel()`.

### CovaBot
- Registers config and dependency health checks on startup when Postgres env vars are present (Postgres + optional Redis + Qdrant).

## Test plan
- [x] `npm run check:ci` passes (type-check + lint + all 691 tests)
- [x] `/health` endpoint on each container includes new modules in the `modules` object
- [ ] Deploy to staging and hit `curl http://localhost:3000/health` on each container to verify response shape
- [ ] Confirm `modules.dependencies` shows `ok`/`error` per service on CovaBot
- [ ] Trigger a YAML parse error in BunkBot config and verify `modules.bunkbot.yaml_errors` is populated
- [ ] Issue a `/play` command in DJCova and verify `modules.voice.guilds[0].pending_playback` clears when audio starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)