### PR TITLE
fix(ci): track .changeset/config.json; unblock from gitignore

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "restricted",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ cypress/downloads/
 .env.local
 .env copy
 config.json
+!.changeset/config.json
 bots.yml
 prometheus.yml
 


### PR DESCRIPTION
## Summary
- `.changeset/config.json` was never committed — a blanket `config.json` rule in `.gitignore` silently excluded it
- CI was failing during the **Apply changesets** step with `ENOENT: no such file or directory, open '.../.changeset/config.json'`
- Added `!.changeset/config.json` negation to `.gitignore` and committed the file

## Test plan
- [ ] CD / Main Merge — Apply changesets step passes without ENOENT

🤖 Generated with [Claude Code](https://claude.com/claude-code)