### PR TITLE
chore(deploy): rename .env to stack.env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -372,7 +372,7 @@ services:
     restart: unless-stopped
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-starbunk}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in stack.env}
       - POSTGRES_DB=${POSTGRES_DB:-starbunk}
       - PGDATA=/var/lib/postgresql/data/pgdata
     volumes:

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -40,9 +40,9 @@ fi
 
 # Check if docker-compose or docker compose is available
 if command -v docker-compose &> /dev/null; then
-  COMPOSE_CMD="docker-compose"
+  COMPOSE_CMD="docker-compose --env-file stack.env"
 elif docker compose version &> /dev/null; then
-  COMPOSE_CMD="docker compose"
+  COMPOSE_CMD="docker compose --env-file stack.env"
 else
   echo "❌ Error: Neither docker-compose nor docker compose is available"
   exit 1
@@ -70,9 +70,9 @@ backup_current_state() {
   BACKUP_DIR="${COMPOSE_DIR}/backups/deployment-$(date +%Y%m%d-%H%M%S)"
   mkdir -p "$BACKUP_DIR"
 
-  # Backup docker-compose.yml and .env
+  # Backup docker-compose.yml and stack.env
   cp docker-compose.yml "$BACKUP_DIR/" 2>/dev/null || true
-  cp .env "$BACKUP_DIR/" 2>/dev/null || true
+  cp stack.env "$BACKUP_DIR/" 2>/dev/null || true
 
   # Save current container list
   $COMPOSE_CMD ps --format json > "$BACKUP_DIR/containers.json" 2>/dev/null || true

--- a/scripts/deployment/health-check.sh
+++ b/scripts/deployment/health-check.sh
@@ -20,9 +20,9 @@ cd "$COMPOSE_DIR"
 
 # Determine docker-compose command
 if command -v docker-compose &> /dev/null; then
-  COMPOSE_CMD="docker-compose"
+  COMPOSE_CMD="docker-compose --env-file stack.env"
 elif docker compose version &> /dev/null; then
-  COMPOSE_CMD="docker compose"
+  COMPOSE_CMD="docker compose --env-file stack.env"
 else
   echo "❌ Error: Neither docker-compose nor docker compose is available"
   exit 1

--- a/scripts/deployment/rollback.sh
+++ b/scripts/deployment/rollback.sh
@@ -36,9 +36,9 @@ fi
 
 # Determine docker-compose command
 if command -v docker-compose &> /dev/null; then
-  COMPOSE_CMD="docker-compose"
+  COMPOSE_CMD="docker-compose --env-file stack.env"
 elif docker compose version &> /dev/null; then
-  COMPOSE_CMD="docker compose"
+  COMPOSE_CMD="docker compose --env-file stack.env"
 else
   echo "❌ Error: Neither docker-compose nor docker compose is available"
   exit 1
@@ -106,7 +106,7 @@ backup_current_state() {
   mkdir -p "$SAFETY_BACKUP_DIR"
 
   cp docker-compose.yml "$SAFETY_BACKUP_DIR/" 2>/dev/null || true
-  cp .env "$SAFETY_BACKUP_DIR/" 2>/dev/null || true
+  cp stack.env "$SAFETY_BACKUP_DIR/" 2>/dev/null || true
   $COMPOSE_CMD ps --format json > "$SAFETY_BACKUP_DIR/containers.json" 2>/dev/null || true
 
   echo "✅ Safety backup created: $SAFETY_BACKUP_DIR"
@@ -135,12 +135,12 @@ restore_configuration() {
     echo "⚠️  No docker-compose.yml in backup - keeping current"
   fi
 
-  # Restore .env if it exists in backup
-  if [ -f "$BACKUP_DIR/.env" ]; then
-    cp "$BACKUP_DIR/.env" ./.env
-    echo "✅ Restored .env"
+  # Restore stack.env if it exists in backup
+  if [ -f "$BACKUP_DIR/stack.env" ]; then
+    cp "$BACKUP_DIR/stack.env" ./stack.env
+    echo "✅ Restored stack.env"
   else
-    echo "⚠️  No .env in backup - keeping current"
+    echo "⚠️  No stack.env in backup - keeping current"
   fi
 
   echo ""


### PR DESCRIPTION
## Summary

- Rename `.env` → `stack.env` across all deployment scripts and `docker-compose.yml`
- Add `--env-file stack.env` to `COMPOSE_CMD` in `deploy.sh`, `health-check.sh`, and `rollback.sh` so Docker Compose uses the renamed file for variable substitution
- Update backup/restore logic in `deploy.sh` and `rollback.sh` to copy `stack.env`

## On Tower
Rename the existing env file before the next deploy:
```bash
mv $PROD_DOCKER_COMPOSE_DIR/.env $PROD_DOCKER_COMPOSE_DIR/stack.env
```

## Test plan
- [ ] Rename `.env` → `stack.env` on Tower before triggering a deploy
- [ ] Confirm deploy completes and containers start healthy
- [ ] Confirm rollback script picks up `stack.env` from backup if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)