### PR TITLE
fix(ci): remove secrets from workflow if conditions (fixes failed CD runs)

### DIFF
--- a/.github/actions/discord-dm/action.yml
+++ b/.github/actions/discord-dm/action.yml
@@ -26,6 +26,12 @@ runs:
         USER_ID: ${{ inputs.user_id }}
         MESSAGE: ${{ inputs.message }}
       run: |
+        # Skip silently if either required value is missing
+        if [ -z "${BOT_TOKEN}" ] || [ -z "${USER_ID}" ]; then
+          echo "::warning::discord-dm: BOT_TOKEN or USER_ID not set — skipping notification"
+          exit 0
+        fi
+
         # Open (or reuse) a DM channel with the target user
         CHANNEL_RESPONSE=$(curl -sf -X POST \
           -H "Authorization: Bot ${BOT_TOKEN}" \

--- a/.github/actions/discord-dm/action.yml
+++ b/.github/actions/discord-dm/action.yml
@@ -1,0 +1,53 @@
+name: Send Discord DM
+description: >
+  Send a Direct Message to a specific user via the Discord bot API.
+  Never posts to any guild channel.
+  Fails silently (continue-on-error friendly) so notification errors
+  never block the parent workflow.
+
+inputs:
+  bot_token:
+    description: Discord bot token (the "Bot " prefix is added automatically)
+    required: true
+  user_id:
+    description: Target Discord user ID (enable Developer Mode → right-click username → Copy User ID)
+    required: true
+  message:
+    description: Message text to send (supports Discord markdown)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Send Discord DM
+      shell: bash
+      env:
+        BOT_TOKEN: ${{ inputs.bot_token }}
+        USER_ID: ${{ inputs.user_id }}
+        MESSAGE: ${{ inputs.message }}
+      run: |
+        # Open (or reuse) a DM channel with the target user
+        CHANNEL_RESPONSE=$(curl -sf -X POST \
+          -H "Authorization: Bot ${BOT_TOKEN}" \
+          -H "Content-Type: application/json" \
+          -d "{\"recipient_id\":\"${USER_ID}\"}" \
+          https://discord.com/api/v10/users/@me/channels 2>&1) || {
+          echo "::warning::discord-dm: failed to open DM channel (non-fatal)"
+          exit 0
+        }
+
+        CHANNEL_ID=$(echo "$CHANNEL_RESPONSE" | jq -r '.id // empty')
+        if [ -z "$CHANNEL_ID" ]; then
+          echo "::warning::discord-dm: could not extract channel ID from response: $CHANNEL_RESPONSE"
+          exit 0
+        fi
+
+        # JSON-encode the message so special characters are safe
+        MESSAGE_JSON=$(printf '%s' "$MESSAGE" | jq -Rs '.')
+
+        curl -sf -X POST \
+          -H "Authorization: Bot ${BOT_TOKEN}" \
+          -H "Content-Type: application/json" \
+          --data "{\"content\":${MESSAGE_JSON}}" \
+          "https://discord.com/api/v10/channels/${CHANNEL_ID}/messages" || \
+          echo "::warning::discord-dm: failed to send message (non-fatal)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
           echo "All images verified. Watchtower will pull and redeploy within 5 minutes."
 
       - name: Notify — deploy queued
-        if: success() && secrets.DISCORD_NOTIFY_TOKEN != '' && vars.DISCORD_NOTIFY_USER_ID != ''
+        if: success() && vars.DISCORD_NOTIFY_USER_ID != ''
         uses: ./.github/actions/discord-dm
         with:
           bot_token: ${{ secrets.DISCORD_NOTIFY_TOKEN }}
@@ -59,7 +59,7 @@ jobs:
             All images verified in GHCR. Watchtower will pull and restart containers within **5 minutes**.
 
       - name: Notify — verification failed
-        if: failure() && secrets.DISCORD_NOTIFY_TOKEN != '' && vars.DISCORD_NOTIFY_USER_ID != ''
+        if: failure() && vars.DISCORD_NOTIFY_USER_ID != ''
         uses: ./.github/actions/discord-dm
         with:
           bot_token: ${{ secrets.DISCORD_NOTIFY_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,8 @@ jobs:
     # Only run when triggered by a successful CD workflow, or manually
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - uses: actions/checkout@v6
+
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -46,25 +48,23 @@ jobs:
           fi
           echo "All images verified. Watchtower will pull and redeploy within 5 minutes."
 
-      - name: Notify Discord — deploy queued
-        if: success() && vars.DISCORD_WEBHOOK_URL != ''
-        uses: rjstone/discord-webhook-notify@v1
+      - name: Notify — deploy queued
+        if: success() && secrets.DISCORD_NOTIFY_TOKEN != '' && vars.DISCORD_NOTIFY_USER_ID != ''
+        uses: ./.github/actions/discord-dm
         with:
-          severity: info
-          text: "**Production deploy queued**"
-          details: >
-            🟢 All images verified in GHCR.
-            Watchtower will pull and restart containers within **5 minutes**.
-          webhookUrl: ${{ vars.DISCORD_WEBHOOK_URL }}
+          bot_token: ${{ secrets.DISCORD_NOTIFY_TOKEN }}
+          user_id: ${{ vars.DISCORD_NOTIFY_USER_ID }}
+          message: |
+            🟢 **Production deploy queued**
+            All images verified in GHCR. Watchtower will pull and restart containers within **5 minutes**.
 
-      - name: Notify Discord — image verification failed
-        if: failure() && vars.DISCORD_WEBHOOK_URL != ''
-        uses: rjstone/discord-webhook-notify@v1
+      - name: Notify — verification failed
+        if: failure() && secrets.DISCORD_NOTIFY_TOKEN != '' && vars.DISCORD_NOTIFY_USER_ID != ''
+        uses: ./.github/actions/discord-dm
         with:
-          severity: error
-          text: "**Deploy verification FAILED**"
-          details: >
-            ❌ One or more images could not be verified in GHCR.
-            Watchtower may not be able to pull the new images.
+          bot_token: ${{ secrets.DISCORD_NOTIFY_TOKEN }}
+          user_id: ${{ vars.DISCORD_NOTIFY_USER_ID }}
+          message: |
+            ❌ **Deploy verification FAILED**
+            One or more images could not be found in GHCR. Watchtower may not deploy the new version.
             — [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          webhookUrl: ${{ vars.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,3 +45,26 @@ jobs:
             exit 1
           fi
           echo "All images verified. Watchtower will pull and redeploy within 5 minutes."
+
+      - name: Notify Discord — deploy queued
+        if: success() && vars.DISCORD_WEBHOOK_URL != ''
+        uses: rjstone/discord-webhook-notify@v1
+        with:
+          severity: info
+          text: "**Production deploy queued**"
+          details: >
+            🟢 All images verified in GHCR.
+            Watchtower will pull and restart containers within **5 minutes**.
+          webhookUrl: ${{ vars.DISCORD_WEBHOOK_URL }}
+
+      - name: Notify Discord — image verification failed
+        if: failure() && vars.DISCORD_WEBHOOK_URL != ''
+        uses: rjstone/discord-webhook-notify@v1
+        with:
+          severity: error
+          text: "**Deploy verification FAILED**"
+          details: >
+            ❌ One or more images could not be verified in GHCR.
+            Watchtower may not be able to pull the new images.
+            — [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          webhookUrl: ${{ vars.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,17 +18,16 @@ jobs:
       - name: Set short SHA
         run: echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 
-      - name: Notify Discord — build started
-        if: vars.DISCORD_WEBHOOK_URL != ''
-        uses: rjstone/discord-webhook-notify@v1
+      - name: Notify — build started
+        if: secrets.DISCORD_NOTIFY_TOKEN != '' && vars.DISCORD_NOTIFY_USER_ID != ''
+        uses: ./.github/actions/discord-dm
         with:
-          severity: info
-          text: "**CD Pipeline started**"
-          details: >
-            🔨 Building `${{ github.event.head_commit.message }}`
-            by **${{ github.actor }}** (`${{ env.SHORT_SHA }}`)
-            — [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          webhookUrl: ${{ vars.DISCORD_WEBHOOK_URL }}
+          bot_token: ${{ secrets.DISCORD_NOTIFY_TOKEN }}
+          user_id: ${{ vars.DISCORD_NOTIFY_USER_ID }}
+          message: |
+            🔨 **Build started** (`${{ env.SHORT_SHA }}`)
+            > ${{ github.event.head_commit.message }}
+            Triggered by **${{ github.actor }}** — [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -117,33 +116,34 @@ jobs:
     name: Notify Images Published
     runs-on: ubuntu-latest
     needs: docker_publish
-    if: always() && vars.DISCORD_WEBHOOK_URL != ''
+    if: always() && secrets.DISCORD_NOTIFY_TOKEN != '' && vars.DISCORD_NOTIFY_USER_ID != ''
     steps:
+      - uses: actions/checkout@v6
+
       - name: Set short SHA
         run: echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 
-      - name: Notify Discord — images published
+      - name: Notify — images published
         if: needs.docker_publish.result == 'success'
-        uses: rjstone/discord-webhook-notify@v1
+        uses: ./.github/actions/discord-dm
         with:
-          severity: info
-          text: "**Docker images ready**"
-          details: >
-            🐳 All 4 images (bunkbot, covabot, djcova, bluebot) pushed to GHCR
-            as `:main` and `:sha-${{ env.SHORT_SHA }}`
+          bot_token: ${{ secrets.DISCORD_NOTIFY_TOKEN }}
+          user_id: ${{ vars.DISCORD_NOTIFY_USER_ID }}
+          message: |
+            🐳 **Docker images published** (`${{ env.SHORT_SHA }}`)
+            All 4 images (bunkbot, covabot, djcova, bluebot) pushed to GHCR as `:main` and `:sha-${{ env.SHORT_SHA }}`
             — [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          webhookUrl: ${{ vars.DISCORD_WEBHOOK_URL }}
 
-      - name: Notify Discord — images failed
+      - name: Notify — images failed
         if: needs.docker_publish.result == 'failure'
-        uses: rjstone/discord-webhook-notify@v1
+        uses: ./.github/actions/discord-dm
         with:
-          severity: error
-          text: "**Docker publish FAILED**"
-          details: >
-            ❌ One or more Docker images failed to publish.
+          bot_token: ${{ secrets.DISCORD_NOTIFY_TOKEN }}
+          user_id: ${{ vars.DISCORD_NOTIFY_USER_ID }}
+          message: |
+            ❌ **Docker publish FAILED** (`${{ env.SHORT_SHA }}`)
+            One or more images failed to build or push.
             — [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          webhookUrl: ${{ vars.DISCORD_WEBHOOK_URL }}
 
   e2e_tests:
     name: E2E Tests
@@ -226,27 +226,26 @@ jobs:
         if: always()
         run: docker compose -f docker-compose.e2e.yml down -v
 
-      - name: Notify Discord — E2E passed
-        if: success() && vars.DISCORD_WEBHOOK_URL != ''
-        uses: rjstone/discord-webhook-notify@v1
+      - name: Notify — E2E passed
+        if: success() && secrets.DISCORD_NOTIFY_TOKEN != '' && vars.DISCORD_NOTIFY_USER_ID != ''
+        uses: ./.github/actions/discord-dm
         with:
-          severity: info
-          text: "**E2E tests passed**"
-          details: >
-            ✅ All end-to-end tests passed against the `:main` images.
+          bot_token: ${{ secrets.DISCORD_NOTIFY_TOKEN }}
+          user_id: ${{ vars.DISCORD_NOTIFY_USER_ID }}
+          message: |
+            ✅ **E2E tests passed**
+            All end-to-end tests passed against the `:main` images.
             — [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          webhookUrl: ${{ vars.DISCORD_WEBHOOK_URL }}
 
-      - name: Notify Discord — E2E failed
-        if: failure() && vars.DISCORD_WEBHOOK_URL != ''
-        uses: rjstone/discord-webhook-notify@v1
+      - name: Notify — E2E failed
+        if: failure() && secrets.DISCORD_NOTIFY_TOKEN != '' && vars.DISCORD_NOTIFY_USER_ID != ''
+        uses: ./.github/actions/discord-dm
         with:
-          severity: error
-          text: "**E2E tests FAILED**"
-          details: >
-            ❌ End-to-end tests failed — deploy is blocked.
+          bot_token: ${{ secrets.DISCORD_NOTIFY_TOKEN }}
+          user_id: ${{ vars.DISCORD_NOTIFY_USER_ID }}
+          message: |
+            ❌ **E2E tests FAILED** — deploy is blocked
             — [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          webhookUrl: ${{ vars.DISCORD_WEBHOOK_URL }}
 
   publish_releases:
     name: Publish Releases
@@ -321,26 +320,24 @@ jobs:
           echo "tag=$BUILD_TAG" >> $GITHUB_OUTPUT
           echo "No semantic release — created build tag: ${BUILD_TAG}"
 
-      - name: Notify Discord — new version released
-        if: steps.semrel.outputs.new_version != '' && vars.DISCORD_WEBHOOK_URL != ''
-        uses: rjstone/discord-webhook-notify@v1
+      - name: Notify — new version released
+        if: steps.semrel.outputs.new_version != '' && secrets.DISCORD_NOTIFY_TOKEN != '' && vars.DISCORD_NOTIFY_USER_ID != ''
+        uses: ./.github/actions/discord-dm
         with:
-          severity: info
-          text: "**New release published**"
-          details: >
-            🚀 Version **v${{ steps.semrel.outputs.new_version }}** released and images tagged.
-            Watchtower will deploy within 5 minutes.
+          bot_token: ${{ secrets.DISCORD_NOTIFY_TOKEN }}
+          user_id: ${{ vars.DISCORD_NOTIFY_USER_ID }}
+          message: |
+            🚀 **v${{ steps.semrel.outputs.new_version }} released**
+            Images tagged and pushed. Watchtower will deploy within 5 minutes.
             — [View release](${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ steps.semrel.outputs.new_version }})
-          webhookUrl: ${{ vars.DISCORD_WEBHOOK_URL }}
 
-      - name: Notify Discord — build tagged
-        if: steps.semrel.outputs.new_version == '' && vars.DISCORD_WEBHOOK_URL != ''
-        uses: rjstone/discord-webhook-notify@v1
+      - name: Notify — build tagged
+        if: steps.semrel.outputs.new_version == '' && secrets.DISCORD_NOTIFY_TOKEN != '' && vars.DISCORD_NOTIFY_USER_ID != ''
+        uses: ./.github/actions/discord-dm
         with:
-          severity: info
-          text: "**Build tagged (no version bump)**"
-          details: >
-            🏷️ No version bump — build tag `${{ steps.build_tag.outputs.tag }}` created.
-            Watchtower will deploy the `:latest` images within 5 minutes.
+          bot_token: ${{ secrets.DISCORD_NOTIFY_TOKEN }}
+          user_id: ${{ vars.DISCORD_NOTIFY_USER_ID }}
+          message: |
+            🏷️ **Build tagged** (`${{ steps.build_tag.outputs.tag }}`)
+            No version bump. Watchtower will deploy `:latest` within 5 minutes.
             — [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          webhookUrl: ${{ vars.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 
       - name: Notify — build started
-        if: secrets.DISCORD_NOTIFY_TOKEN != '' && vars.DISCORD_NOTIFY_USER_ID != ''
+        if: vars.DISCORD_NOTIFY_USER_ID != ''
         uses: ./.github/actions/discord-dm
         with:
           bot_token: ${{ secrets.DISCORD_NOTIFY_TOKEN }}
@@ -116,7 +116,7 @@ jobs:
     name: Notify Images Published
     runs-on: ubuntu-latest
     needs: docker_publish
-    if: always() && secrets.DISCORD_NOTIFY_TOKEN != '' && vars.DISCORD_NOTIFY_USER_ID != ''
+    if: always() && vars.DISCORD_NOTIFY_USER_ID != ''
     steps:
       - uses: actions/checkout@v6
 
@@ -227,7 +227,7 @@ jobs:
         run: docker compose -f docker-compose.e2e.yml down -v
 
       - name: Notify — E2E passed
-        if: success() && secrets.DISCORD_NOTIFY_TOKEN != '' && vars.DISCORD_NOTIFY_USER_ID != ''
+        if: success() && vars.DISCORD_NOTIFY_USER_ID != ''
         uses: ./.github/actions/discord-dm
         with:
           bot_token: ${{ secrets.DISCORD_NOTIFY_TOKEN }}
@@ -238,7 +238,7 @@ jobs:
             — [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
       - name: Notify — E2E failed
-        if: failure() && secrets.DISCORD_NOTIFY_TOKEN != '' && vars.DISCORD_NOTIFY_USER_ID != ''
+        if: failure() && vars.DISCORD_NOTIFY_USER_ID != ''
         uses: ./.github/actions/discord-dm
         with:
           bot_token: ${{ secrets.DISCORD_NOTIFY_TOKEN }}
@@ -321,7 +321,7 @@ jobs:
           echo "No semantic release — created build tag: ${BUILD_TAG}"
 
       - name: Notify — new version released
-        if: steps.semrel.outputs.new_version != '' && secrets.DISCORD_NOTIFY_TOKEN != '' && vars.DISCORD_NOTIFY_USER_ID != ''
+        if: steps.semrel.outputs.new_version != '' && vars.DISCORD_NOTIFY_USER_ID != ''
         uses: ./.github/actions/discord-dm
         with:
           bot_token: ${{ secrets.DISCORD_NOTIFY_TOKEN }}
@@ -332,7 +332,7 @@ jobs:
             — [View release](${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ steps.semrel.outputs.new_version }})
 
       - name: Notify — build tagged
-        if: steps.semrel.outputs.new_version == '' && secrets.DISCORD_NOTIFY_TOKEN != '' && vars.DISCORD_NOTIFY_USER_ID != ''
+        if: steps.semrel.outputs.new_version == '' && vars.DISCORD_NOTIFY_USER_ID != ''
         uses: ./.github/actions/discord-dm
         with:
           bot_token: ${{ secrets.DISCORD_NOTIFY_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Set short SHA
+        run: echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+
+      - name: Notify Discord — build started
+        if: vars.DISCORD_WEBHOOK_URL != ''
+        uses: rjstone/discord-webhook-notify@v1
+        with:
+          severity: info
+          text: "**CD Pipeline started**"
+          details: >
+            🔨 Building `${{ github.event.head_commit.message }}`
+            by **${{ github.actor }}** (`${{ env.SHORT_SHA }}`)
+            — [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          webhookUrl: ${{ vars.DISCORD_WEBHOOK_URL }}
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -55,7 +71,7 @@ jobs:
           name: build-artifacts
       - name: Extract artifacts
         run: tar -xzf build-artifacts.tar.gz
-      
+
       - name: Compute content hash
         id: compute_hash
         run: |
@@ -96,6 +112,38 @@ jobs:
           docker tag "${IMAGE}:main" "${IMAGE}:sha-${GIT_SHA}"
           docker push "${IMAGE}:main"
           docker push "${IMAGE}:sha-${GIT_SHA}"
+
+  notify_images_published:
+    name: Notify Images Published
+    runs-on: ubuntu-latest
+    needs: docker_publish
+    if: always() && vars.DISCORD_WEBHOOK_URL != ''
+    steps:
+      - name: Set short SHA
+        run: echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+
+      - name: Notify Discord — images published
+        if: needs.docker_publish.result == 'success'
+        uses: rjstone/discord-webhook-notify@v1
+        with:
+          severity: info
+          text: "**Docker images ready**"
+          details: >
+            🐳 All 4 images (bunkbot, covabot, djcova, bluebot) pushed to GHCR
+            as `:main` and `:sha-${{ env.SHORT_SHA }}`
+            — [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          webhookUrl: ${{ vars.DISCORD_WEBHOOK_URL }}
+
+      - name: Notify Discord — images failed
+        if: needs.docker_publish.result == 'failure'
+        uses: rjstone/discord-webhook-notify@v1
+        with:
+          severity: error
+          text: "**Docker publish FAILED**"
+          details: >
+            ❌ One or more Docker images failed to publish.
+            — [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          webhookUrl: ${{ vars.DISCORD_WEBHOOK_URL }}
 
   e2e_tests:
     name: E2E Tests
@@ -178,6 +226,28 @@ jobs:
         if: always()
         run: docker compose -f docker-compose.e2e.yml down -v
 
+      - name: Notify Discord — E2E passed
+        if: success() && vars.DISCORD_WEBHOOK_URL != ''
+        uses: rjstone/discord-webhook-notify@v1
+        with:
+          severity: info
+          text: "**E2E tests passed**"
+          details: >
+            ✅ All end-to-end tests passed against the `:main` images.
+            — [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          webhookUrl: ${{ vars.DISCORD_WEBHOOK_URL }}
+
+      - name: Notify Discord — E2E failed
+        if: failure() && vars.DISCORD_WEBHOOK_URL != ''
+        uses: rjstone/discord-webhook-notify@v1
+        with:
+          severity: error
+          text: "**E2E tests FAILED**"
+          details: >
+            ❌ End-to-end tests failed — deploy is blocked.
+            — [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          webhookUrl: ${{ vars.DISCORD_WEBHOOK_URL }}
+
   publish_releases:
     name: Publish Releases
     runs-on: ubuntu-latest
@@ -240,6 +310,7 @@ jobs:
           done
 
       - name: Create build tag (no semantic release)
+        id: build_tag
         if: steps.semrel.outputs.new_version == ''
         run: |
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -247,4 +318,29 @@ jobs:
           BUILD_TAG="build-$(date +%Y%m%d)-${GITHUB_SHA:0:7}"
           git tag "$BUILD_TAG" -m "CI build ${GITHUB_RUN_NUMBER} from ${GITHUB_SHA:0:7}"
           git push origin "$BUILD_TAG"
+          echo "tag=$BUILD_TAG" >> $GITHUB_OUTPUT
           echo "No semantic release — created build tag: ${BUILD_TAG}"
+
+      - name: Notify Discord — new version released
+        if: steps.semrel.outputs.new_version != '' && vars.DISCORD_WEBHOOK_URL != ''
+        uses: rjstone/discord-webhook-notify@v1
+        with:
+          severity: info
+          text: "**New release published**"
+          details: >
+            🚀 Version **v${{ steps.semrel.outputs.new_version }}** released and images tagged.
+            Watchtower will deploy within 5 minutes.
+            — [View release](${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ steps.semrel.outputs.new_version }})
+          webhookUrl: ${{ vars.DISCORD_WEBHOOK_URL }}
+
+      - name: Notify Discord — build tagged
+        if: steps.semrel.outputs.new_version == '' && vars.DISCORD_WEBHOOK_URL != ''
+        uses: rjstone/discord-webhook-notify@v1
+        with:
+          severity: info
+          text: "**Build tagged (no version bump)**"
+          details: >
+            🏷️ No version bump — build tag `${{ steps.build_tag.outputs.tag }}` created.
+            Watchtower will deploy the `:latest` images within 5 minutes.
+            — [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          webhookUrl: ${{ vars.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary

Fixes the two failed workflow runs after #677 merged.

**Root cause:** GitHub forbids `secrets` context in job-level `if:` conditions, and its behaviour in step-level `if:` is unreliable. Both `main.yml` and `deploy.yml` had conditions like:

```yaml
if: always() && secrets.DISCORD_NOTIFY_TOKEN != '' && ...  # job level — invalid
if: success() && secrets.DISCORD_NOTIFY_TOKEN != '' && ...  # step level — unreliable
```

GitHub reports this as a "workflow file issue" and the run fails at parse time with 0s duration.

**Fix:** Remove all `secrets.DISCORD_NOTIFY_TOKEN != ''` guards from `if:` expressions. The only guard needed is `vars.DISCORD_NOTIFY_USER_ID != ''` (vars are always valid in `if:`). The composite action itself now explicitly checks for an empty `BOT_TOKEN` and exits 0 silently, so a missing secret is handled gracefully at runtime rather than in the expression.

## Test plan
- [ ] Merge and confirm both `main.yml` and `deploy.yml` parse and run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)