### PR TITLE
feat(covabot): structured observability — metrics, logs, Loki datasource

### DIFF
--- a/.changeset/covabot-observability.md
+++ b/.changeset/covabot-observability.md
@@ -1,0 +1,5 @@
+---
+"@starbunk/covabot": minor
+---
+
+Add structured observability to CovaBot: expanded ResponseReason type (self_message, bot_author, empty_message, rate_limited, llm_ignored), INFO-level structured logs for message_responded/message_skipped events with content previews, and Prometheus counter covabot_message_decisions_total with decision/reason/channel_id/profile_id labels.

--- a/.gitignore
+++ b/.gitignore
@@ -263,6 +263,7 @@ actionlint
 !src/**/CLAUDE.md
 !.claude/commands/*.md
 !.claude/skills/**/*.md
+!.changeset/*.md
 # Personality config markdown files (not documentation — loaded as system prompt)
 !src/covabot/config/personalities/**/*.md
 

--- a/infrastructure/grafana/dashboards/covabot-message-activity.json
+++ b/infrastructure/grafana/dashboards/covabot-message-activity.json
@@ -1,0 +1,402 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_STARBUNK_PROMETHEUS",
+      "label": "Starbunk Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    },
+    {
+      "name": "DS_STARBUNK_LOKI",
+      "label": "Starbunk Loki",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "loki",
+      "pluginName": "Loki"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "loki",
+      "name": "Loki",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "piechart",
+      "name": "Pie chart",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "logs",
+      "name": "Logs",
+      "version": ""
+    }
+  ],
+  "annotations": { "list": [] },
+  "description": "Daily overview of messages CovaBot chose to respond to vs. skip (human messages only)",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 10,
+      "title": "Today at a Glance",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "starbunk-prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "starbunk-prometheus" },
+          "expr": "sum(increase(covabot_message_decisions_total{decision=\"responded\"}[$__range]))",
+          "instant": true,
+          "legendFormat": "Responded",
+          "refId": "A"
+        }
+      ],
+      "title": "Responded",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "starbunk-prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "orange", "value": null }
+            ]
+          },
+          "unit": "short",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "starbunk-prometheus" },
+          "expr": "sum(increase(covabot_message_decisions_total{decision=\"skipped\"}[$__range]))",
+          "instant": true,
+          "legendFormat": "Skipped",
+          "refId": "A"
+        }
+      ],
+      "title": "Skipped (Human)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "starbunk-prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "green", "value": 25 }
+            ]
+          },
+          "unit": "percent",
+          "max": 100,
+          "min": 0,
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "starbunk-prometheus" },
+          "expr": "sum(increase(covabot_message_decisions_total{decision=\"responded\"}[$__range])) / sum(increase(covabot_message_decisions_total[$__range])) * 100",
+          "instant": true,
+          "legendFormat": "Response Rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Response Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "starbunk-prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "blue", "value": null }
+            ]
+          },
+          "unit": "short",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "starbunk-prometheus" },
+          "expr": "sum(increase(covabot_message_decisions_total{reason=\"llm_ignored\"}[$__range]))",
+          "instant": true,
+          "legendFormat": "LLM Silences",
+          "refId": "A"
+        }
+      ],
+      "title": "LLM Chose Silence",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 11,
+      "title": "Activity Over Time",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "starbunk-prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "unit": "short",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "responded" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "skipped" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 6 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": ["sum"], "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "starbunk-prometheus" },
+          "expr": "sum by (decision) (increase(covabot_message_decisions_total[$__rate_interval]))",
+          "legendFormat": "{{decision}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Message Decisions per Interval",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "starbunk-prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "hideFrom": { "legend": false, "tooltip": false, "viz": false } },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 6 },
+      "id": 6,
+      "options": {
+        "displayLabels": ["name", "value"],
+        "legend": { "displayMode": "list", "placement": "bottom", "values": ["percent"] },
+        "pieType": "pie",
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "starbunk-prometheus" },
+          "expr": "sum by (reason) (increase(covabot_message_decisions_total{decision=\"skipped\"}[$__range]))",
+          "instant": true,
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Why Messages Were Skipped",
+      "type": "piechart"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "id": 12,
+      "title": "Message Log",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "starbunk-loki" },
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 15 },
+      "id": 7,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "starbunk-loki" },
+          "expr": "{service_name=\"covabot\"} | json | event=`message_responded`",
+          "queryType": "range",
+          "refId": "A",
+          "legendFormat": ""
+        }
+      ],
+      "title": "Messages CovaBot Responded To",
+      "description": "Fields: author_name, channel_id, content_preview, response_preview, reason, profile_id",
+      "type": "logs"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "starbunk-loki" },
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 27 },
+      "id": 8,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "starbunk-loki" },
+          "expr": "{service_name=\"covabot\"} | json | event=`message_skipped`",
+          "queryType": "range",
+          "refId": "A",
+          "legendFormat": ""
+        }
+      ],
+      "title": "Messages CovaBot Did Not Respond To (Human Only)",
+      "description": "Excludes bot/self/empty filters. Fields: author_name, channel_id, content_preview, reason, profile_id",
+      "type": "logs"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["starbunk", "covabot"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1d", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "CovaBot Message Activity",
+  "uid": "starbunk-covabot-message-activity",
+  "version": 1
+}

--- a/infrastructure/grafana/provisioning/datasources/loki.yml
+++ b/infrastructure/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+datasources:
+  - name: Starbunk Loki
+    type: loki
+    access: proxy
+    url: http://starbunk-loki:3100
+    uid: starbunk-loki
+    jsonData:
+      maxLines: 1000
+      timeout: 60

--- a/src/covabot/src/handlers/message-handler.ts
+++ b/src/covabot/src/handlers/message-handler.ts
@@ -26,6 +26,7 @@ import {
 } from '@/models/memory-types';
 import { VERBOSE_LOGGING } from '@/utils/verbose-mode';
 import { getBotActivityTracker } from '@starbunk/shared/health/bot-activity-tracker';
+import { messageDecisionsTotal } from '@/observability/covabot-metrics';
 
 const logger = logLayer.withPrefix('MessageHandler');
 
@@ -129,14 +130,36 @@ export class MessageHandler {
     }
 
     if (!decision.shouldRespond) {
-      if (VERBOSE_LOGGING) {
+      // Log human-visible skips at INFO so Loki can surface them in the dashboard.
+      // Bot/self/empty filters are structural noise — skip those.
+      if (
+        decision.reason !== 'self_message' &&
+        decision.reason !== 'bot_author' &&
+        decision.reason !== 'empty_message'
+      ) {
+        messageDecisionsTotal.inc({
+          decision: 'skipped',
+          reason: decision.reason,
+          channel_id: message.channelId,
+          profile_id: profile.id,
+        });
+        logger
+          .withMetadata({
+            event: 'message_skipped',
+            profile_id: profile.id,
+            channel_id: message.channelId,
+            author_name: message.author.username,
+            content_preview: message.content.substring(0, 100),
+            reason: decision.reason,
+          })
+          .info('Message skipped');
+      } else if (VERBOSE_LOGGING) {
         logger
           .withMetadata({
             profile_id: profile.id,
             reason: decision.reason,
             channel_id: message.channelId,
             author: message.author.username,
-            content_preview: message.content.substring(0, 80),
           })
           .info('Not responding to message');
       } else {
@@ -160,17 +183,23 @@ export class MessageHandler {
             content_preview: message.content.substring(0, 80),
           })
           .warn('LLM returned IGNORE for a direct @mention — this is a prompt compliance failure');
-      } else if (VERBOSE_LOGGING) {
+      } else {
+        messageDecisionsTotal.inc({
+          decision: 'skipped',
+          reason: 'llm_ignored',
+          channel_id: message.channelId,
+          profile_id: profile.id,
+        });
         logger
           .withMetadata({
+            event: 'message_skipped',
             profile_id: profile.id,
             channel_id: message.channelId,
-            author: message.author.username,
-            content_preview: message.content.substring(0, 80),
+            author_name: message.author.username,
+            content_preview: message.content.substring(0, 100),
+            reason: 'llm_ignored',
           })
-          .info('LLM chose to stay silent (IGNORE)');
-      } else {
-        logger.withMetadata({ profile_id: profile.id }).debug('LLM decided to ignore');
+          .info('Message skipped (LLM chose silence)');
       }
       return;
     }
@@ -182,6 +211,12 @@ export class MessageHandler {
       try {
         await this.sendResponse(profile, message, responseContent);
         getBotActivityTracker('bot_activity').onResponseSent(true);
+        messageDecisionsTotal.inc({
+          decision: 'responded',
+          reason: decision.reason,
+          channel_id: message.channelId,
+          profile_id: profile.id,
+        });
       } catch (sendError) {
         getBotActivityTracker('bot_activity').onResponseSent(false, 'send_failed');
         throw sendError;
@@ -210,8 +245,12 @@ export class MessageHandler {
 
       logger
         .withMetadata({
+          event: 'message_responded',
           profile_id: profile.id,
           channel_id: message.channelId,
+          author_name: message.author.username,
+          content_preview: message.content.substring(0, 100),
+          response_preview: responseContent.substring(0, 100),
           response_length: responseContent.length,
           reason: decision.reason,
         })

--- a/src/covabot/src/index.ts
+++ b/src/covabot/src/index.ts
@@ -17,6 +17,7 @@ import { runSmokeMode } from '@starbunk/shared/health/smoke-mode';
 import { initializeHealthServer } from '@starbunk/shared/health/health-server-init';
 import { setApplicationHealth } from '@starbunk/shared/observability/health-server';
 import { shutdownObservability } from '@starbunk/shared/observability/shutdown';
+import { getMetricsService } from '@starbunk/shared/observability/metrics-service';
 import { CovaBot, CovaBotConfig } from './cova-bot';
 import { registerDependencyHealthChecks } from '@starbunk/shared/health/dependency-health';
 import { registerConfigHealthCheck } from '@starbunk/shared/health/config-health';
@@ -91,6 +92,10 @@ async function main(): Promise<void> {
     cloudLlmApiKey,
     cloudLlmDefaultModel: process.env.CLOUD_LLM_DEFAULT_MODEL,
   };
+
+  // Initialize MetricsService with the correct service name BEFORE anything calls
+  // getMetricsService() without a name (e.g. health server, covabot-metrics module).
+  getMetricsService('covabot');
 
   // Initialize and start the bot
   const bot = CovaBot.getInstance(botConfig);

--- a/src/covabot/src/models/memory-types.ts
+++ b/src/covabot/src/models/memory-types.ts
@@ -99,7 +99,14 @@ export interface InterestMatch {
 
 // ─── Decision Types ───────────────────────────────────────────────────────
 
-export type ResponseReason = 'direct_mention' | 'llm_response' | 'ignored';
+export type ResponseReason =
+  | 'direct_mention' // respond: user @mentioned the bot
+  | 'llm_response' // respond: passed to LLM for engagement decision
+  | 'self_message' // skip: bot's own message
+  | 'bot_author' // skip: message from another bot
+  | 'empty_message' // skip: no content
+  | 'rate_limited' // skip: social battery depleted
+  | 'llm_ignored'; // skip: LLM chose to stay silent
 
 export interface ResponseDecision {
   shouldRespond: boolean;

--- a/src/covabot/src/observability/covabot-metrics.ts
+++ b/src/covabot/src/observability/covabot-metrics.ts
@@ -1,0 +1,29 @@
+/**
+ * CovaBot Prometheus metrics
+ *
+ * Registers CovaBot-specific counters on the shared MetricsService registry
+ * so they are served via the /metrics endpoint alongside process metrics.
+ */
+
+import * as promClient from 'prom-client';
+import { getMetricsService } from '@starbunk/shared/observability/metrics-service';
+
+function makeCounter(name: string, help: string, labelNames: string[]): promClient.Counter<string> {
+  const registry = getMetricsService().getRegistry();
+  return new promClient.Counter({ name, help, labelNames, registers: [registry] });
+}
+
+/**
+ * Tracks every message decision CovaBot makes.
+ *
+ * Labels:
+ *   decision   — "responded" | "skipped"
+ *   reason     — ResponseReason value (e.g. "rate_limited", "llm_ignored", "direct_mention")
+ *   channel_id — Discord channel snowflake
+ *   profile_id — CovaBot personality profile ID
+ */
+export const messageDecisionsTotal = makeCounter(
+  'covabot_message_decisions_total',
+  'Total message decisions made by CovaBot, by outcome and reason',
+  ['decision', 'reason', 'channel_id', 'profile_id'],
+);

--- a/src/covabot/src/services/response-decision-service.ts
+++ b/src/covabot/src/services/response-decision-service.ts
@@ -47,8 +47,9 @@ export class ResponseDecisionService {
       .debug('Evaluating response decision');
 
     // Step 1: Hard filters — structural rejections that need no LLM input
-    if (this.shouldIgnore(profile, message, botUserId)) {
-      return { shouldRespond: false, reason: 'ignored' };
+    const ignoreReason = this.shouldIgnore(profile, message, botUserId);
+    if (ignoreReason) {
+      return { shouldRespond: false, reason: ignoreReason };
     }
 
     // Step 2: Direct @mention — bypass rate limits, the user explicitly addressed us
@@ -86,7 +87,7 @@ export class ResponseDecisionService {
       } else {
         logger.withMetadata(meta).debug('Social battery depleted');
       }
-      return { shouldRespond: false, reason: 'ignored' };
+      return { shouldRespond: false, reason: 'rate_limited' };
     }
 
     // Step 4: Everything else — LLM decides via IGNORE marker with full context signals
@@ -107,22 +108,26 @@ export class ResponseDecisionService {
     return { shouldRespond: true, reason: 'llm_response' };
   }
 
-  private shouldIgnore(profile: CovaProfile, message: Message, botUserId: string): boolean {
+  private shouldIgnore(
+    profile: CovaProfile,
+    message: Message,
+    botUserId: string,
+  ): 'self_message' | 'bot_author' | 'empty_message' | null {
     if (message.author.id === botUserId) {
       logger.withMetadata({ profile_id: profile.id }).debug('Ignoring self-message');
-      return true;
+      return 'self_message';
     }
 
     if (profile.ignoreBots && message.author.bot && !e2eAllowedBotIds.has(message.author.id)) {
       logger
         .withMetadata({ profile_id: profile.id, author_id: message.author.id })
         .debug('Ignoring bot message');
-      return true;
+      return 'bot_author';
     }
 
     if (!message.content || message.content.trim().length === 0) {
       logger.withMetadata({ profile_id: profile.id }).debug('Ignoring empty message');
-      return true;
+      return 'empty_message';
     }
 
     if (VERBOSE_LOGGING) {
@@ -136,7 +141,7 @@ export class ResponseDecisionService {
         .info('Message passed hard filters — evaluating');
     }
 
-    return false;
+    return null;
   }
 
   private isDirectMention(message: Message, botUserId: string): boolean {

--- a/src/covabot/tests/integration/message-flow.test.ts
+++ b/src/covabot/tests/integration/message-flow.test.ts
@@ -339,7 +339,7 @@ describe('Message Flow Integration', () => {
       const decision = await decisionService.shouldRespond(ctx);
 
       expect(decision.shouldRespond).toBe(false);
-      expect(decision.reason).toBe('ignored');
+      expect(decision.reason).toBe('self_message');
     });
 
     it('should ignore messages from bots when configured', async () => {
@@ -352,7 +352,7 @@ describe('Message Flow Integration', () => {
       const decision = await decisionService.shouldRespond(ctx);
 
       expect(decision.shouldRespond).toBe(false);
-      expect(decision.reason).toBe('ignored');
+      expect(decision.reason).toBe('bot_author');
     });
 
     it('should respond to direct mentions', async () => {
@@ -400,7 +400,7 @@ describe('Message Flow Integration', () => {
 
       // Battery ceiling reached — non-pattern message should be blocked
       expect(decision.shouldRespond).toBe(false);
-      expect(decision.reason).toBe('ignored');
+      expect(decision.reason).toBe('rate_limited');
     });
   });
 


### PR DESCRIPTION
## Summary

- **Granular `ResponseReason` type** — replaces catch-all `'ignored'` with `self_message`, `bot_author`, `empty_message`, `rate_limited`, and `llm_ignored` so skip causes are distinguishable in metrics and logs
- **Prometheus counter `covabot_message_decisions_total`** — emitted on every skip/respond with `decision`, `reason`, `channel_id`, and `profile_id` labels; MetricsService initialised at startup before any consumer fires
- **Structured INFO logs** — `message_skipped` / `message_responded` events with `author_name`, `content_preview`, and `response_preview` fields surfaced without verbose-mode flag, enabling Loki log-based panels
- **Loki datasource provisioning** — `infrastructure/grafana/provisioning/datasources/loki.yml` so Grafana auto-discovers the Loki instance on startup
- **CovaBot message-activity dashboard** — new Grafana dashboard tracking decision rates by reason over time
- **`.gitignore` fix** — `!.changeset/*.md` exception added (after the `*.md` deny rule) so changeset files are tracked correctly

## Test plan

- [ ] `npm run check:ci` passes locally (type-check + lint + tests) ✅ (verified by pre-push hook)
- [ ] Integration tests updated for new reason values (`self_message`, `bot_author`, `rate_limited`)
- [ ] Grafana dashboard visible at port 3456 after `docker-compose up -d` with the Loki datasource provisioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)