### PR TITLE
fix(ci): unignore CHANGELOG.md files and add publish failure notification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -521,3 +521,14 @@ jobs:
             🏷️ **Build tagged** (`${{ steps.build_tag.outputs.tag }}`)
             No version bump. Deployment will use `:latest`.
             — [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+      - name: Notify — publish failed
+        if: failure() && vars.DISCORD_NOTIFY_USER_ID != ''
+        uses: ./.github/actions/discord-dm
+        with:
+          bot_token: ${{ secrets.DISCORD_NOTIFY_TOKEN }}
+          user_id: ${{ vars.DISCORD_NOTIFY_USER_ID }}
+          message: |
+            ❌ **Publish Releases FAILED**
+            The version commit, tagging, or Docker push step failed. Deploy did NOT proceed.
+            — [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/.gitignore
+++ b/.gitignore
@@ -266,6 +266,8 @@ actionlint
 !.changeset/*.md
 # Personality config markdown files (not documentation — loaded as system prompt)
 !src/covabot/config/personalities/**/*.md
+# Changeset-generated changelogs (committed as part of version bump)
+!src/*/CHANGELOG.md
 
 # ==========================================
 # PROJECT-SPECIFIC: WIKI


### PR DESCRIPTION
## Summary

- **`.gitignore`**: Add `!src/*/CHANGELOG.md` to the unignore exceptions. The `*.md` catch-all was blocking `git add` in the `Commit version bumps` step of `publish_releases`, causing it to exit non-zero on every run that included a changeset.
- **`main.yml`**: Add a `Notify — publish failed` step (guarded by `failure()`) at the end of `publish_releases` so a Discord DM is sent when the job fails, rather than leaving only the earlier success messages (images published, E2E passed) visible.

## Root cause

`build_apps` runs `npx changeset version`, which generates `src/*/CHANGELOG.md`. The artifact is uploaded and later extracted in `publish_releases`. When `git add src/*/CHANGELOG.md` ran, git refused with exit code 1 because those paths matched the `*.md` catch-all and weren't in the exception list.

## Test plan

- [ ] Merge to main and verify `publish_releases` / `Commit version bumps` step succeeds on the next changeset-bearing push
- [ ] Confirm no Discord "publish failed" DM arrives on a clean run
- [ ] Verify a "publish failed" DM is sent if the step is manually broken (or trust the `failure()` condition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)