### PR TITLE
feat(bots): send Discord DM when a bot starts after a version update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,7 +106,10 @@ jobs:
             docker tag "${IMAGE}:sha-${HASH}" "${IMAGE}:main"
           else
             echo "Building image ${IMAGE}:main"
-            docker build -f ./src/${APP}/Dockerfile.ci -t ${IMAGE}:main -t ${IMAGE}:sha-${HASH} .
+            APP_VERSION=$(cat VERSION 2>/dev/null || echo "dev")
+            docker build -f ./src/${APP}/Dockerfile.ci \
+              --build-arg APP_VERSION="${APP_VERSION}" \
+              -t ${IMAGE}:main -t ${IMAGE}:sha-${HASH} .
             docker push ${IMAGE}:sha-${HASH}
           fi
           docker tag "${IMAGE}:main" "${IMAGE}:sha-${GIT_SHA}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,12 @@ services:
       - DEBUG_MODE=${DEBUG_MODE:-false}
       - TESTING_SERVER_IDS=${TESTING_SERVER_IDS:-}
       - TESTING_CHANNEL_IDS=${TESTING_CHANNEL_IDS:-}
+
+      # Startup notifications
+      - DISCORD_NOTIFY_USER_ID=${DISCORD_NOTIFY_USER_ID:-}
     volumes:
       - ${HOST_WORKDIR}/config/bunkbot:/app/config:ro
+      - ${HOST_WORKDIR}/data/bunkbot:/app/data
     ports:
       - "${BUNKBOT_WEB_PORT:-7081}:7081"
     networks:
@@ -104,6 +108,10 @@ services:
       - DEBUG_MODE=${DEBUG_MODE:-false}
       - TESTING_SERVER_IDS=${TESTING_SERVER_IDS:-}
       - TESTING_CHANNEL_IDS=${TESTING_CHANNEL_IDS:-}
+
+      # Startup notifications (data dir is /data for djcova, not /app/data)
+      - DISCORD_NOTIFY_USER_ID=${DISCORD_NOTIFY_USER_ID:-}
+      - STARTUP_DM_DATA_DIR=/data
     volumes:
       - ${HOST_WORKDIR}/config/djcova:/app/config:ro
       - ${HOST_WORKDIR}/data/djcova:/data
@@ -207,6 +215,9 @@ services:
       - COVABOT_VERBOSE=${COVABOT_VERBOSE:-false}
       # Prompt-level logging (set to true to log raw LLM responses — very noisy)
       - COVABOT_LOG_PROMPTS=${COVABOT_LOG_PROMPTS:-false}
+
+      # Startup notifications
+      - DISCORD_NOTIFY_USER_ID=${DISCORD_NOTIFY_USER_ID:-}
     volumes:
       - ${HOST_WORKDIR}/config/covabot:/app/config:ro
       - ${HOST_WORKDIR}/data/covabot:/app/data
@@ -279,6 +290,9 @@ services:
       - DEBUG_MODE=${DEBUG_MODE:-false}
       - TESTING_SERVER_IDS=${TESTING_SERVER_IDS:-}
       - TESTING_CHANNEL_IDS=${TESTING_CHANNEL_IDS:-}
+
+      # Startup notifications
+      - DISCORD_NOTIFY_USER_ID=${DISCORD_NOTIFY_USER_ID:-}
     volumes:
       - ${HOST_WORKDIR}/config/bluebot:/app/config:ro
       - ${HOST_WORKDIR}/data/bluebot:/app/data

--- a/src/bluebot/Dockerfile.ci
+++ b/src/bluebot/Dockerfile.ci
@@ -7,6 +7,7 @@ FROM node:22-alpine AS runtime
 # Build-time arguments for non-secret environment variables
 ARG DEBUG_MODE=false
 ARG NODE_ENV=production
+ARG APP_VERSION=dev
 ARG LOG_LEVEL=info
 ARG LOG_FORMAT=json
 ARG ENABLE_METRICS=true
@@ -37,6 +38,7 @@ COPY --chown=bluebot:bluebot src/bluebot/dist ./src/bluebot/dist
 
 # Set default environment variables from build args
 ENV NODE_ENV=${NODE_ENV} \
+    APP_VERSION=${APP_VERSION} \
     LOG_LEVEL=${LOG_LEVEL} \
     LOG_FORMAT=${LOG_FORMAT} \
     DEBUG_MODE=${DEBUG_MODE} \

--- a/src/bluebot/src/index.ts
+++ b/src/bluebot/src/index.ts
@@ -6,6 +6,7 @@ import { BlueBot } from '@/blue-bot';
 import { runSmokeTest } from '@starbunk/shared/health/smoke-test';
 import { initializeHealthServer } from '@starbunk/shared/health/health-server-init';
 import { setApplicationHealth } from '@starbunk/shared/observability/health-server';
+import { notifyStartupIfNewVersion } from '@starbunk/shared/discord/startup-dm';
 import { shutdownObservability } from '@starbunk/shared/observability/shutdown';
 import { getMetricsService } from '@starbunk/shared/observability/metrics-service';
 
@@ -62,6 +63,7 @@ async function main(): Promise<void> {
   const bot = new BlueBot(client);
   await bot.start();
   setApplicationHealth('healthy');
+  await notifyStartupIfNewVersion(client, 'BlueBot');
 
   // Set up graceful shutdown handlers
   const shutdown = async (signal: string) => {

--- a/src/bunkbot/Dockerfile.ci
+++ b/src/bunkbot/Dockerfile.ci
@@ -6,6 +6,7 @@ FROM node:22-alpine AS runtime
 
 # Build-time arguments for non-secret environment variables
 ARG NODE_ENV=production
+ARG APP_VERSION=dev
 ARG LOG_LEVEL=info
 ARG DEBUG_MODE=false
 ARG ENABLE_METRICS=true
@@ -34,6 +35,7 @@ COPY --chown=bunkbot:bunkbot src/bunkbot/dist ./src/bunkbot/dist
 
 # Set default environment variables from build args
 ENV NODE_ENV=${NODE_ENV} \
+    APP_VERSION=${APP_VERSION} \
     LOG_LEVEL=${LOG_LEVEL} \
     DEBUG_MODE=${DEBUG_MODE} \
     ENABLE_METRICS=${ENABLE_METRICS} \

--- a/src/bunkbot/src/index.ts
+++ b/src/bunkbot/src/index.ts
@@ -8,6 +8,7 @@ import { runSmokeTest } from '@starbunk/shared/health/smoke-test';
 import { getMetricsService } from '@starbunk/shared/observability/metrics-service';
 import { initializeHealthServer } from '@starbunk/shared/health/health-server-init';
 import { setApplicationHealth } from '@starbunk/shared/observability/health-server';
+import { notifyStartupIfNewVersion } from '@starbunk/shared/discord/startup-dm';
 
 // Setup logging mixins before any logging occurs
 setupBunkBotLogging();
@@ -69,6 +70,7 @@ async function main() {
   const bunkBot = new BunkBot(client, metricsService, healthServer);
   await bunkBot.initialize();
   setApplicationHealth('healthy');
+  await notifyStartupIfNewVersion(client, 'BunkBot');
 
   // Graceful shutdown
   const shutdown = async (signal: string) => {

--- a/src/covabot/Dockerfile.ci
+++ b/src/covabot/Dockerfile.ci
@@ -6,6 +6,7 @@ FROM node:22-alpine AS runtime
 
 # Build-time arguments for non-secret environment variables
 ARG NODE_ENV=production
+ARG APP_VERSION=dev
 ARG LOG_LEVEL=info
 ARG LOG_FORMAT=json
 ARG DEBUG_MODE=false
@@ -44,6 +45,7 @@ RUN cd /app && npm rebuild better-sqlite3
 
 # Set default environment variables from build args
 ENV NODE_ENV=${NODE_ENV} \
+    APP_VERSION=${APP_VERSION} \
     LOG_LEVEL=${LOG_LEVEL} \
     LOG_FORMAT=${LOG_FORMAT} \
     DEBUG_MODE=${DEBUG_MODE} \

--- a/src/covabot/src/cova-bot.ts
+++ b/src/covabot/src/cova-bot.ts
@@ -9,6 +9,7 @@ import { Client, Events, GatewayIntentBits, Message } from 'discord.js';
 import { logLayer } from '@starbunk/shared/observability/log-layer';
 import { setApplicationHealth } from '@starbunk/shared/observability/health-server';
 import { DiscordService } from '@starbunk/shared/discord/discord-service';
+import { notifyStartupIfNewVersion } from '@starbunk/shared/discord/startup-dm';
 import { PostgresService } from '@starbunk/shared/database';
 import { initializeDatabase } from '@/database';
 import { MemoryService } from '@/services/memory-service';
@@ -304,6 +305,9 @@ export class CovaBot {
           guild_count: readyClient.guilds.cache.size,
         })
         .info('Discord client ready');
+      notifyStartupIfNewVersion(readyClient, 'CovaBot').catch(() => {
+        /* non-fatal */
+      });
     });
 
     // Prevent uncaught exceptions from gateway/network errors

--- a/src/djcova/Dockerfile.ci
+++ b/src/djcova/Dockerfile.ci
@@ -7,6 +7,7 @@ FROM node:22-alpine AS runtime
 # Build-time arguments for non-secret environment variables
 ARG DEBUG_MODE=false
 ARG NODE_ENV=production
+ARG APP_VERSION=dev
 ARG LOG_LEVEL=info
 ARG LOG_FORMAT=json
 ARG ENABLE_METRICS=true
@@ -41,6 +42,7 @@ COPY --chown=djcova:djcova src/djcova/dist ./src/djcova/dist
 # Set default environment variables from build args
 ENV DEBUG_MODE=${DEBUG_MODE} \
     NODE_ENV=${NODE_ENV} \
+    APP_VERSION=${APP_VERSION} \
     LOG_LEVEL=${LOG_LEVEL} \
     LOG_FORMAT=${LOG_FORMAT} \
     ENABLE_METRICS=${ENABLE_METRICS} \

--- a/src/djcova/src/index.ts
+++ b/src/djcova/src/index.ts
@@ -16,6 +16,7 @@ import { SharedErrorCode, logError } from '@starbunk/shared/errors';
 import { commands } from '@/commands';
 import { getDJCovaService } from '@/core/djcova-factory';
 import { registerDJCovaHealthModule } from './health/djcova-health';
+import { notifyStartupIfNewVersion } from '@starbunk/shared/discord/startup-dm';
 
 // Setup logging mixins before creating any logger instances
 setupDJCovaLogging();
@@ -124,6 +125,9 @@ async function main(): Promise<void> {
       logger.info('🎵 DJCova is ready and connected to Discord');
       logger.info(`Bot user: ${client.user?.tag}`);
       djcovaHealth.discordReady = true;
+      notifyStartupIfNewVersion(client, 'DJCova').catch(() => {
+        /* non-fatal */
+      });
     });
 
     client.on(Events.Error, error => {

--- a/src/shared/src/discord/startup-dm.ts
+++ b/src/shared/src/discord/startup-dm.ts
@@ -1,0 +1,59 @@
+import { Client } from 'discord.js';
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { logLayer } from '../observability/log-layer';
+
+const logger = logLayer.withPrefix('StartupDM');
+
+/**
+ * Send a Discord DM to DISCORD_NOTIFY_USER_ID when the service starts with a
+ * new APP_VERSION compared to the version stored in the data directory.
+ *
+ * Skips silently when:
+ *  - APP_VERSION is unset or "dev"
+ *  - DISCORD_NOTIFY_USER_ID is unset
+ *  - The stored version matches the current version (crash-restart, not a deploy)
+ *
+ * Data directory defaults to /app/data; override with STARTUP_DM_DATA_DIR env var.
+ */
+export async function notifyStartupIfNewVersion(
+  client: Client,
+  displayName: string,
+): Promise<void> {
+  const currentVersion = process.env.APP_VERSION;
+  const notifyUserId = process.env.DISCORD_NOTIFY_USER_ID;
+
+  if (!currentVersion || currentVersion === 'dev') return;
+  if (!notifyUserId) return;
+
+  const dataDir = process.env.STARTUP_DM_DATA_DIR ?? '/app/data';
+  const versionFile = `${dataDir}/.last_version`;
+
+  let lastVersion: string | null = null;
+  try {
+    lastVersion = readFileSync(versionFile, 'utf-8').trim();
+  } catch {
+    // File doesn't exist — first boot on this volume
+  }
+
+  if (lastVersion === currentVersion) return;
+
+  try {
+    const user = await client.users.fetch(notifyUserId);
+    const message =
+      lastVersion === null
+        ? `🟢 **${displayName}** is online! (v${currentVersion})`
+        : `🚀 **${displayName}** updated and online! v${lastVersion} → v${currentVersion}`;
+
+    await user.send(message);
+    logger.info(`Sent startup DM: ${message}`);
+  } catch (err) {
+    logger.warn(`Failed to send startup DM: ${(err as Error).message}`);
+  }
+
+  try {
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(versionFile, currentVersion, 'utf-8');
+  } catch (err) {
+    logger.warn(`Failed to write version file at ${versionFile}: ${(err as Error).message}`);
+  }
+}


### PR DESCRIPTION
## Summary
- Each bot (BunkBot, BlueBot, CovaBot, DJCova) sends a DM to `DISCORD_NOTIFY_USER_ID` when it comes online after a **version change**
- Crash restarts with the same image are silently ignored (version file unchanged)
- First-ever boot on a fresh volume: sends `🟢 BotName is online! (v1.42.0)`
- After a Watchtower deploy: sends `🚀 BotName updated and online! v1.41.0 → v1.42.0`

## How it works
- `APP_VERSION` is baked into each Docker image at build time via `--build-arg APP_VERSION=$(cat VERSION)` in `main.yml`
- On startup, each bot compares `APP_VERSION` against a `.last_version` file in its persistent data volume
- If different (or no file yet), it DMs the user and writes the new version to the file
- Shared utility at `src/shared/src/discord/startup-dm.ts` handles all the logic; all failures are non-fatal

## Infrastructure changes
- All 4 `Dockerfile.ci` files gain `ARG APP_VERSION=dev` + `ENV APP_VERSION=${APP_VERSION}`
- `docker-compose.yml`: `DISCORD_NOTIFY_USER_ID` + `STARTUP_DM_DATA_DIR` added to each service; bunkbot gets a new `/app/data` volume (others already had one)
- `main.yml`: passes `--build-arg APP_VERSION` to docker build step

## Test plan
- [ ] Merge and confirm CI passes
- [ ] After Watchtower deploys new images, expect 4 DMs (one per bot)
- [ ] Manually restart a container without a new deploy — confirm no duplicate DM is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)