### PR TITLE
fix(ci): revert Dockerfile.ci to local shared dist; drop publish_shared job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           # E2E matrix: always include the infrastructure test, plus one entry per changed app
           E2E_INCLUDE='[{"app":"infrastructure","test_cmd":"test:infra"}]'
           for APP in "${APPS[@]}"; do
-            E2E_INCLUDE=$(echo "$E2E_INCLUDE" | jq --arg app "$APP" --arg cmd "test:${APP}" '. + [{"app":$app,"test_cmd":$cmd}]')
+            E2E_INCLUDE=$(echo "$E2E_INCLUDE" | jq -c --arg app "$APP" --arg cmd "test:${APP}" '. + [{"app":$app,"test_cmd":$cmd}]')
           done
 
           echo "changed_apps=$APPS_JSON" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,92 +144,12 @@ jobs:
           path: build-artifacts.tar.gz
           retention-days: 1
 
-  # ─── Publish @starbunk/shared to GitHub Packages (before Docker builds) ──────
-  publish_shared:
-    name: Publish Shared Package
-    runs-on: ubuntu-latest
-    needs: [detect_changes, build_apps]
-    # Run whenever build_apps succeeds — the internal check_version step skips
-    # publishing if the version is unchanged or already published. Gating only
-    # on shared source changes misses the case where a pending changeset bumps
-    # the shared version but the triggering PR didn't touch shared source.
-    if: needs.build_apps.result == 'success'
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.CI_TOKEN }}
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: 'npm'
-          registry-url: 'https://npm.pkg.github.com'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Download build artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: build-artifacts
-
-      - name: Restore bumped package.json files from artifact
-        run: |
-          tar -xzf build-artifacts.tar.gz --wildcards 'src/shared/package.json' 2>/dev/null || \
-          tar -xzf build-artifacts.tar.gz
-
-      - name: Check if shared version changed
-        id: check_version
-        run: |
-          NEW_VER=$(node -p "require('./src/shared/package.json').version")
-          OLD_VER=$(git show HEAD:src/shared/package.json 2>/dev/null \
-            | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).version))" \
-            2>/dev/null || echo "0.0.0")
-          echo "new_version=${NEW_VER}" >> $GITHUB_OUTPUT
-          if [ "$NEW_VER" != "$OLD_VER" ]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
-            echo "shared: ${OLD_VER} -> ${NEW_VER}"
-          else
-            echo "changed=false" >> $GITHUB_OUTPUT
-            echo "shared version unchanged (${NEW_VER})"
-          fi
-
-      - name: Check if version already published
-        id: check_published
-        if: steps.check_version.outputs.changed == 'true'
-        run: |
-          NEW_VER="${{ steps.check_version.outputs.new_version }}"
-          if npm view "@starbunk/shared@${NEW_VER}" version \
-               --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
-            echo "already_published=true" >> $GITHUB_OUTPUT
-            echo "@starbunk/shared@${NEW_VER} already published — skipping"
-          else
-            echo "already_published=false" >> $GITHUB_OUTPUT
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build shared for publish
-        if: steps.check_version.outputs.changed == 'true' && steps.check_published.outputs.already_published != 'true'
-        run: npm run build:shared
-
-      - name: Publish @starbunk/shared
-        if: steps.check_version.outputs.changed == 'true' && steps.check_published.outputs.already_published != 'true'
-        run: cd src/shared && npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   # ─── Docker publish (only changed apps) ──────────────────────────────────────
   docker_publish:
     name: Docker Publish
     runs-on: ubuntu-latest
-    needs: [detect_changes, build_apps, publish_shared]
-    # Run if publish_shared succeeded or was skipped (no shared changes)
-    if: >-
-      always() &&
-      needs.build_apps.result == 'success' &&
-      (needs.publish_shared.result == 'success' || needs.publish_shared.result == 'skipped')
+    needs: [detect_changes, build_apps]
+    if: needs.build_apps.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -284,7 +204,6 @@ jobs:
             APP_VERSION=$(node -p "require('./src/${APP}/package.json').version" 2>/dev/null || echo "dev")
             docker build -f ./src/${APP}/Dockerfile.ci \
               --build-arg APP_VERSION="${APP_VERSION}" \
-              --secret id=npm_token,env=GITHUB_TOKEN \
               -t ${IMAGE}:main -t ${IMAGE}:sha-${HASH} .
             docker push ${IMAGE}:sha-${HASH}
           fi
@@ -432,14 +351,13 @@ jobs:
   publish_releases:
     name: Publish Releases
     runs-on: ubuntu-latest
-    needs: [detect_changes, publish_shared, docker_publish, e2e_tests]
+    needs: [detect_changes, docker_publish, e2e_tests]
     # Run unless a dependency actually failed (skipped is fine — shared-only
     # or no-app-change runs skip docker/e2e but still need version commits).
     if: >-
       always() &&
       !cancelled() &&
       needs.detect_changes.result == 'success' &&
-      (needs.publish_shared.result == 'success' || needs.publish_shared.result == 'skipped') &&
       (needs.docker_publish.result == 'success' || needs.docker_publish.result == 'skipped') &&
       (needs.e2e_tests.result == 'success' || needs.e2e_tests.result == 'skipped')
     steps:
@@ -453,7 +371,6 @@ jobs:
         with:
           node-version: 24
           cache: 'npm'
-          registry-url: 'https://npm.pkg.github.com'
 
       - name: Install dependencies
         run: npm ci
@@ -557,7 +474,7 @@ jobs:
               docker tag "${IMAGE}:latest" "${IMAGE}:${VERSION}"
               docker push "${IMAGE}:${VERSION}"
             fi
-            # shared is published in publish_shared (before Docker builds)
+            # shared has no Docker image — only source artifact
           done
 
           git push --tags

--- a/src/bluebot/Dockerfile.ci
+++ b/src/bluebot/Dockerfile.ci
@@ -24,21 +24,16 @@ RUN apk add --no-cache openssl dumb-init curl && \
     adduser -S -D -H -u 1001 -h /app -s /sbin/nologin -G bluebot bluebot
 
 # Copy package files for dependency installation
-# Note: src/shared is intentionally NOT copied — without its directory present,
-# npm workspaces skips it and installs @starbunk/shared from GitHub Packages.
 COPY package.json package-lock.json* ./
+COPY src/shared/package.json ./src/shared/
 COPY src/bluebot/package.json ./src/bluebot/
 
-# Copy .npmrc for @starbunk registry config (no token — token comes from secret mount)
-COPY .npmrc ./
-
-# Install only production dependencies, fetching @starbunk/shared from registry
+# Install only production dependencies
 RUN --mount=type=cache,target=/root/.npm \
-    --mount=type=secret,id=npm_token \
-    NODE_AUTH_TOKEN=$(cat /run/secrets/npm_token 2>/dev/null || echo "") \
-    npm install --prefer-offline --no-audit --omit=dev --ignore-scripts
+    npm ci --prefer-offline --no-audit --omit=dev --ignore-scripts
 
-# Copy pre-built app artifact from CI
+# Copy pre-built artifacts from CI
+COPY --chown=bluebot:bluebot src/shared/dist ./src/shared/dist
 COPY --chown=bluebot:bluebot src/bluebot/dist ./src/bluebot/dist
 
 # Set default environment variables from build args

--- a/src/bunkbot/Dockerfile.ci
+++ b/src/bunkbot/Dockerfile.ci
@@ -21,21 +21,16 @@ RUN apk add --no-cache openssl dumb-init curl && \
     adduser -S -D -H -u 1001 -h /app -s /sbin/nologin -G bunkbot bunkbot
 
 # Copy package files for dependency installation
-# Note: src/shared is intentionally NOT copied — without its directory present,
-# npm workspaces skips it and installs @starbunk/shared from GitHub Packages.
 COPY package.json package-lock.json* ./
+COPY src/shared/package.json ./src/shared/
 COPY src/bunkbot/package.json ./src/bunkbot/
 
-# Copy .npmrc for @starbunk registry config (no token — token comes from secret mount)
-COPY .npmrc ./
-
-# Install only production dependencies, fetching @starbunk/shared from registry
+# Install only production dependencies
 RUN --mount=type=cache,target=/root/.npm \
-    --mount=type=secret,id=npm_token \
-    NODE_AUTH_TOKEN=$(cat /run/secrets/npm_token 2>/dev/null || echo "") \
-    npm install --prefer-offline --no-audit --omit=dev --ignore-scripts
+    npm ci --prefer-offline --no-audit --omit=dev --ignore-scripts
 
-# Copy pre-built app artifact from CI
+# Copy pre-built artifacts from CI
+COPY --chown=bunkbot:bunkbot src/shared/dist ./src/shared/dist
 COPY --chown=bunkbot:bunkbot src/bunkbot/dist ./src/bunkbot/dist
 
 # Set default environment variables from build args

--- a/src/covabot/Dockerfile.ci
+++ b/src/covabot/Dockerfile.ci
@@ -27,21 +27,16 @@ RUN apk add --no-cache openssl dumb-init curl python3 make g++ && \
     chown -R covabot:covabot /app/data /app/config /app/src/config
 
 # Copy package files for dependency installation
-# Note: src/shared is intentionally NOT copied — without its directory present,
-# npm workspaces skips it and installs @starbunk/shared from GitHub Packages.
 COPY package.json package-lock.json* ./
+COPY src/shared/package.json ./src/shared/
 COPY src/covabot/package.json ./src/covabot/
 
-# Copy .npmrc for @starbunk registry config (no token — token comes from secret mount)
-COPY .npmrc ./
-
-# Install only production dependencies, fetching @starbunk/shared from registry
+# Install only production dependencies
 RUN --mount=type=cache,target=/root/.npm \
-    --mount=type=secret,id=npm_token \
-    NODE_AUTH_TOKEN=$(cat /run/secrets/npm_token 2>/dev/null || echo "") \
-    npm install --prefer-offline --no-audit --omit=dev --ignore-scripts
+    npm ci --prefer-offline --no-audit --omit=dev --ignore-scripts
 
-# Copy pre-built app artifact from CI
+# Copy pre-built artifacts from CI
+COPY --chown=covabot:covabot src/shared/dist ./src/shared/dist
 COPY --chown=covabot:covabot src/covabot/dist ./src/covabot/dist
 COPY --chown=covabot:covabot src/covabot/migrations ./src/covabot/migrations
 

--- a/src/djcova/Dockerfile.ci
+++ b/src/djcova/Dockerfile.ci
@@ -27,21 +27,16 @@ RUN apk add --no-cache ffmpeg openssl dumb-init curl python3 py3-pip && \
     pip3 install --no-cache-dir --break-system-packages "yt-dlp==2025.12.8"
 
 # Copy package files for dependency installation
-# Note: src/shared is intentionally NOT copied — without its directory present,
-# npm workspaces skips it and installs @starbunk/shared from GitHub Packages.
 COPY package.json package-lock.json* ./
+COPY src/shared/package.json ./src/shared/
 COPY src/djcova/package.json ./src/djcova/
 
-# Copy .npmrc for @starbunk registry config (no token — token comes from secret mount)
-COPY .npmrc ./
-
-# Install only production dependencies, fetching @starbunk/shared from registry
+# Install only production dependencies
 RUN --mount=type=cache,target=/root/.npm \
-    --mount=type=secret,id=npm_token \
-    NODE_AUTH_TOKEN=$(cat /run/secrets/npm_token 2>/dev/null || echo "") \
-    npm install --prefer-offline --no-audit --omit=dev --ignore-scripts
+    npm ci --prefer-offline --no-audit --omit=dev --ignore-scripts
 
-# Copy pre-built app artifact from CI
+# Copy pre-built artifacts from CI
+COPY --chown=djcova:djcova src/shared/dist ./src/shared/dist
 COPY --chown=djcova:djcova src/djcova/dist ./src/djcova/dist
 
 # Set default environment variables from build args


### PR DESCRIPTION
## Summary

- **Root cause:** The `publish_shared` job has always failed with `403 Permission not_found: owner not found` — the `@starbunk` npm scope doesn't match the `andrewgari` GitHub owner, so GitHub Packages rejects every publish attempt. This was hidden because `publish_shared` was skipped on all runs where shared code didn't change. PR #704 was the first run where shared actually changed, triggering the publish and exposing the failure.
- **Secondary bug:** The `docker_publish` step had a broken YAML structure — `env:` was indented at the same level as `run:`, cutting the shell script mid-`if`. The `fi` and three `docker push` calls were silently parsed as YAML env keys instead of executed. This caused all Docker builds to fail in run #703.
- **Revert Dockerfile.ci (all 4 apps):** Back to the pre-PR-#699 approach — include `src/shared/package.json` in the workspace, run `npm ci` (workspace symlink resolves), and `COPY` the pre-built `src/shared/dist` from the CI artifact. No registry dependency.
- **Remove `publish_shared` job:** Docker builds no longer need a published package. Changeset versioning, release tagging, and `publish_releases` logic are completely untouched.
- The `docker_publish` YAML fix (env before run, fi and docker push in the correct scope) was already landed in PR #704 and is preserved here.

## Test plan
- [ ] CI passes on this PR (build_apps → docker_publish → e2e_tests → publish_releases)
- [ ] All four Docker images build successfully using the pre-built shared dist from the artifact
- [ ] `publish_releases` still commits version bumps and tags after a successful run

🤖 Generated with [Claude Code](https://claude.com/claude-code)