### PR TITLE
feat(ci): use repo docker-compose.yml and configurable compose dir

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,13 +82,13 @@ jobs:
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
 
-      - name: Copy docker-compose.yml to Tower
+      - name: Stage docker-compose.yml on Tower
         run: |
           scp -i ~/.ssh/deploy_key \
             -o StrictHostKeyChecking=accept-new \
             -o ConnectTimeout=30 \
             docker-compose.yml \
-            "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${{ vars.PROD_DOCKER_COMPOSE_DIR }}/docker-compose.yml"
+            "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${{ vars.PROD_DOCKER_COMPOSE_DIR }}/docker-compose.yml.incoming"
 
       - name: Notify — deploy started
         if: vars.DISCORD_NOTIFY_USER_ID != ''
@@ -106,7 +106,7 @@ jobs:
             -o StrictHostKeyChecking=accept-new \
             -o ConnectTimeout=30 \
             "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
-            "bash -s -- ${{ vars.PROD_DOCKER_COMPOSE_DIR }} main ${SHORT_SHA}" \
+            "bash -s -- ${{ vars.PROD_DOCKER_COMPOSE_DIR }} main ${SHORT_SHA} ${{ vars.PROD_DOCKER_COMPOSE_DIR }}/docker-compose.yml.incoming" \
             < scripts/deployment/deploy.sh
 
       - name: Health check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,6 +82,14 @@ jobs:
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
 
+      - name: Copy docker-compose.yml to Tower
+        run: |
+          scp -i ~/.ssh/deploy_key \
+            -o StrictHostKeyChecking=accept-new \
+            -o ConnectTimeout=30 \
+            docker-compose.yml \
+            "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${{ vars.PROD_DOCKER_COMPOSE_DIR }}/docker-compose.yml"
+
       - name: Notify — deploy started
         if: vars.DISCORD_NOTIFY_USER_ID != ''
         uses: ./.github/actions/discord-dm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,8 +4,8 @@ name: Deploy to Production
 # then SSHs into Tower using a deploy key to run deploy.sh + health-check.sh.
 #
 # Required secrets (production environment):
-#   TS_OAUTH_CLIENT_ID  — Tailscale OAuth client ID (tag:ci)
-#   TS_OAUTH_SECRET     — Tailscale OAuth client secret
+#   TAILSCALE_OAUTH_CLIENT_ID      — Tailscale OAuth client ID (tag:ci)
+#   TAILSCALE_OAUTH_CLIENT_SECRET  — Tailscale OAuth client secret
 #   SSH_PRIVATE_KEY     — Private key whose public half is in Tower's authorized_keys
 #   SSH_HOST            — Tower's Tailscale IP (100.x.x.x)
 #   SSH_USER            — SSH user on Tower (typically root)
@@ -44,15 +44,15 @@ jobs:
 
       - name: Preflight — check required secrets
         env:
-          CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          CLIENT_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
+          CLIENT_ID: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
           KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           HOST: ${{ secrets.SSH_HOST }}
           USER: ${{ secrets.SSH_USER }}
         run: |
           MISSING=""
-          [[ -z "$CLIENT_ID" ]]     && MISSING="$MISSING TS_OAUTH_CLIENT_ID"
-          [[ -z "$CLIENT_SECRET" ]] && MISSING="$MISSING TS_OAUTH_SECRET"
+          [[ -z "$CLIENT_ID" ]]     && MISSING="$MISSING TAILSCALE_OAUTH_CLIENT_ID"
+          [[ -z "$CLIENT_SECRET" ]] && MISSING="$MISSING TAILSCALE_OAUTH_CLIENT_SECRET"
           [[ -z "$KEY" ]]           && MISSING="$MISSING SSH_PRIVATE_KEY"
           [[ -z "$HOST" ]]          && MISSING="$MISSING SSH_HOST"
           [[ -z "$USER" ]]          && MISSING="$MISSING SSH_USER"
@@ -64,8 +64,8 @@ jobs:
       - name: Connect to Tailscale
         uses: tailscale/github-action@v3
         with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
           tags: tag:ci
 
       - name: Verify connectivity to Tower

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,9 @@ name: Deploy to Production
 #   SSH_HOST            — Tower's Tailscale IP (100.x.x.x)
 #   SSH_USER            — SSH user on Tower (typically root)
 #
+# Required variables (production environment):
+#   PROD_DOCKER_COMPOSE_DIR  — Path on Tower where docker-compose.yml lives
+#
 # Required Tailscale setup (one-time):
 #   1. Create an OAuth client at tailscale.com/admin/settings/oauth
 #      with the "auth_keys" scope and tag:ci assigned.
@@ -49,6 +52,7 @@ jobs:
           KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           HOST: ${{ secrets.SSH_HOST }}
           USER: ${{ secrets.SSH_USER }}
+          COMPOSE_DIR: ${{ vars.PROD_DOCKER_COMPOSE_DIR }}
         run: |
           MISSING=""
           [[ -z "$CLIENT_ID" ]]     && MISSING="$MISSING TAILSCALE_OAUTH_CLIENT_ID"
@@ -56,6 +60,7 @@ jobs:
           [[ -z "$KEY" ]]           && MISSING="$MISSING SSH_PRIVATE_KEY"
           [[ -z "$HOST" ]]          && MISSING="$MISSING SSH_HOST"
           [[ -z "$USER" ]]          && MISSING="$MISSING SSH_USER"
+          [[ -z "$COMPOSE_DIR" ]]   && MISSING="$MISSING PROD_DOCKER_COMPOSE_DIR"
           if [[ -n "$MISSING" ]]; then
             echo "::error::Missing required secrets:$MISSING"
             exit 1
@@ -93,7 +98,7 @@ jobs:
             -o StrictHostKeyChecking=accept-new \
             -o ConnectTimeout=30 \
             "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
-            "bash -s -- /mnt/user/appdata/starbunk main ${SHORT_SHA}" \
+            "bash -s -- ${{ vars.PROD_DOCKER_COMPOSE_DIR }} main ${SHORT_SHA}" \
             < scripts/deployment/deploy.sh
 
       - name: Health check
@@ -102,7 +107,7 @@ jobs:
             -o StrictHostKeyChecking=accept-new \
             -o ConnectTimeout=30 \
             "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
-            'bash -s -- /mnt/user/appdata/starbunk' \
+            "bash -s -- ${{ vars.PROD_DOCKER_COMPOSE_DIR }}" \
             < scripts/deployment/health-check.sh
 
       - name: Notify — deploy succeeded

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -5,9 +5,10 @@ set -euo pipefail
 # Runs on Unraid server to pull latest images and restart services
 # Called by CircleCI deploy job via SSH
 
-COMPOSE_DIR="${1:-/mnt/user/appdata/starbunk}"
+COMPOSE_DIR="${1}"
 DEPLOY_TAG="${2:-main}"
 VERSION="${3:-unknown}"
+INCOMING_COMPOSE="${4:-}"  # optional path to a new docker-compose.yml to install after backup
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "🚀 Starbunk Production Deployment"
@@ -21,6 +22,11 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 # Verify compose directory exists
 if [ ! -d "$COMPOSE_DIR" ]; then
   echo "❌ Error: Compose directory not found: $COMPOSE_DIR"
+  exit 1
+fi
+
+if [ -z "$COMPOSE_DIR" ]; then
+  echo "❌ Error: COMPOSE_DIR argument is required"
   exit 1
 fi
 
@@ -73,6 +79,16 @@ backup_current_state() {
 
   echo "✅ Backup saved to: $BACKUP_DIR"
   echo ""
+}
+
+# Install incoming docker-compose.yml (after backup, so backup reflects previous state)
+install_incoming_compose() {
+  if [ -n "$INCOMING_COMPOSE" ] && [ -f "$INCOMING_COMPOSE" ]; then
+    echo "📋 Installing new docker-compose.yml from: $INCOMING_COMPOSE"
+    mv "$INCOMING_COMPOSE" docker-compose.yml
+    echo "✅ docker-compose.yml updated"
+    echo ""
+  fi
 }
 
 # Pull latest images
@@ -155,6 +171,7 @@ check_restart_loops() {
 main() {
   get_current_digests
   backup_current_state
+  install_incoming_compose
   pull_images
   restart_services
   wait_for_stability


### PR DESCRIPTION
## Summary
- Adds `scp` step to copy `docker-compose.yml` from the repo to Tower on each deploy — compose file always stays in sync with main
- Replaces hardcoded `/mnt/user/appdata/starbunk` with `PROD_DOCKER_COMPOSE_DIR` variable
- Renames Tailscale secrets to `TAILSCALE_OAUTH_CLIENT_ID` / `TAILSCALE_OAUTH_CLIENT_SECRET`

## Action required
Set in GitHub → Settings → Environments → `production`:
- **Variable**: `PROD_DOCKER_COMPOSE_DIR` — path on Tower where docker-compose lives (e.g. `/mnt/user/appdata/starbunk`)
- **Secret rename**: `TS_OAUTH_CLIENT_ID` → `TAILSCALE_OAUTH_CLIENT_ID`, `TS_OAUTH_SECRET` → `TAILSCALE_OAUTH_CLIENT_SECRET`

## Notes
- `.env` stays on Tower permanently, managed manually — CI never touches it
- Tower must have the compose dir created before first deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)