### PR TITLE
fix(ci): rename Tailscale OAuth secrets to TAILSCALE_OAUTH_CLIENT_ID/SECRET

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,8 +4,8 @@ name: Deploy to Production
 # then SSHs into Tower using a deploy key to run deploy.sh + health-check.sh.
 #
 # Required secrets (production environment):
-#   TS_OAUTH_CLIENT_ID  — Tailscale OAuth client ID (tag:ci)
-#   TS_OAUTH_SECRET     — Tailscale OAuth client secret
+#   TAILSCALE_OAUTH_CLIENT_ID      — Tailscale OAuth client ID (tag:ci)
+#   TAILSCALE_OAUTH_CLIENT_SECRET  — Tailscale OAuth client secret
 #   SSH_PRIVATE_KEY     — Private key whose public half is in Tower's authorized_keys
 #   SSH_HOST            — Tower's Tailscale IP (100.x.x.x)
 #   SSH_USER            — SSH user on Tower (typically root)
@@ -44,15 +44,15 @@ jobs:
 
       - name: Preflight — check required secrets
         env:
-          CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          CLIENT_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
+          CLIENT_ID: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
           KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           HOST: ${{ secrets.SSH_HOST }}
           USER: ${{ secrets.SSH_USER }}
         run: |
           MISSING=""
-          [[ -z "$CLIENT_ID" ]]     && MISSING="$MISSING TS_OAUTH_CLIENT_ID"
-          [[ -z "$CLIENT_SECRET" ]] && MISSING="$MISSING TS_OAUTH_SECRET"
+          [[ -z "$CLIENT_ID" ]]     && MISSING="$MISSING TAILSCALE_OAUTH_CLIENT_ID"
+          [[ -z "$CLIENT_SECRET" ]] && MISSING="$MISSING TAILSCALE_OAUTH_CLIENT_SECRET"
           [[ -z "$KEY" ]]           && MISSING="$MISSING SSH_PRIVATE_KEY"
           [[ -z "$HOST" ]]          && MISSING="$MISSING SSH_HOST"
           [[ -z "$USER" ]]          && MISSING="$MISSING SSH_USER"
@@ -64,8 +64,8 @@ jobs:
       - name: Connect to Tailscale
         uses: tailscale/github-action@v3
         with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
           tags: tag:ci
 
       - name: Verify connectivity to Tower


### PR DESCRIPTION
## Summary
- Renames `TS_OAUTH_CLIENT_ID` → `TAILSCALE_OAUTH_CLIENT_SECRET`
- Renames `TS_OAUTH_SECRET` → `TAILSCALE_OAUTH_CLIENT_SECRET`

## Action required
Update the `production` environment secrets in GitHub to match the new names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)