### PR TITLE
feat(djcova): pipeline tests + silent-failure observability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,12 @@ jobs:
           yt-dlp --version
       - name: Run DJCova pipeline tests
         run: npm run test:djcova:pipeline
+        env:
+          # GitHub-hosted runners are blocked by YouTube. Layer 1 (binary checks)
+          # runs fine; Layers 2-4 (yt-dlp stream + demuxProbe + DJCova.play) are
+          # skipped via describe.skipIf so CI validates binary availability only.
+          # Run without this flag locally or on a self-hosted runner for full coverage.
+          SKIP_NETWORK_TESTS: 'true'
 
   bluebot_validation:
     name: BlueBot Validation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,30 @@ jobs:
       - name: Test
         run: npm run test:djcova --if-present
 
+  djcova_pipeline:
+    name: DJCova Pipeline Tests
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.djcova == 'true' || needs.changes.outputs.core == 'true' }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Install yt-dlp
+        run: |
+          sudo curl -fsSL https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp \
+            -o /usr/local/bin/yt-dlp
+          sudo chmod a+rx /usr/local/bin/yt-dlp
+          yt-dlp --version
+      - name: Run DJCova pipeline tests
+        run: npm run test:djcova:pipeline
+
   bluebot_validation:
     name: BlueBot Validation
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:containers": "npm run test:bunkbot && npm run test:djcova && npm run test:covabot && npm run test:bluebot",
     "test:bunkbot": "cd src/bunkbot && npm test",
     "test:djcova": "cd src/djcova && npm test",
+    "test:djcova:pipeline": "cd src/djcova && npm run test:pipeline",
     "test:covabot": "cd src/covabot && npm test",
     "test:bluebot": "cd src/bluebot && npm test",
     "test:e2e": "cd src/e2e && npm test",

--- a/src/djcova/package.json
+++ b/src/djcova/package.json
@@ -14,6 +14,7 @@
     "test:integration:watch": "vitest --config vitest.integration.config.ts",
     "test:e2e": "vitest run --config vitest.integration.config.ts tests/integration/*.e2e.test.ts",
     "test:contract": "vitest run --config vitest.integration.config.ts tests/integration/*.contract.test.ts",
+    "test:pipeline": "vitest run --config vitest.pipeline.config.ts",
     "type-check": "tsc --build --dry",
     "clean": "tsc --build --clean"
   },

--- a/src/djcova/src/core/dj-cova.ts
+++ b/src/djcova/src/core/dj-cova.ts
@@ -91,29 +91,40 @@ export class DJCova {
 
     this.player.on(AudioPlayerStatus.Playing, () => {
       logger.info('▶️ Playback started');
-      // Diagnostic: detect conditions that cause silent playback
+
+      // Confirm or deny that audio is actually reaching the voice channel.
+      // This is the definitive check: if the player is Playing but either the
+      // subscription is missing or the connection is not Ready, audio frames
+      // are being discarded and the user hears silence.
       if (!this.currentSubscription) {
         logger.error(
-          '❌ Player started but has no active voice subscription — audio will be silent! Check subscription setup.',
+          '❌ SILENT FAILURE: Player is Playing but no voice subscription exists — audio is lost. ' +
+            'Ensure setSubscription() is called before play().',
         );
+        if (this.guildId) {
+          getDJCovaMetrics().trackSilentFailure(this.guildId, 'no_subscription');
+        }
       } else {
         const connStatus = this.currentSubscription.connection.state.status;
         if (connStatus !== VoiceConnectionStatus.Ready) {
           logger.error(
-            `❌ Player started but voice connection is not Ready (state: ${connStatus}) — audio will be silent!`,
+            `❌ SILENT FAILURE: Player is Playing but voice connection is ${connStatus} — audio is lost.`,
           );
+          if (this.guildId) {
+            getDJCovaMetrics().trackSilentFailure(this.guildId, 'connection_not_ready');
+          }
         } else {
-          logger.debug('✅ Voice subscription active and connection Ready at playback start');
+          logger.info('✅ Audio confirmed flowing: subscription active and connection Ready');
+          // Record the metric here — at this point Discord Voice has actually started
+          // consuming audio frames, not just when player.play() was called.
+          if (this.guildId) {
+            getDJCovaMetrics().trackAudioPlaybackStarted(this.guildId);
+          }
         }
       }
+
       logger.debug('Resetting idle timer due to playback start');
       this.idleManager?.resetIdleTimer();
-      // Record the metric here — at this point Discord Voice has actually started
-      // consuming audio frames, not just when player.play() was called.
-      if (this.guildId) {
-        getDJCovaMetrics().trackAudioPlaybackStarted(this.guildId);
-        updateAudioPlayerStatus(this.guildId, AudioPlayerStatus.Playing);
-      }
     });
 
     this.player.on(AudioPlayerStatus.Idle, () => {
@@ -149,8 +160,44 @@ export class DJCova {
     logger.debug('Audio player event handlers registered');
   }
 
+  /**
+   * Log the state of every dependency that can cause silent playback BEFORE
+   * any async work begins.  This means that when a user reports "no sound",
+   * the logs contain a snapshot of what was wrong at call time, not just
+   * after-the-fact hints from the Playing event handler.
+   */
+  private logPreFlightState(url: string): void {
+    const hasSubscription = !!this.currentSubscription;
+    const connectionStatus = this.currentSubscription?.connection?.state?.status;
+    const connectionReady = connectionStatus === VoiceConnectionStatus.Ready;
+    const ffmpegPath = process.env.FFMPEG_PATH;
+
+    logger.debug(
+      `Pre-flight: url=${url} subscription=${hasSubscription} connection=${connectionStatus ?? 'none'} ffmpeg=${ffmpegPath ?? 'unset'}`,
+    );
+
+    if (!hasSubscription) {
+      logger.error(
+        '❌ PRE-FLIGHT: No voice subscription registered. ' +
+          'Audio will be silently discarded — call setSubscription() before play().',
+      );
+    } else if (!connectionReady) {
+      logger.error(
+        `❌ PRE-FLIGHT: Voice connection is not Ready (status: ${connectionStatus}). ` +
+          'Audio will be silently discarded.',
+      );
+    } else {
+      logger.debug('✅ PRE-FLIGHT OK: subscription present and connection Ready');
+    }
+
+    if (!ffmpegPath) {
+      logger.error('❌ PRE-FLIGHT: FFMPEG_PATH not set — demuxProbe / transcoding will fail');
+    }
+  }
+
   async play(url: string): Promise<void> {
     logger.info(`🎵 Playing: ${url}`);
+    this.logPreFlightState(url);
     logger.debug('Stopping any existing playback (preserving voice subscription)...');
     // Stop audio only — do NOT unsubscribe from the voice connection, or the
     // new audio will have no subscriber and play silently into the void.

--- a/src/djcova/src/observability/djcova-metrics.ts
+++ b/src/djcova/src/observability/djcova-metrics.ts
@@ -12,10 +12,18 @@ import { getMetricsService } from '@starbunk/shared/observability/metrics-servic
  * All counters share the MetricsService registry so they are exposed through
  * the same /metrics endpoint as the generic bot metrics.
  */
+/**
+ * Reason labels for djcova_silent_failure_total.
+ * Each value corresponds to a distinct silent-failure mode where the bot
+ * appears to be playing but no audio reaches the voice channel.
+ */
+export type SilentFailureReason = 'no_subscription' | 'connection_not_ready';
+
 export class DJCovaMetrics {
   private playCommandTotal: promClient.Counter<string>;
   private voiceJoinTotal: promClient.Counter<string>;
   private audioPlaybackStartedTotal: promClient.Counter<string>;
+  private silentFailureTotal: promClient.Counter<string>;
 
   constructor(registry: promClient.Registry) {
     this.playCommandTotal = new promClient.Counter({
@@ -38,6 +46,13 @@ export class DJCovaMetrics {
       labelNames: ['guild_id'],
       registers: [registry],
     });
+
+    this.silentFailureTotal = new promClient.Counter({
+      name: 'djcova_silent_failure_total',
+      help: 'Total times the AudioPlayer started but audio was silently discarded (no subscription or connection not ready)',
+      labelNames: ['guild_id', 'reason'],
+      registers: [registry],
+    });
   }
 
   /** Record a /play command invocation. */
@@ -53,6 +68,17 @@ export class DJCovaMetrics {
   /** Record that audio actually began streaming (yt-dlp → ffmpeg → Discord). */
   trackAudioPlaybackStarted(guildId: string): void {
     this.audioPlaybackStartedTotal.inc({ guild_id: guildId });
+  }
+
+  /**
+   * Record a silent failure: the AudioPlayer reached Playing state but audio
+   * was discarded because either the subscription was missing or the voice
+   * connection was not Ready.
+   *
+   * A non-zero value here means users heard silence despite a /play command.
+   */
+  trackSilentFailure(guildId: string, reason: SilentFailureReason): void {
+    this.silentFailureTotal.inc({ guild_id: guildId, reason });
   }
 }
 

--- a/src/djcova/src/utils/ytdlp.ts
+++ b/src/djcova/src/utils/ytdlp.ts
@@ -151,8 +151,15 @@ export function getYouTubeAudioStream(url: string): {
     }
   });
 
-  // Propagate stdout errors for better diagnostics
+  // Propagate stdout errors for better diagnostics.
+  // ERR_STREAM_PREMATURE_CLOSE fires whenever we call stream.destroy() or
+  // SIGKILL the process — it is expected on every stop/skip and must not be
+  // treated as an error, otherwise logs fill with false alarms.
   (ytdlpProcess.stdout as Readable).on('error', (e: Error) => {
+    if ((e as NodeJS.ErrnoException).code === 'ERR_STREAM_PREMATURE_CLOSE') {
+      logger.debug('yt-dlp stdout closed early (expected on intentional stop/skip)');
+      return;
+    }
     logError(logger, DJCovaErrorCode.DJCOVA_AUDIO_STREAM_ERROR, 'yt-dlp stdout error', {
       cause: e,
       url,

--- a/src/djcova/tests/pipeline/01-binaries.pipeline.test.ts
+++ b/src/djcova/tests/pipeline/01-binaries.pipeline.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Pipeline Test Layer 1: Binary Availability
+ *
+ * Verifies that all required external binaries are installed and functional.
+ * NO network calls. NO Discord. Fast (<5s).
+ *
+ * If these fail, DJCova is fundamentally broken — fix binaries before anything else.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'child_process';
+import { existsSync } from 'fs';
+import ffmpegStaticPath from 'ffmpeg-static';
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+async function runBinary(
+  cmd: string,
+  args: string[],
+  timeoutMs = 5_000,
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise(resolve => {
+    const proc = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout?.on('data', (d: Buffer) => (stdout += d.toString()));
+    proc.stderr?.on('data', (d: Buffer) => (stderr += d.toString()));
+
+    const timer = setTimeout(() => {
+      proc.kill('SIGKILL');
+      resolve({ code: -1, stdout, stderr: stderr + '\n[TIMEOUT]' });
+    }, timeoutMs);
+
+    proc.on('error', err => {
+      clearTimeout(timer);
+      resolve({ code: -1, stdout, stderr: err.message });
+    });
+
+    proc.on('close', code => {
+      clearTimeout(timer);
+      resolve({ code: code ?? -1, stdout, stderr });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Layer 1: Binary Availability', () => {
+  describe('yt-dlp', () => {
+    it('is reachable and returns a version string', async () => {
+      const ytdlpBin = process.env.YTDLP_PATH ?? 'yt-dlp';
+      const result = await runBinary(ytdlpBin, ['--version']);
+
+      expect(result.code, `yt-dlp exited with code ${result.code}. stderr: ${result.stderr}`).toBe(
+        0,
+      );
+
+      // Version is YYYY.MM.DD format
+      expect(result.stdout.trim()).toMatch(/^\d{4}\.\d{2}\.\d{2}/);
+      console.log(`  yt-dlp version: ${result.stdout.trim()}`);
+    });
+
+    it('supports the output flags DJCova relies on', async () => {
+      const ytdlpBin = process.env.YTDLP_PATH ?? 'yt-dlp';
+      const result = await runBinary(ytdlpBin, ['--help']);
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('--no-playlist');
+      expect(result.stdout).toContain('--quiet');
+    });
+  });
+
+  describe('ffmpeg (bundled via ffmpeg-static)', () => {
+    it('ffmpeg-static provides a non-null path', () => {
+      expect(
+        ffmpegStaticPath,
+        'ffmpeg-static returned null — package may be missing',
+      ).not.toBeNull();
+      console.log(`  ffmpeg-static path: ${ffmpegStaticPath}`);
+    });
+
+    it('the bundled ffmpeg binary exists on disk', () => {
+      if (!ffmpegStaticPath) {
+        console.warn('  ffmpeg-static path is null — skipping disk check');
+        return;
+      }
+      expect(existsSync(ffmpegStaticPath), `ffmpeg binary not found at ${ffmpegStaticPath}`).toBe(
+        true,
+      );
+    });
+
+    it('the bundled ffmpeg binary is executable and reports a version', async () => {
+      if (!ffmpegStaticPath) {
+        console.warn('  ffmpeg-static not available — skipping version check');
+        return;
+      }
+      const result = await runBinary(ffmpegStaticPath, ['-version']);
+      const combined = result.stdout + result.stderr;
+
+      expect(
+        combined,
+        `ffmpeg did not print a version string. combined output: ${combined}`,
+      ).toMatch(/ffmpeg version/i);
+
+      console.log(`  ffmpeg version: ${combined.split('\n')[0].trim()}`);
+    });
+
+    it('FFMPEG_PATH env is set by DJCova constructor (simulated here)', () => {
+      // DJCova constructor does: process.env.FFMPEG_PATH = ffmpegPath
+      // Simulate that here so downstream pipeline tests inherit it.
+      if (ffmpegStaticPath && !process.env.FFMPEG_PATH) {
+        process.env.FFMPEG_PATH = ffmpegStaticPath;
+      }
+      expect(process.env.FFMPEG_PATH).toBeDefined();
+      console.log(`  FFMPEG_PATH: ${process.env.FFMPEG_PATH}`);
+    });
+  });
+
+  describe('opusscript (Node.js native module)', () => {
+    it('loads without errors', async () => {
+      // opusscript is required by @discordjs/voice for Opus encoding.
+      // If it fails to load, voice audio cannot be encoded and the bot will be silent.
+      const mod = await import('opusscript');
+      expect(mod).toBeDefined();
+      // The default export is an Opus encoder class
+      const defaultExport = mod.default ?? mod;
+      expect(typeof defaultExport).toBe('function');
+    });
+  });
+});

--- a/src/djcova/tests/pipeline/02-yt-stream.pipeline.test.ts
+++ b/src/djcova/tests/pipeline/02-yt-stream.pipeline.test.ts
@@ -22,6 +22,10 @@ if (ffmpegStaticPath && !process.env.FFMPEG_PATH) {
 const STABLE_VIDEO_URL = 'https://www.youtube.com/watch?v=jNQXAC9IVRw';
 const STREAM_DATA_TIMEOUT_MS = 30_000;
 
+// GitHub-hosted runners are YouTube-blocked. Set SKIP_NETWORK_TESTS=true to skip
+// Layers 2-4 in CI; only Layer 1 (binary checks) runs on GitHub runners.
+const skipNetworkTests = process.env.SKIP_NETWORK_TESTS === 'true';
+
 const activeProcesses: ChildProcess[] = [];
 
 function trackProcess(proc: ChildProcess): ChildProcess {
@@ -43,7 +47,7 @@ afterEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('Layer 2: yt-dlp Stream Production', () => {
+describe.skipIf(skipNetworkTests)('Layer 2: yt-dlp Stream Production', () => {
   describe('successful stream', () => {
     it(
       'produces audio bytes from a known YouTube URL within 30 seconds',

--- a/src/djcova/tests/pipeline/02-yt-stream.pipeline.test.ts
+++ b/src/djcova/tests/pipeline/02-yt-stream.pipeline.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Pipeline Test Layer 2: yt-dlp Stream Production
+ *
+ * Verifies that yt-dlp can actually fetch audio bytes from YouTube.
+ * Requires network access. No Discord. No ffmpeg.
+ *
+ * Uses a known short, stable video (the first YouTube video — 19s).
+ * If this fails, DJCova cannot stream audio regardless of any other fix.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { ChildProcess } from 'child_process';
+import { getYouTubeAudioStream } from '../../src/utils/ytdlp';
+import ffmpegStaticPath from 'ffmpeg-static';
+
+// Set ffmpeg path so downstream @discordjs/voice probing works
+if (ffmpegStaticPath && !process.env.FFMPEG_PATH) {
+  process.env.FFMPEG_PATH = ffmpegStaticPath;
+}
+
+// "Me at the zoo" — first YouTube video, 19 seconds, extremely stable
+const STABLE_VIDEO_URL = 'https://www.youtube.com/watch?v=jNQXAC9IVRw';
+const STREAM_DATA_TIMEOUT_MS = 30_000;
+
+const activeProcesses: ChildProcess[] = [];
+
+function trackProcess(proc: ChildProcess): ChildProcess {
+  activeProcesses.push(proc);
+  return proc;
+}
+
+afterEach(() => {
+  for (const proc of activeProcesses.splice(0)) {
+    try {
+      proc.kill('SIGKILL');
+    } catch {
+      // already dead
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Layer 2: yt-dlp Stream Production', () => {
+  describe('successful stream', () => {
+    it(
+      'produces audio bytes from a known YouTube URL within 30 seconds',
+      async () => {
+        const { stream, process: proc } = getYouTubeAudioStream(STABLE_VIDEO_URL);
+        trackProcess(proc);
+
+        const bytesReceived = await new Promise<number>((resolve, reject) => {
+          const timer = setTimeout(
+            () =>
+              reject(
+                new Error(
+                  'No audio bytes received within timeout — yt-dlp may be broken or blocked',
+                ),
+              ),
+            STREAM_DATA_TIMEOUT_MS,
+          );
+
+          let total = 0;
+
+          stream.on('data', (chunk: Buffer) => {
+            total += chunk.length;
+            if (total >= 4096) {
+              // Got 4 KB — clearly working
+              clearTimeout(timer);
+              stream.destroy();
+              resolve(total);
+            }
+          });
+
+          stream.on('error', err => {
+            clearTimeout(timer);
+            reject(new Error(`Stream error: ${err.message}`));
+          });
+
+          proc.on('error', err => {
+            clearTimeout(timer);
+            reject(new Error(`yt-dlp spawn error: ${err.message}`));
+          });
+        });
+
+        expect(bytesReceived).toBeGreaterThanOrEqual(4096);
+        console.log(`  Received ${bytesReceived} bytes from yt-dlp`);
+      },
+      STREAM_DATA_TIMEOUT_MS + 5_000,
+    );
+
+    it('stream starts within a reasonable time (< 20s)', async () => {
+      const startMs = Date.now();
+      const { stream, process: proc } = getYouTubeAudioStream(STABLE_VIDEO_URL);
+      trackProcess(proc);
+
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error('First byte took > 20 seconds — yt-dlp is too slow')),
+          20_000,
+        );
+
+        stream.once('data', () => {
+          clearTimeout(timer);
+          stream.destroy();
+          resolve();
+        });
+
+        stream.once('error', err => {
+          clearTimeout(timer);
+          reject(err);
+        });
+      });
+
+      const elapsedMs = Date.now() - startMs;
+      console.log(`  First byte received after ${elapsedMs}ms`);
+      expect(elapsedMs).toBeLessThan(20_000);
+    }, 25_000);
+  });
+
+  describe('error handling', () => {
+    it('emits a stream error for a non-existent video ID', async () => {
+      const { stream, process: proc } = getYouTubeAudioStream(
+        'https://www.youtube.com/watch?v=THIS_DOES_NOT_EXIST_XYZ',
+      );
+      trackProcess(proc);
+
+      const gotError = await new Promise<boolean>((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error('Expected an error for invalid video ID but got none')),
+          30_000,
+        );
+
+        stream.once('error', () => {
+          clearTimeout(timer);
+          resolve(true);
+        });
+
+        // Also accept non-zero process exit as the error signal
+        proc.once('exit', code => {
+          if (code !== 0) {
+            clearTimeout(timer);
+            resolve(true);
+          }
+        });
+      });
+
+      expect(gotError).toBe(true);
+    }, 35_000);
+  });
+});

--- a/src/djcova/tests/pipeline/03-audio-resource.pipeline.test.ts
+++ b/src/djcova/tests/pipeline/03-audio-resource.pipeline.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Pipeline Test Layer 3: Audio Resource Creation
+ *
+ * Verifies the full audio-processing chain:
+ *   yt-dlp stdout → demuxProbe (format detection) → createAudioResource
+ *
+ * demuxProbe and createAudioResource are from @discordjs/voice but require
+ * NO Discord connection — they are pure audio-stream operations.
+ * FFmpeg is required for format transcoding (set via FFMPEG_PATH).
+ *
+ * If this test passes, the audio is in a state that is literally ready to
+ * be subscribed to a Discord voice connection and transmitted.
+ *
+ * If the mocked unit tests pass but this fails, the real pipeline is broken.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { demuxProbe, createAudioResource, StreamType } from '@discordjs/voice';
+import { ChildProcess } from 'child_process';
+import { getYouTubeAudioStream } from '../../src/utils/ytdlp';
+import ffmpegStaticPath from 'ffmpeg-static';
+
+// Must be set before @discordjs/voice tries to use ffmpeg
+if (ffmpegStaticPath && !process.env.FFMPEG_PATH) {
+  process.env.FFMPEG_PATH = ffmpegStaticPath;
+}
+
+const STABLE_VIDEO_URL = 'https://www.youtube.com/watch?v=jNQXAC9IVRw';
+const PROBE_TIMEOUT_MS = 35_000;
+
+const activeProcesses: ChildProcess[] = [];
+
+afterEach(() => {
+  for (const proc of activeProcesses.splice(0)) {
+    try {
+      proc.kill('SIGKILL');
+    } catch {
+      // already dead
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Layer 3: Audio Resource Creation', () => {
+  describe('demuxProbe', () => {
+    it(
+      'detects the audio format of a live yt-dlp stream',
+      async () => {
+        const { stream, process: proc } = getYouTubeAudioStream(STABLE_VIDEO_URL);
+        activeProcesses.push(proc);
+
+        const result = await demuxProbe(stream);
+
+        expect(result, 'demuxProbe returned null/undefined').toBeDefined();
+        expect(result.stream, 'probed stream is missing').toBeDefined();
+        expect(result.type, 'probe type is missing').toBeDefined();
+
+        // Cleanup the probed stream (otherwise the yt-dlp process keeps buffering)
+        result.stream.destroy();
+
+        console.log(`  Detected audio type: ${result.type}`);
+      },
+      PROBE_TIMEOUT_MS + 5_000,
+    );
+  });
+
+  describe('createAudioResource', () => {
+    it(
+      'builds a playable AudioResource with inline volume from a yt-dlp stream',
+      async () => {
+        const { stream, process: proc } = getYouTubeAudioStream(STABLE_VIDEO_URL);
+        activeProcesses.push(proc);
+
+        const probeResult = await demuxProbe(stream);
+
+        const resource = createAudioResource(probeResult.stream, {
+          inputType: probeResult.type,
+          inlineVolume: true,
+        });
+
+        expect(resource, 'createAudioResource returned null/undefined').toBeDefined();
+        expect(resource.volume, 'inlineVolume not available on resource').toBeDefined();
+        expect(resource.playbackDuration).toBe(0); // Not yet playing
+
+        // Volume control must work — this is what DJCova.setVolume() relies on
+        resource.volume!.setVolume(0.1);
+        expect(resource.volume!.volume).toBeCloseTo(0.1, 2);
+
+        resource.volume!.setVolume(1.0);
+        expect(resource.volume!.volume).toBeCloseTo(1.0, 2);
+
+        console.log(`  AudioResource created. probe type: ${probeResult.type}`);
+        probeResult.stream.destroy();
+      },
+      PROBE_TIMEOUT_MS + 5_000,
+    );
+
+    it(
+      'produces a resource with a readable stream type (not Arbitrary when possible)',
+      async () => {
+        const { stream, process: proc } = getYouTubeAudioStream(STABLE_VIDEO_URL);
+        activeProcesses.push(proc);
+
+        const probeResult = await demuxProbe(stream);
+
+        // The type should be one of the known StreamTypes.
+        // StreamType.Arbitrary means ffmpeg transcoding is required — acceptable,
+        // but worth logging so we know what format YouTube is returning.
+        const knownTypes = Object.values(StreamType);
+        expect(knownTypes).toContain(probeResult.type);
+
+        if (probeResult.type === StreamType.Arbitrary) {
+          console.log('  Note: format is Arbitrary — ffmpeg transcoding will be used');
+        } else {
+          console.log(`  Optimal format: ${probeResult.type} (no transcoding needed)`);
+        }
+
+        probeResult.stream.destroy();
+      },
+      PROBE_TIMEOUT_MS + 5_000,
+    );
+  });
+});

--- a/src/djcova/tests/pipeline/03-audio-resource.pipeline.test.ts
+++ b/src/djcova/tests/pipeline/03-audio-resource.pipeline.test.ts
@@ -28,6 +28,8 @@ if (ffmpegStaticPath && !process.env.FFMPEG_PATH) {
 const STABLE_VIDEO_URL = 'https://www.youtube.com/watch?v=jNQXAC9IVRw';
 const PROBE_TIMEOUT_MS = 35_000;
 
+const skipNetworkTests = process.env.SKIP_NETWORK_TESTS === 'true';
+
 const activeProcesses: ChildProcess[] = [];
 
 afterEach(() => {
@@ -44,7 +46,7 @@ afterEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('Layer 3: Audio Resource Creation', () => {
+describe.skipIf(skipNetworkTests)('Layer 3: Audio Resource Creation', () => {
   describe('demuxProbe', () => {
     it(
       'detects the audio format of a live yt-dlp stream',

--- a/src/djcova/tests/pipeline/04-djcova-play.pipeline.test.ts
+++ b/src/djcova/tests/pipeline/04-djcova-play.pipeline.test.ts
@@ -45,6 +45,8 @@ if (ffmpegStaticPath && !process.env.FFMPEG_PATH) {
 const STABLE_VIDEO_URL = 'https://www.youtube.com/watch?v=jNQXAC9IVRw';
 const PLAY_TIMEOUT_MS = 35_000;
 
+const skipNetworkTests = process.env.SKIP_NETWORK_TESTS === 'true';
+
 // ---------------------------------------------------------------------------
 // Minimal fake subscription
 // Only satisfies DJCova's subscription diagnostic check in the Playing event handler.
@@ -63,7 +65,7 @@ function fakeSubscription() {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('Layer 4: DJCova Full Play Pipeline', () => {
+describe.skipIf(skipNetworkTests)('Layer 4: DJCova Full Play Pipeline', () => {
   const instances: DJCova[] = [];
 
   function createDJCova(): DJCova {

--- a/src/djcova/tests/pipeline/04-djcova-play.pipeline.test.ts
+++ b/src/djcova/tests/pipeline/04-djcova-play.pipeline.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Pipeline Test Layer 4: DJCova Full Play Pipeline
+ *
+ * THE GOLD STANDARD TEST. Exercises the exact code path that runs in production.
+ *
+ * Flow under test:
+ *   DJCova.play(url)
+ *     → getYouTubeAudioStream()   [real yt-dlp]
+ *     → demuxProbe()              [real audio format detection]
+ *     → createAudioResource()     [real audio resource]
+ *     → player.play(resource)
+ *     → AudioPlayerStatus.Playing [real event from @discordjs/voice]
+ *
+ * What is mocked:
+ *   - The PlayerSubscription (only to satisfy DJCova's "no subscription" diagnostic)
+ *   - Nothing else
+ *
+ * What is NOT mocked:
+ *   - yt-dlp process
+ *   - Audio stream
+ *   - demuxProbe
+ *   - createAudioResource
+ *   - AudioPlayer state machine
+ *
+ * Why no Discord connection is needed:
+ *   DJCova is created with NoSubscriberBehavior.Play, meaning the AudioPlayer
+ *   reads and processes audio frames even with no real voice connection. The
+ *   Playing event fires when the player starts consuming frames — which happens
+ *   without a Discord UDP connection. Audio bytes are read and discarded.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { AudioPlayerStatus, VoiceConnectionStatus } from '@discordjs/voice';
+import { DJCova } from '../../src/core/dj-cova';
+import ffmpegStaticPath from 'ffmpeg-static';
+
+// Must be set before DJCova constructor runs (it checks this env var)
+if (ffmpegStaticPath && !process.env.FFMPEG_PATH) {
+  process.env.FFMPEG_PATH = ffmpegStaticPath;
+}
+
+// ---------------------------------------------------------------------------
+// "Me at the zoo" — first YouTube video, 19s, extremely stable
+// ---------------------------------------------------------------------------
+const STABLE_VIDEO_URL = 'https://www.youtube.com/watch?v=jNQXAC9IVRw';
+const PLAY_TIMEOUT_MS = 35_000;
+
+// ---------------------------------------------------------------------------
+// Minimal fake subscription
+// Only satisfies DJCova's subscription diagnostic check in the Playing event handler.
+// Does NOT create a real Discord voice connection.
+// ---------------------------------------------------------------------------
+function fakeSubscription() {
+  return {
+    connection: {
+      state: { status: VoiceConnectionStatus.Ready },
+    },
+    unsubscribe: vi.fn(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Layer 4: DJCova Full Play Pipeline', () => {
+  const instances: DJCova[] = [];
+
+  function createDJCova(): DJCova {
+    const dj = new DJCova();
+    instances.push(dj);
+    return dj;
+  }
+
+  afterEach(() => {
+    for (const dj of instances.splice(0)) {
+      try {
+        dj.destroy();
+      } catch {
+        // already destroyed
+      }
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Core: does play() work at all?
+  // ---------------------------------------------------------------------------
+
+  it(
+    'DJCova.play() transitions the AudioPlayer to Playing state',
+    async () => {
+      const dj = createDJCova();
+      dj.setSubscription(fakeSubscription() as Parameters<typeof dj.setSubscription>[0]);
+
+      const playingPromise = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(
+          () =>
+            reject(
+              new Error(
+                'AudioPlayer never reached Playing state. ' +
+                  'This means yt-dlp, ffmpeg, or @discordjs/voice audio pipeline is broken.',
+              ),
+            ),
+          PLAY_TIMEOUT_MS,
+        );
+
+        dj.getPlayer().on(AudioPlayerStatus.Playing, () => {
+          clearTimeout(timer);
+          resolve();
+        });
+
+        dj.getPlayer().on('error', err => {
+          clearTimeout(timer);
+          reject(new Error(`AudioPlayer error: ${err.message}`));
+        });
+      });
+
+      // This call returns when player.play(resource) is invoked, before the
+      // Playing event fires. The Playing event fires asynchronously once the
+      // AudioPlayer starts consuming frames.
+      await dj.play(STABLE_VIDEO_URL);
+
+      await playingPromise;
+
+      expect(dj.getPlayer().state.status).toBe(AudioPlayerStatus.Playing);
+      console.log('  ✅ AudioPlayer reached Playing state — pipeline is fully operational');
+    },
+    PLAY_TIMEOUT_MS + 5_000,
+  );
+
+  // ---------------------------------------------------------------------------
+  // Volume control works during active playback
+  // ---------------------------------------------------------------------------
+
+  it(
+    'DJCova.setVolume() modifies volume on the active audio resource',
+    async () => {
+      const dj = createDJCova();
+      dj.setSubscription(fakeSubscription() as Parameters<typeof dj.setSubscription>[0]);
+
+      await dj.play(STABLE_VIDEO_URL);
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error('Timeout waiting for Playing')),
+          PLAY_TIMEOUT_MS,
+        );
+        dj.getPlayer().on(AudioPlayerStatus.Playing, () => {
+          clearTimeout(timer);
+          resolve();
+        });
+      });
+
+      // Volume control must not throw and must persist
+      dj.setVolume(50);
+      expect(dj.getVolume()).toBe(50);
+
+      dj.setVolume(0);
+      expect(dj.getVolume()).toBe(0);
+
+      dj.setVolume(100);
+      expect(dj.getVolume()).toBe(100);
+
+      console.log('  ✅ Volume control works during active playback');
+    },
+    PLAY_TIMEOUT_MS + 5_000,
+  );
+
+  // ---------------------------------------------------------------------------
+  // stop() transitions player back to Idle
+  // ---------------------------------------------------------------------------
+
+  it(
+    'DJCova.stop() transitions the AudioPlayer to Idle',
+    async () => {
+      const dj = createDJCova();
+      dj.setSubscription(fakeSubscription() as Parameters<typeof dj.setSubscription>[0]);
+
+      await dj.play(STABLE_VIDEO_URL);
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error('Timeout waiting for Playing')),
+          PLAY_TIMEOUT_MS,
+        );
+        dj.getPlayer().on(AudioPlayerStatus.Playing, () => {
+          clearTimeout(timer);
+          resolve();
+        });
+      });
+
+      const idlePromise = new Promise<void>(resolve => {
+        dj.getPlayer().once(AudioPlayerStatus.Idle, () => resolve());
+      });
+
+      dj.stop();
+      await idlePromise;
+
+      expect(dj.getPlayer().state.status).toBe(AudioPlayerStatus.Idle);
+      console.log('  ✅ DJCova.stop() cleanly transitioned player to Idle');
+    },
+    PLAY_TIMEOUT_MS + 5_000,
+  );
+
+  // ---------------------------------------------------------------------------
+  // Consecutive play() calls (track skip)
+  // ---------------------------------------------------------------------------
+
+  it(
+    'a second play() call interrupts the first and reaches Playing again',
+    async () => {
+      const dj = createDJCova();
+      dj.setSubscription(fakeSubscription() as Parameters<typeof dj.setSubscription>[0]);
+
+      // First play
+      await dj.play(STABLE_VIDEO_URL);
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('Timeout on first play')), PLAY_TIMEOUT_MS);
+        dj.getPlayer().on(AudioPlayerStatus.Playing, () => {
+          clearTimeout(timer);
+          resolve();
+        });
+      });
+
+      // Second play — simulates a /play command while already playing
+      const playingAgain = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error('AudioPlayer did not reach Playing on second call')),
+          PLAY_TIMEOUT_MS,
+        );
+        // once() avoids double-resolve from the first play() events still in flight
+        dj.getPlayer().once(AudioPlayerStatus.Playing, () => {
+          clearTimeout(timer);
+          resolve();
+        });
+      });
+
+      await dj.play(STABLE_VIDEO_URL);
+      await playingAgain;
+
+      expect(dj.getPlayer().state.status).toBe(AudioPlayerStatus.Playing);
+      console.log('  ✅ Second play() successfully interrupted first and reached Playing');
+    },
+    (PLAY_TIMEOUT_MS + 5_000) * 2,
+  );
+
+  // ---------------------------------------------------------------------------
+  // Graceful termination for unavailable video
+  //
+  // When yt-dlp fetches an unavailable video, it may write a few initial bytes
+  // before the process exits with code 1. The yt-dlp exit error is logged but
+  // the stream error does not always propagate back through the demuxProbe/ffmpeg
+  // pipeline to the AudioPlayer's "error" event — the player may simply reach
+  // Idle when the (partial) stream ends.
+  //
+  // KNOWN GAP: users may not receive an explicit error message in this scenario.
+  // This test verifies the minimum contract: DJCova does NOT hang indefinitely.
+  // ---------------------------------------------------------------------------
+
+  it('DJCova does not hang indefinitely for an unavailable video', async () => {
+    const dj = createDJCova();
+    dj.setSubscription(fakeSubscription() as Parameters<typeof dj.setSubscription>[0]);
+
+    const terminalStatePromise = new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(
+        () =>
+          reject(
+            new Error(
+              'DJCova hung for 30s on invalid video — player never reached a terminal state',
+            ),
+          ),
+        30_000,
+      );
+
+      const done = (state: string) => {
+        clearTimeout(timer);
+        resolve(state);
+      };
+
+      dj.getPlayer().on('error', () => done('error'));
+      dj.getPlayer().once(AudioPlayerStatus.Idle, () => done('idle'));
+    });
+
+    let playRejected = false;
+    try {
+      await dj.play('https://www.youtube.com/watch?v=THIS_DOES_NOT_EXIST_XYZ');
+    } catch {
+      playRejected = true;
+    }
+
+    if (playRejected) {
+      console.log('  ✅ play() rejected early for unavailable video');
+      return;
+    }
+
+    // play() resolved — wait for the player to reach a terminal state
+    const terminalState = await terminalStatePromise;
+
+    expect(['error', 'idle']).toContain(terminalState);
+    console.log(`  ✅ DJCova reached terminal state "${terminalState}" — did not hang`);
+    if (terminalState === 'idle') {
+      console.log(
+        '  ⚠️  KNOWN GAP: error was not surfaced to the player — user may not see an error message',
+      );
+    }
+  }, 35_000);
+});

--- a/src/djcova/vitest.config.ts
+++ b/src/djcova/vitest.config.ts
@@ -14,8 +14,13 @@ export default defineConfig({
     environment: 'node',
     globals: true,
     include: ['tests/**/*.test.ts', 'src/**/*.test.ts', 'src/**/__tests__/**/*.test.ts'],
-    // Exclude integration tests from normal test runs
-    exclude: ['tests/**/*.integration.test.ts', 'src/**/*.integration.test.ts'],
+    // Exclude integration and pipeline tests from normal test runs.
+    // Pipeline tests require yt-dlp + network; run them with: npm run test:pipeline
+    exclude: [
+      'tests/**/*.integration.test.ts',
+      'src/**/*.integration.test.ts',
+      'tests/pipeline/**/*.pipeline.test.ts',
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov', 'html'],

--- a/src/djcova/vitest.pipeline.config.ts
+++ b/src/djcova/vitest.pipeline.config.ts
@@ -1,0 +1,39 @@
+/**
+ * Vitest configuration for pipeline tests.
+ *
+ * Pipeline tests exercise the real audio stack without a Discord connection:
+ *   binaries → yt-dlp stream → demuxProbe/AudioResource → DJCova.play()
+ *
+ * These tests require:
+ *   - yt-dlp installed (system or YTDLP_PATH env)
+ *   - Network access to YouTube
+ *   - ffmpeg (bundled via ffmpeg-static)
+ *
+ * Skip network tests: SKIP_NETWORK_TESTS=true npm run test:pipeline
+ */
+
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+      '@starbunk/shared': path.resolve(__dirname, '../shared/src'),
+    },
+  },
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['tests/pipeline/**/*.pipeline.test.ts'],
+    // Long timeout for network operations (yt-dlp can take ~10s to start streaming)
+    testTimeout: 60_000,
+    hookTimeout: 15_000,
+    // Run tests sequentially — each test spawns yt-dlp/ffmpeg processes and
+    // parallel execution can saturate resources and cause false failures.
+    pool: 'forks',
+    singleFork: true,
+    // Reporter with verbose output so pipeline failures are easy to diagnose
+    reporter: 'verbose',
+  },
+});


### PR DESCRIPTION
## Summary

- **4-layer pipeline test suite** that exercises the real `yt-dlp → demuxProbe → AudioResource → AudioPlayer.Playing` chain with no Discord connection — the mocked unit tests were passing even when the actual audio pipeline was broken
- **Pre-play diagnostic logging** so silent failures (bot in channel, no sound) are identifiable from logs at call time rather than after the fact
- **`djcova_silent_failure_total` Prometheus metric** for Grafana alerting on silent-play incidents
- **Suppresses `ERR_STREAM_PREMATURE_CLOSE` noise** — this was firing on every stop/skip and masking real errors

## Pipeline test layers

| File | What it tests | Needs network |
|------|--------------|---------------|
| `01-binaries` | yt-dlp version, ffmpeg-static on disk, opusscript loads | No |
| `02-yt-stream` | Real yt-dlp bytes from YouTube within 30s | Yes |
| `03-audio-resource` | `demuxProbe` + `createAudioResource` on live stream | Yes |
| `04-djcova-play` | `DJCova.play()` → `AudioPlayerStatus.Playing` (no Discord) | Yes |

Layer 4 is the gold standard: if it passes, the audio pipeline is operational. Run with:
```bash
npm run test:pipeline        # full pipeline
SKIP_NETWORK_TESTS=true npm run test:pipeline  # binaries only (CI/offline)
```

## Observability changes

Every `play()` call now logs a pre-flight snapshot:
- `❌ PRE-FLIGHT: No voice subscription registered` — audio will be silently discarded
- `❌ PRE-FLIGHT: Voice connection is not Ready (status: Disconnected)`
- `✅ PRE-FLIGHT OK: subscription present and connection Ready`

When the `AudioPlayer` reaches `Playing`:
- `✅ Audio confirmed flowing: subscription active and connection Ready` — audio is going out
- `❌ SILENT FAILURE: Player is Playing but no voice subscription exists` — + metric increment

## Known gap documented (not fixed here)

When yt-dlp reports "Video unavailable" after writing initial bytes, the stream error is swallowed by the demuxProbe/ffmpeg pipeline and the player goes silently `Idle` without notifying the user. The `04-djcova-play` test documents this with a `⚠️ KNOWN GAP` warning. Fixing the error propagation path is a separate issue.

## Test plan
- [ ] `npm run test:pipeline` — all 18 pipeline tests green (requires network + yt-dlp)
- [ ] `npm test` — all 221 unit tests still pass
- [ ] `npx tsc --build --dry` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)