### PR TITLE
docs(claude-md): strengthen wiki rules, add changelog workflow and skills guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,14 +10,114 @@ The project is split into four isolated containers, each under `src/`:
 3. **CovaBot** (`src/covabot`): AI-powered personality emulation.
 4. **BlueBot** (`src/bluebot`): Pattern matching bot for "blue" references.
 
-## Second Brain / Wiki
-- Location: `wiki/` (repo root)
-- **Always** check relevant wiki pages before starting any task
-- **Always** update the relevant page after completing a task
-- Wiki uses markdown files organized by topic
-- If a page doesn't exist for something, create it
-- keep folder structure /raw /wiki and /templates. /wiki will be permanent commited files, use raw clean so we can see staged changes before moving them.
-- Liberal use of Obsidian linking
+---
+
+## Second Brain / Wiki — MANDATORY
+
+> **Non-negotiable: the wiki is the project's long-term memory. You must read it before starting and update it after finishing every meaningful task.**
+
+### Location
+- `wiki/` — permanent, committed markdown files (Obsidian-compatible)
+- `wiki/raw/` — staging area for in-progress or pre-merge content
+- `wiki/templates/` — page templates
+
+### Rules — follow these every time
+
+1. **Before starting any task** — search the wiki for relevant pages. If a page exists, read it fully before writing a single line of code.
+2. **After completing any meaningful task** — update the relevant wiki page(s) to reflect what changed. If no page exists yet, create one.
+3. **A task is not done until the wiki is updated.** This is part of the definition of done, the same as passing CI.
+4. Create new pages freely. Use [[Obsidian-style links]] to connect related pages.
+5. Keep `wiki/raw/` for drafts and staged content. Promote to `wiki/` on merge.
+
+### What counts as "meaningful"
+Any change that affects: architecture, configuration, a bot's behavior, infrastructure, deployment, testing strategy, a new feature, or a bug fix with a non-obvious root cause.
+
+---
+
+## CHANGELOG Workflow
+
+Every branch that introduces meaningful changes maintains its own changelog entry in `wiki/raw/`.
+
+### While working on a branch
+
+Create or update `wiki/raw/CHANGELOG-<branch-name>.md` as you go. Format:
+
+```markdown
+## [Unreleased] — <branch-name>
+
+### Added
+- ...
+
+### Changed
+- ...
+
+### Fixed
+- ...
+```
+
+This file is committed to the branch alongside code changes. It is the staging area for the real changelog.
+
+### On merge (PR completion)
+
+Prepend the branch entry into `wiki/Changelog.md` under the current date, then delete the `raw/CHANGELOG-<branch-name>.md` file. The permanent changelog lives at `wiki/Changelog.md`.
+
+Format for a merged entry in `wiki/Changelog.md`:
+
+```markdown
+## YYYY-MM-DD — <short description> (#PR)
+
+### Added / Changed / Fixed
+- ...
+```
+
+---
+
+## Skills — Use the Right Tool
+
+Skills are slash commands that enforce consistent workflows. **Always prefer a skill over doing the equivalent steps manually.** The two most critical ones for this project are called out below; do not bypass them.
+
+### `/task` — default for all code changes (MANDATORY)
+
+Use `/task` any time you are asked to implement, fix, refactor, or otherwise change code. It is the default skill for every development request.
+
+What it enforces:
+- Syncs `main` before branching — you never work off a stale base
+- Creates a properly named `<type>/<description>` branch — you never commit directly to `main`
+- Stages only specific files — never `git add .` or `git add -A`
+- Writes conventional commits (`feat(scope): ...`, `fix(scope): ...`)
+- Never uses `--no-verify`
+- Opens a PR with a summary and test plan when done
+
+**Bypass only when the user explicitly says** "work on the current branch" or "skip the PR".
+
+### `/deploy` — all production deployments (MANDATORY)
+
+Use `/deploy` any time you are asked to deploy, update containers, restart services, or push changes to the Tower server. Never SSH into Tower and run docker commands manually.
+
+What it enforces:
+- Discovers the correct Compose stacks under `/mnt/user/appdata/portainer`
+- Rsyncs `infrastructure/` (Grafana dashboards, provisioning files) before restarting
+- Uses `docker compose` (v2), not `docker-compose` (v1)
+- Reports per-stack success/failure
+
+```
+/deploy           # update all stacks
+/deploy starbunk  # update only the starbunk stack
+```
+
+### Other useful skills
+
+| Skill | When to use |
+|-------|-------------|
+| `/check` | Before declaring a task done — runs the full CI suite locally |
+| `/build` | When you need to verify a clean build without running all tests |
+| `/test` | Run the test suite in isolation |
+| `/lint` | Fix lint errors before committing |
+| `/review-pr-comments` | After a PR is open — reads open review comments, implements fixes, resolves them |
+| `/simplify` | After a feature is working — review for unnecessary complexity |
+| `/logs` | Inspect container or application logs on Tower |
+
+---
 
 ## Development Constraints
 - **Do not commit local secrets or configurations** under `config/`, `.workspace/`, `data/`, or `local/`.
@@ -44,13 +144,16 @@ The changeset file goes in `.changeset/` and must be committed with your changes
 `@starbunk/shared` changes do **not** auto-bump app versions. Apps only bump when they have their own changeset. If an app needs a new shared feature, update its `@starbunk/shared` dep and add a changeset for that app in the same PR.
 
 ## CI/CD and Definition of "Done"
-- The only satisfactory **"complete"** state for any task touching this repository is when **all CI/CD checks are passing**.
-- Locally, always run `npm run check:ci` at the project root before considering a task done.
-  - `npm run check:ci` currently runs type-checking, linting, and the full test suite.
-- For any work that results in a PR, do **not** treat the task as complete until:
-  - All GitHub/CI checks are green for that PR, and
-  - Any blocking code review comments have been addressed.
-- If CI fails, fixing the failure (or updating the tests/CI configuration with explicit agreement) is part of the task, not a separate optional step.
+
+A task is **complete** only when all of the following are true:
+
+- [ ] All CI/CD checks are green
+- [ ] `npm run check:ci` passes locally (type-check, lint, tests)
+- [ ] Any blocking PR review comments are resolved
+- [ ] Relevant wiki page(s) are updated
+- [ ] `wiki/raw/CHANGELOG-<branch>.md` exists (or has been merged into `wiki/Changelog.md` on close)
+
+If CI fails, fixing it is part of the task — not optional.
 
 ## Scripts Context
 - `npm run dev:[container_name]` starts custom containers individually.


### PR DESCRIPTION
## Summary
- **Wiki section** elevated to MANDATORY with numbered rules, explicit definition of \"meaningful change\", and a hard statement that a task is not done until the wiki is updated
- **CHANGELOG workflow** added: each branch maintains `wiki/raw/CHANGELOG-<branch>.md` while in flight; on merge it gets prepended into `wiki/Changelog.md` and the raw file is deleted
- **Skills section** added, calling out `/task` and `/deploy` as mandatory with a description of what each enforces (git hygiene, infrastructure sync, etc.) plus a quick-reference table for `/check`, `/build`, `/test`, `/lint`, `/review-pr-comments`, `/simplify`, and `/logs`
- **Definition of Done** converted to an explicit checklist that includes wiki and changelog steps alongside CI

## Test plan
- [ ] Read through CLAUDE.md and verify all sections are coherent end-to-end
- [ ] Confirm wiki rules, changelog workflow, and skills table are unambiguous to a fresh agent context

🤖 Generated with [Claude Code](https://claude.com/claude-code)