### PR TITLE
fix(deploy): remove stale containers before bringing up new ones

### DIFF
--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -112,9 +112,14 @@ pull_images() {
 restart_services() {
   echo "🔄 Restarting services with new images..."
 
-  # Use --force-recreate to ensure containers are rebuilt with new images
-  # Use --no-build to prevent local builds (we want to use pulled images)
-  $COMPOSE_CMD up -d --force-recreate --no-build
+  # Gracefully stop containers owned by this compose project
+  $COMPOSE_CMD down 2>/dev/null || true
+
+  # Force-remove any starbunk containers that weren't owned by this project
+  # (e.g. created under a different project name before the name: field was pinned)
+  docker ps -aq --filter "name=starbunk-" | xargs -r docker rm -f 2>/dev/null || true
+
+  $COMPOSE_CMD up -d --no-build
 
   EXIT_CODE=$?
   if [ $EXIT_CODE -ne 0 ]; then


### PR DESCRIPTION
## Summary

- `docker compose up --force-recreate` cannot take ownership of containers created under a different project name (e.g. before `name: starbunk-js` was pinned in docker-compose.yml)
- Add `compose down` before the `up` to gracefully stop containers owned by the current project
- Add a `docker rm -f` sweep on any remaining `starbunk-*` containers to clear strays from the old project context

## Test plan
- [ ] Trigger deploy with existing starbunk containers running on Tower
- [ ] Confirm deploy completes without "container name already in use" error
- [ ] Confirm all containers come up healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)