### PR TITLE
feat(ci): install @starbunk/shared from GitHub Packages in Docker builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,12 +193,27 @@ jobs:
             echo "shared version unchanged (${NEW_VER})"
           fi
 
-      - name: Build shared for publish
+      - name: Check if version already published
+        id: check_published
         if: steps.check_version.outputs.changed == 'true'
+        run: |
+          NEW_VER="${{ steps.check_version.outputs.new_version }}"
+          if npm view "@starbunk/shared@${NEW_VER}" version \
+               --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
+            echo "already_published=true" >> $GITHUB_OUTPUT
+            echo "@starbunk/shared@${NEW_VER} already published — skipping"
+          else
+            echo "already_published=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build shared for publish
+        if: steps.check_version.outputs.changed == 'true' && steps.check_published.outputs.already_published != 'true'
         run: npm run build:shared
 
       - name: Publish @starbunk/shared
-        if: steps.check_version.outputs.changed == 'true'
+        if: steps.check_version.outputs.changed == 'true' && steps.check_published.outputs.already_published != 'true'
         run: cd src/shared && npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -267,6 +282,8 @@ jobs:
               --build-arg APP_VERSION="${APP_VERSION}" \
               --secret id=npm_token,env=GITHUB_TOKEN \
               -t ${IMAGE}:main -t ${IMAGE}:sha-${HASH} .
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             docker push ${IMAGE}:sha-${HASH}
           fi
           docker tag "${IMAGE}:main" "${IMAGE}:sha-${GIT_SHA}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,11 +144,75 @@ jobs:
           path: build-artifacts.tar.gz
           retention-days: 1
 
+  # ─── Publish @starbunk/shared to GitHub Packages (before Docker builds) ──────
+  publish_shared:
+    name: Publish Shared Package
+    runs-on: ubuntu-latest
+    needs: [detect_changes, build_apps]
+    # Only run when shared source changed; app Docker builds will then
+    # install the new version from the registry rather than vendoring local dist.
+    if: needs.detect_changes.outputs.shared == 'true'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.CI_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'npm'
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: build-artifacts
+
+      - name: Restore bumped package.json files from artifact
+        run: |
+          tar -xzf build-artifacts.tar.gz --wildcards 'src/shared/package.json' 2>/dev/null || \
+          tar -xzf build-artifacts.tar.gz
+
+      - name: Check if shared version changed
+        id: check_version
+        run: |
+          NEW_VER=$(node -p "require('./src/shared/package.json').version")
+          OLD_VER=$(git show HEAD:src/shared/package.json 2>/dev/null \
+            | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).version))" \
+            2>/dev/null || echo "0.0.0")
+          echo "new_version=${NEW_VER}" >> $GITHUB_OUTPUT
+          if [ "$NEW_VER" != "$OLD_VER" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "shared: ${OLD_VER} -> ${NEW_VER}"
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "shared version unchanged (${NEW_VER})"
+          fi
+
+      - name: Build shared for publish
+        if: steps.check_version.outputs.changed == 'true'
+        run: npm run build:shared
+
+      - name: Publish @starbunk/shared
+        if: steps.check_version.outputs.changed == 'true'
+        run: cd src/shared && npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # ─── Docker publish (only changed apps) ──────────────────────────────────────
   docker_publish:
     name: Docker Publish
     runs-on: ubuntu-latest
-    needs: [detect_changes, build_apps]
+    needs: [detect_changes, build_apps, publish_shared]
+    # Run if publish_shared succeeded or was skipped (no shared changes)
+    if: >-
+      always() &&
+      needs.build_apps.result == 'success' &&
+      (needs.publish_shared.result == 'success' || needs.publish_shared.result == 'skipped')
     strategy:
       fail-fast: false
       matrix:
@@ -201,6 +265,7 @@ jobs:
             APP_VERSION=$(node -p "require('./src/${APP}/package.json').version" 2>/dev/null || echo "dev")
             docker build -f ./src/${APP}/Dockerfile.ci \
               --build-arg APP_VERSION="${APP_VERSION}" \
+              --secret id=npm_token,env=GITHUB_TOKEN \
               -t ${IMAGE}:main -t ${IMAGE}:sha-${HASH} .
             docker push ${IMAGE}:sha-${HASH}
           fi
@@ -348,13 +413,14 @@ jobs:
   publish_releases:
     name: Publish Releases
     runs-on: ubuntu-latest
-    needs: [detect_changes, docker_publish, e2e_tests]
-    # Run even if docker_publish/e2e were skipped (shared-only change).
-    # Only skip if a dependency actually failed.
+    needs: [detect_changes, publish_shared, docker_publish, e2e_tests]
+    # Run unless a dependency actually failed (skipped is fine — shared-only
+    # or no-app-change runs skip docker/e2e but still need version commits).
     if: >-
       always() &&
       !cancelled() &&
       needs.detect_changes.result == 'success' &&
+      (needs.publish_shared.result == 'success' || needs.publish_shared.result == 'skipped') &&
       (needs.docker_publish.result == 'success' || needs.docker_publish.result == 'skipped') &&
       (needs.e2e_tests.result == 'success' || needs.e2e_tests.result == 'skipped')
     steps:
@@ -465,22 +531,19 @@ jobs:
               echo "Created tag: ${TAG}"
             fi
 
-            # Publish @starbunk/shared to GitHub Packages
-            if [[ "$APP" == "shared" ]]; then
-              cd src/shared && npm publish && cd ../..
-            else
+            if [[ "$APP" != "shared" ]]; then
               # Tag the Docker image for bot containers
               IMAGE="ghcr.io/${OWNER_LC}/${APP}"
               docker pull "${IMAGE}:latest" || true
               docker tag "${IMAGE}:latest" "${IMAGE}:${VERSION}"
               docker push "${IMAGE}:${VERSION}"
             fi
+            # shared is published in publish_shared (before Docker builds)
           done
 
           git push --tags
         env:
           GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create build tag (no version bumps)
         id: build_tag

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 audit=false
 @starbunk:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9784,6 +9784,7 @@
       "name": "@starbunk/bluebot",
       "version": "1.31.0",
       "dependencies": {
+        "@starbunk/shared": "1.31.0",
         "discord.js": "^14.26.3",
         "dotenv": "^17.2.3",
         "fastest-levenshtein": "^1.0.16",
@@ -9855,7 +9856,7 @@
       "name": "@starbunk/bunkbot",
       "version": "1.31.0",
       "dependencies": {
-        "@starbunk/shared": "*",
+        "@starbunk/shared": "1.31.0",
         "discord.js": "^14.26.3",
         "dotenv": "^17.2.3",
         "js-yaml": "^4.1.1",
@@ -9929,7 +9930,7 @@
       "name": "@starbunk/covabot",
       "version": "1.31.0",
       "dependencies": {
-        "@starbunk/shared": "*",
+        "@starbunk/shared": "1.31.0",
         "discord.js": "^14.26.3",
         "dotenv": "^16.5.0",
         "js-yaml": "^4.1.0",
@@ -10023,7 +10024,7 @@
         "@discordjs/builders": "^1.6.5",
         "@discordjs/rest": "^2.5.0",
         "@discordjs/voice": "^0.18.0",
-        "@starbunk/shared": "*",
+        "@starbunk/shared": "1.31.0",
         "chalk": "^4.1.2",
         "discord-api-types": "^0.38.23",
         "discord.js": "^14.26.3",

--- a/src/bluebot/Dockerfile.ci
+++ b/src/bluebot/Dockerfile.ci
@@ -24,16 +24,18 @@ RUN apk add --no-cache openssl dumb-init curl && \
     adduser -S -D -H -u 1001 -h /app -s /sbin/nologin -G bluebot bluebot
 
 # Copy package files for dependency installation
+# Note: src/shared is intentionally NOT copied — without its directory present,
+# npm workspaces skips it and installs @starbunk/shared from GitHub Packages.
 COPY package.json package-lock.json* ./
-COPY src/shared/package.json ./src/shared/
 COPY src/bluebot/package.json ./src/bluebot/
 
-# Install only production dependencies
+# Install only production dependencies, fetching @starbunk/shared from registry
 RUN --mount=type=cache,target=/root/.npm \
-    npm ci --prefer-offline --no-audit --omit=dev --ignore-scripts
+    --mount=type=secret,id=npm_token \
+    NODE_AUTH_TOKEN=$(cat /run/secrets/npm_token 2>/dev/null || echo "") \
+    npm install --prefer-offline --no-audit --omit=dev --ignore-scripts
 
-# Copy pre-built artifacts from CI
-COPY --chown=bluebot:bluebot src/shared/dist ./src/shared/dist
+# Copy pre-built app artifact from CI
 COPY --chown=bluebot:bluebot src/bluebot/dist ./src/bluebot/dist
 
 # Set default environment variables from build args

--- a/src/bluebot/Dockerfile.ci
+++ b/src/bluebot/Dockerfile.ci
@@ -29,6 +29,9 @@ RUN apk add --no-cache openssl dumb-init curl && \
 COPY package.json package-lock.json* ./
 COPY src/bluebot/package.json ./src/bluebot/
 
+# Copy .npmrc for @starbunk registry config (no token — token comes from secret mount)
+COPY .npmrc ./
+
 # Install only production dependencies, fetching @starbunk/shared from registry
 RUN --mount=type=cache,target=/root/.npm \
     --mount=type=secret,id=npm_token \

--- a/src/bluebot/package.json
+++ b/src/bluebot/package.json
@@ -26,6 +26,7 @@
     "deps:list": "npm list --depth=0"
   },
   "dependencies": {
+    "@starbunk/shared": "1.31.0",
     "discord.js": "^14.26.3",
     "dotenv": "^17.2.3",
     "fastest-levenshtein": "^1.0.16",

--- a/src/bunkbot/Dockerfile.ci
+++ b/src/bunkbot/Dockerfile.ci
@@ -21,16 +21,18 @@ RUN apk add --no-cache openssl dumb-init curl && \
     adduser -S -D -H -u 1001 -h /app -s /sbin/nologin -G bunkbot bunkbot
 
 # Copy package files for dependency installation
+# Note: src/shared is intentionally NOT copied — without its directory present,
+# npm workspaces skips it and installs @starbunk/shared from GitHub Packages.
 COPY package.json package-lock.json* ./
-COPY src/shared/package.json ./src/shared/
 COPY src/bunkbot/package.json ./src/bunkbot/
 
-# Install only production dependencies
+# Install only production dependencies, fetching @starbunk/shared from registry
 RUN --mount=type=cache,target=/root/.npm \
-    npm ci --prefer-offline --no-audit --omit=dev --ignore-scripts
+    --mount=type=secret,id=npm_token \
+    NODE_AUTH_TOKEN=$(cat /run/secrets/npm_token 2>/dev/null || echo "") \
+    npm install --prefer-offline --no-audit --omit=dev --ignore-scripts
 
-# Copy pre-built artifacts from CI
-COPY --chown=bunkbot:bunkbot src/shared/dist ./src/shared/dist
+# Copy pre-built app artifact from CI
 COPY --chown=bunkbot:bunkbot src/bunkbot/dist ./src/bunkbot/dist
 
 # Set default environment variables from build args

--- a/src/bunkbot/Dockerfile.ci
+++ b/src/bunkbot/Dockerfile.ci
@@ -26,6 +26,9 @@ RUN apk add --no-cache openssl dumb-init curl && \
 COPY package.json package-lock.json* ./
 COPY src/bunkbot/package.json ./src/bunkbot/
 
+# Copy .npmrc for @starbunk registry config (no token — token comes from secret mount)
+COPY .npmrc ./
+
 # Install only production dependencies, fetching @starbunk/shared from registry
 RUN --mount=type=cache,target=/root/.npm \
     --mount=type=secret,id=npm_token \

--- a/src/bunkbot/package.json
+++ b/src/bunkbot/package.json
@@ -24,7 +24,7 @@
     "pipeline": "npm run lint && npm run type-check && npm run build && npm run test"
   },
   "dependencies": {
-    "@starbunk/shared": "*",
+    "@starbunk/shared": "1.31.0",
     "discord.js": "^14.26.3",
     "dotenv": "^17.2.3",
     "js-yaml": "^4.1.1",

--- a/src/covabot/Dockerfile.ci
+++ b/src/covabot/Dockerfile.ci
@@ -27,16 +27,18 @@ RUN apk add --no-cache openssl dumb-init curl python3 make g++ && \
     chown -R covabot:covabot /app/data /app/config /app/src/config
 
 # Copy package files for dependency installation
+# Note: src/shared is intentionally NOT copied — without its directory present,
+# npm workspaces skips it and installs @starbunk/shared from GitHub Packages.
 COPY package.json package-lock.json* ./
-COPY src/shared/package.json ./src/shared/
 COPY src/covabot/package.json ./src/covabot/
 
-# Install only production dependencies
+# Install only production dependencies, fetching @starbunk/shared from registry
 RUN --mount=type=cache,target=/root/.npm \
-    npm ci --prefer-offline --no-audit --omit=dev --ignore-scripts
+    --mount=type=secret,id=npm_token \
+    NODE_AUTH_TOKEN=$(cat /run/secrets/npm_token 2>/dev/null || echo "") \
+    npm install --prefer-offline --no-audit --omit=dev --ignore-scripts
 
-# Copy pre-built artifacts from CI
-COPY --chown=covabot:covabot src/shared/dist ./src/shared/dist
+# Copy pre-built app artifact from CI
 COPY --chown=covabot:covabot src/covabot/dist ./src/covabot/dist
 COPY --chown=covabot:covabot src/covabot/migrations ./src/covabot/migrations
 

--- a/src/covabot/Dockerfile.ci
+++ b/src/covabot/Dockerfile.ci
@@ -32,6 +32,9 @@ RUN apk add --no-cache openssl dumb-init curl python3 make g++ && \
 COPY package.json package-lock.json* ./
 COPY src/covabot/package.json ./src/covabot/
 
+# Copy .npmrc for @starbunk registry config (no token — token comes from secret mount)
+COPY .npmrc ./
+
 # Install only production dependencies, fetching @starbunk/shared from registry
 RUN --mount=type=cache,target=/root/.npm \
     --mount=type=secret,id=npm_token \

--- a/src/covabot/package.json
+++ b/src/covabot/package.json
@@ -17,7 +17,7 @@
     "lint:fix": "eslint --ext .ts src --fix"
   },
   "dependencies": {
-    "@starbunk/shared": "*",
+    "@starbunk/shared": "1.31.0",
     "discord.js": "^14.26.3",
     "dotenv": "^16.5.0",
     "js-yaml": "^4.1.0",

--- a/src/djcova/Dockerfile.ci
+++ b/src/djcova/Dockerfile.ci
@@ -27,16 +27,18 @@ RUN apk add --no-cache ffmpeg openssl dumb-init curl python3 py3-pip && \
     pip3 install --no-cache-dir --break-system-packages "yt-dlp==2025.12.8"
 
 # Copy package files for dependency installation
+# Note: src/shared is intentionally NOT copied — without its directory present,
+# npm workspaces skips it and installs @starbunk/shared from GitHub Packages.
 COPY package.json package-lock.json* ./
-COPY src/shared/package.json ./src/shared/
 COPY src/djcova/package.json ./src/djcova/
 
-# Install only production dependencies
+# Install only production dependencies, fetching @starbunk/shared from registry
 RUN --mount=type=cache,target=/root/.npm \
-    npm ci --prefer-offline --no-audit --omit=dev --ignore-scripts
+    --mount=type=secret,id=npm_token \
+    NODE_AUTH_TOKEN=$(cat /run/secrets/npm_token 2>/dev/null || echo "") \
+    npm install --prefer-offline --no-audit --omit=dev --ignore-scripts
 
-# Copy pre-built artifacts from CI
-COPY --chown=djcova:djcova src/shared/dist ./src/shared/dist
+# Copy pre-built app artifact from CI
 COPY --chown=djcova:djcova src/djcova/dist ./src/djcova/dist
 
 # Set default environment variables from build args

--- a/src/djcova/Dockerfile.ci
+++ b/src/djcova/Dockerfile.ci
@@ -32,6 +32,9 @@ RUN apk add --no-cache ffmpeg openssl dumb-init curl python3 py3-pip && \
 COPY package.json package-lock.json* ./
 COPY src/djcova/package.json ./src/djcova/
 
+# Copy .npmrc for @starbunk registry config (no token — token comes from secret mount)
+COPY .npmrc ./
+
 # Install only production dependencies, fetching @starbunk/shared from registry
 RUN --mount=type=cache,target=/root/.npm \
     --mount=type=secret,id=npm_token \

--- a/src/djcova/package.json
+++ b/src/djcova/package.json
@@ -22,7 +22,7 @@
     "@discordjs/builders": "^1.6.5",
     "@discordjs/rest": "^2.5.0",
     "@discordjs/voice": "^0.18.0",
-    "@starbunk/shared": "*",
+    "@starbunk/shared": "1.31.0",
     "chalk": "^4.1.2",
     "discord-api-types": "^0.38.23",
     "discord.js": "^14.26.3",


### PR DESCRIPTION
## Summary

Closes #697. Apps now install `@starbunk/shared` from the npm registry (`npm.pkg.github.com`) instead of copying `src/shared/dist/` into each Docker image.

**What changed:**

- **Dockerfiles** (all 4 apps): removed `COPY src/shared/package.json` and `COPY src/shared/dist` — without the directory present, npm workspaces skips it and falls through to the registry. Added `--mount=type=secret,id=npm_token` so `npm install` can authenticate with GitHub Packages.
- **App `package.json`**: `@starbunk/shared` pinned to `1.31.0` (was `"*"`). Bluebot gains an explicit dep it previously inherited silently via workspace hoisting.
- **CI workflow**: new `publish_shared` job runs after `build_apps` and before `docker_publish` — publishes the package when shared source changed, so the new version is available when app images are built.
- `docker_publish` now passes `GITHUB_TOKEN` as a Docker build secret for npm auth.
- `publish_releases` no longer re-publishes shared (done earlier in `publish_shared`).

**The result:**
- Shared-only PR → `publish_shared` runs, new version goes to GitHub Packages, no app images rebuild
- App + shared PR → `publish_shared` runs first, then app image builds install the new version
- App-only PR → `publish_shared` skipped, app image builds install existing pinned version

## Test plan
- [x] `npm run check:ci` passes locally (113 tests)
- [ ] CI green on this PR
- [ ] Verify a shared-only merge publishes the package without triggering app image builds
- [ ] Verify an app+shared merge correctly installs the new shared version in the app image

🤖 Generated with [Claude Code](https://claude.com/claude-code)