### PR TITLE
feat(infra): Grafana dashboard provisioning + create-dashboard skill

### DIFF
--- a/.claude/skills/create-dashboard/SKILL.md
+++ b/.claude/skills/create-dashboard/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: create-dashboard
+description: Scaffold a new Grafana dashboard JSON in infrastructure/grafana/dashboards/
+argument-hint: <slug> [Title words]
+allowed-tools: [Read, Write, Bash]
+---
+
+# Create Dashboard: Scaffold a new Grafana dashboard
+
+Creates a new Grafana dashboard JSON at `infrastructure/grafana/dashboards/<slug>.json`.
+The file is ready to commit — Grafana will pick it up within 30s after the next `/deploy starbunk`.
+
+## Arguments
+
+The user invoked this with: $ARGUMENTS
+
+Parse `$ARGUMENTS` as: `<slug> [title words...]`
+
+- **slug** — first token, lowercased, spaces→hyphens (e.g. `covabot-detail`, `fleet`)
+- **title** — remaining tokens joined, or title-case of slug if omitted
+
+## Instructions
+
+### Step 1 — Derive values
+
+- `slug`  = first word of $ARGUMENTS, lowercased, spaces replaced with `-`
+- `title` = remaining words joined (e.g. "CovaBot Detail"), or title-case of slug if none given
+- `uid`   = `starbunk-<slug>` (e.g. `starbunk-covabot-detail`)
+- `path`  = `infrastructure/grafana/dashboards/<slug>.json`
+
+### Step 2 — Guard: check for existing file
+
+If `infrastructure/grafana/dashboards/<slug>.json` already exists, stop and say:
+
+> Dashboard `<slug>.json` already exists. Edit it directly or choose a different name.
+
+### Step 3 — Write the scaffold
+
+Create `infrastructure/grafana/dashboards/<slug>.json` with the content below,
+substituting `<uid>`, `<title>`, and `<description>` (use title as description too unless user provided one):
+
+```json
+{
+  "__inputs": [
+    {
+      "name": "DS_STARBUNK_PROMETHEUS",
+      "label": "Starbunk Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": { "list": [] },
+  "description": "<description>",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["starbunk"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "<title>",
+  "uid": "<uid>",
+  "version": 1
+}
+```
+
+### Step 4 — Report to user
+
+Tell the user:
+
+- Created: `infrastructure/grafana/dashboards/<slug>.json`
+- **Datasource UID** for all Prometheus queries: `starbunk-prometheus`
+- Open the file and add panels — use the Grafana JSON schema; see the existing dashboards in the same folder for examples
+- Commit the file, then run `/deploy starbunk` — Grafana will reload within 30 s
+- Common metric namespaces scraped by Prometheus:
+  - `starbunk_*` — app-level metrics from all four bots via OTEL collector (`:8889/metrics`)
+  - `process_*`, `nodejs_*` — runtime metrics
+  - `up` — scrape health per target
+
+## Notes
+
+- `"id": null` is intentional — Grafana assigns a numeric ID on first load
+- `"uid"` must be unique across all dashboards; the `starbunk-<slug>` convention avoids collisions
+- `"allowUiUpdates": false` in the provisioner means edits made in the Grafana UI are **not** persisted — always edit the JSON file in the repo
+- Prometheus scrapes the OTEL collector at `starbunk-otel-collector:8889`; metrics arrive with the `starbunk_` prefix added by the collector's namespace config

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,6 +90,16 @@ jobs:
             docker-compose.yml \
             "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${{ vars.PROD_DOCKER_COMPOSE_DIR }}/docker-compose.yml.incoming"
 
+      - name: Sync infrastructure files to Tower
+        run: |
+          # Sync infrastructure/ (Grafana dashboards, provisioning, Prometheus config, etc.)
+          # to PROD_DOCKER_COMPOSE_DIR/infrastructure/ so bind mounts are always up to date.
+          # Grafana hot-reloads dashboard JSON files every 30s — no restart needed.
+          rsync -az --delete \
+            -e "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=accept-new -o ConnectTimeout=30" \
+            infrastructure/ \
+            "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${{ vars.PROD_DOCKER_COMPOSE_DIR }}/infrastructure/"
+
       - name: Notify — deploy started
         if: vars.DISCORD_NOTIFY_USER_ID != ''
         uses: ./.github/actions/discord-dm

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ config.json
 !.changeset/config.json
 bots.yml
 prometheus.yml
+!infrastructure/**/prometheus.yml
 
 # ==========================================
 # RUNTIME & PROCESS FILES
@@ -261,6 +262,7 @@ actionlint
 !CLAUDE.md
 !src/**/CLAUDE.md
 !.claude/commands/*.md
+!.claude/skills/**/*.md
 # Personality config markdown files (not documentation — loaded as system prompt)
 !src/covabot/config/personalities/**/*.md
 

--- a/infrastructure/grafana/provisioning/dashboards/dashboards.yml
+++ b/infrastructure/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: starbunk-dashboards
+    orgId: 1
+    folder: Starbunk
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards

--- a/infrastructure/grafana/provisioning/datasources/prometheus.yml
+++ b/infrastructure/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+datasources:
+  - name: Starbunk Prometheus
+    type: prometheus
+    access: proxy
+    url: http://starbunk-prometheus:9090
+    isDefault: true
+    uid: starbunk-prometheus
+    jsonData:
+      httpMethod: POST
+      prometheusType: Prometheus
+      prometheusVersion: 2.53.0
+      timeInterval: 15s


### PR DESCRIPTION
## Summary

- **`infrastructure/grafana/provisioning/`** — Grafana datasource config (`starbunk-prometheus` UID) and dashboard file-provider config (hot-reload every 30s)
- **`infrastructure/grafana/dashboards/`** — empty dir ready for dashboard JSON files; each file dropped here is picked up by Grafana within 30s of landing on Tower
- **`deploy.yml`** — new `rsync` step syncs the entire `infrastructure/` directory to `PROD_DOCKER_COMPOSE_DIR/infrastructure/` on every deploy, keeping bind-mounts in sync without a container restart
- **`.claude/skills/create-dashboard/`** — `/create-dashboard <slug> [title]` skill that scaffolds a valid Grafana dashboard JSON with correct UID convention (`starbunk-<slug>`), datasource wiring, and schema version

## How it works

```
Edit/add infrastructure/grafana/dashboards/*.json
  → commit & push
  → CI: rsync infrastructure/ → Tower:$PROD_DOCKER_COMPOSE_DIR/infrastructure/
  → Grafana bind-mount sees new/updated file
  → hot-reload within 30s (no restart)
```

## Test plan

- [ ] Confirm `rsync` step runs without error on next deploy
- [ ] Add a test dashboard via `/create-dashboard test-dash Test Dashboard`, commit, deploy, verify it appears in Grafana under the "Starbunk" folder
- [ ] Verify existing deploys are unaffected (rsync of an empty `infrastructure/grafana/dashboards/` is a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)