### PR TITLE
fix(ci): always run publish_shared when build_apps succeeds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,9 +149,11 @@ jobs:
     name: Publish Shared Package
     runs-on: ubuntu-latest
     needs: [detect_changes, build_apps]
-    # Only run when shared source changed; app Docker builds will then
-    # install the new version from the registry rather than vendoring local dist.
-    if: needs.detect_changes.outputs.shared == 'true'
+    # Run whenever build_apps succeeds — the internal check_version step skips
+    # publishing if the version is unchanged or already published. Gating only
+    # on shared source changes misses the case where a pending changeset bumps
+    # the shared version but the triggering PR didn't touch shared source.
+    if: needs.build_apps.result == 'success'
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Root cause

CI was failing on every push to main with:
```
npm error 404  The requested resource '@starbunk/shared@1.31.1' could not be found
```

The chain of events:
1. `build_apps` runs `npx changeset version` → bumps `@starbunk/shared` from `1.31.0` → `1.31.1` (due to the pending `fix-webhook-identity-fallback` changeset)
2. The bumped `package.json` files are packed into the build artifact
3. `publish_shared` was gated on `detect_changes.outputs.shared == 'true'` — only runs if shared **source** changed in the triggering PR
4. PRs #701, #702, #703 were CI/infra-only and didn't touch shared source → `publish_shared` was **skipped**
5. `docker_publish` extracted the artifact (containing `@starbunk/shared@1.31.1`) and tried to `npm install` it from GitHub Packages — **which was never published**

## Fix

Change `publish_shared`'s `if` condition from:
```yaml
if: needs.detect_changes.outputs.shared == 'true'
```
to:
```yaml
if: needs.build_apps.result == 'success'
```

The job's internal `check_version` and `check_published` steps already handle idempotency — they skip the actual `npm publish` if the version is unchanged or already published. The outer gate was just too narrow.

## Test plan
- [ ] CI passes on this PR (changeset check, type-check, lint, tests)
- [ ] After merge, CD Main Merge run should: run `publish_shared`, publish `@starbunk/shared@1.31.1`, then successfully build all Docker images

🤖 Generated with [Claude Code](https://claude.com/claude-code)