### PR TITLE
fix(ci): skip validation on workflow-only changes; add force-validation label override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI / PR Validation
 on:
   pull_request:
     branches: [ main ]
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
   changes:
@@ -16,6 +16,7 @@ jobs:
       bluebot: ${{ steps.filter.outputs.bluebot }}
       core: ${{ steps.filter.outputs.core }}
       e2e: ${{ steps.filter.outputs.e2e }}
+      force_validate: ${{ contains(github.event.pull_request.labels.*.name, 'force-validation') }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -45,7 +46,7 @@ jobs:
     name: BunkBot Validation
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.bunkbot == 'true' || needs.changes.outputs.core == 'true' }}
+    if: ${{ needs.changes.outputs.bunkbot == 'true' || needs.changes.outputs.core == 'true' || needs.changes.outputs.force_validate == 'true' }}
     steps:
       - uses: actions/checkout@v6
       - name: Setup Node
@@ -68,7 +69,7 @@ jobs:
     name: CovaBot Validation
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.covabot == 'true' || needs.changes.outputs.core == 'true' }}
+    if: ${{ needs.changes.outputs.covabot == 'true' || needs.changes.outputs.core == 'true' || needs.changes.outputs.force_validate == 'true' }}
     steps:
       - uses: actions/checkout@v6
       - name: Setup Node
@@ -91,7 +92,7 @@ jobs:
     name: DJCova Validation
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.djcova == 'true' || needs.changes.outputs.core == 'true' }}
+    if: ${{ needs.changes.outputs.djcova == 'true' || needs.changes.outputs.core == 'true' || needs.changes.outputs.force_validate == 'true' }}
     steps:
       - uses: actions/checkout@v6
       - name: Setup Node
@@ -114,7 +115,7 @@ jobs:
     name: DJCova Pipeline Tests
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.djcova == 'true' || needs.changes.outputs.core == 'true' }}
+    if: ${{ needs.changes.outputs.djcova == 'true' || needs.changes.outputs.core == 'true' || needs.changes.outputs.force_validate == 'true' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -144,7 +145,7 @@ jobs:
     name: BlueBot Validation
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.bluebot == 'true' || needs.changes.outputs.core == 'true' }}
+    if: ${{ needs.changes.outputs.bluebot == 'true' || needs.changes.outputs.core == 'true' || needs.changes.outputs.force_validate == 'true' }}
     steps:
       - uses: actions/checkout@v6
       - name: Setup Node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
             core:
               - 'package.json'
               - 'package-lock.json'
-              - '.github/workflows/**'
             e2e:
               - 'src/e2e/**'
               - 'docker-compose.e2e.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
         needs.changes.outputs.djcova == 'true' ||
         needs.changes.outputs.bluebot == 'true' ||
         needs.changes.outputs.e2e == 'true' ||
-        needs.changes.outputs.core == 'true'
+        needs.changes.outputs.force_validate == 'true'
       )
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -265,6 +265,8 @@ jobs:
 
       - name: Check exists and build image
         id: check_build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           APP=${{ matrix.app }}
           OWNER_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
@@ -282,8 +284,6 @@ jobs:
               --build-arg APP_VERSION="${APP_VERSION}" \
               --secret id=npm_token,env=GITHUB_TOKEN \
               -t ${IMAGE}:main -t ${IMAGE}:sha-${HASH} .
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             docker push ${IMAGE}:sha-${HASH}
           fi
           docker tag "${IMAGE}:main" "${IMAGE}:sha-${GIT_SHA}"


### PR DESCRIPTION
## Summary
- Remove `.github/workflows/**` from the `core` path filter — workflow-only PRs no longer trigger type-check, lint, build, or test jobs for any app
- Remove `core` trigger from E2E job for the same reason (`package.json` changes don't require E2E)
- Add `labeled` to PR trigger types and a `force-validation` label override — adding the `force-validation` label to any PR forces all validation and E2E jobs to run regardless of what files changed

## Test plan
- [ ] Workflow-only PR: validation and E2E jobs are skipped
- [ ] `package.json`-only change: validation jobs run, E2E skipped
- [ ] App source change: relevant validation and E2E jobs run as before
- [ ] Adding `force-validation` label: all jobs run

🤖 Generated with [Claude Code](https://claude.com/claude-code)