### PR TITLE
fix(bunkbot): exclude URLs from reply-bot trigger evaluation

### DIFF
--- a/.changeset/exclude-urls-from-conditions.md
+++ b/.changeset/exclude-urls-from-conditions.md
@@ -1,0 +1,5 @@
+---
+"@starbunk/bunkbot": patch
+---
+
+Exclude URLs from reply-bot trigger evaluation

--- a/src/bunkbot/src/reply-bots/conditions/conditions.ts
+++ b/src/bunkbot/src/reply-bots/conditions/conditions.ts
@@ -41,10 +41,14 @@ export const not =
  * Specific Condition Sensors
  */
 
+const URL_PATTERN = /https?:\/\/\S+/gi;
+const stripUrls = (text: string): string => text.replace(URL_PATTERN, '');
+
 // Scenario 1: Someone says a specific word (exact match)
 export const containsWord = (word: string) => (message: Message) => {
+  const strippedContent = stripUrls(message.content);
   const regex = new RegExp(`\\b${word}\\b`, 'i');
-  const matches = regex.test(message.content);
+  const matches = regex.test(strippedContent);
   if (matches) {
     logger
       .withMetadata({
@@ -59,7 +63,8 @@ export const containsWord = (word: string) => (message: Message) => {
 
 // Scenario 1: Someone says a phrase (partial match)
 export const containsPhrase = (phrase: string) => (message: Message) => {
-  const matches = message.content.toLowerCase().includes(phrase.toLowerCase());
+  const strippedContent = stripUrls(message.content);
+  const matches = strippedContent.toLowerCase().includes(phrase.toLowerCase());
   if (matches) {
     logger
       .withMetadata({
@@ -104,8 +109,9 @@ export const withChance = (percent: number) => () => {
 
 // Advanced: Regex Pattern matching
 export const matchesPattern = (pattern: string) => (message: Message) => {
+  const strippedContent = stripUrls(message.content);
   const regex = new RegExp(pattern, 'i');
-  const matches = regex.test(message.content);
+  const matches = regex.test(strippedContent);
   if (matches) {
     logger
       .withMetadata({

--- a/src/bunkbot/src/reply-bots/conditions/conditions.ts
+++ b/src/bunkbot/src/reply-bots/conditions/conditions.ts
@@ -41,7 +41,7 @@ export const not =
  * Specific Condition Sensors
  */
 
-const URL_PATTERN = /https?:\/\/\S+/gi;
+const URL_PATTERN = /https?:\/\/[^\s)\]>,"']+/gi;
 const stripUrls = (text: string): string => text.replace(URL_PATTERN, '');
 
 // Scenario 1: Someone says a specific word (exact match)

--- a/src/bunkbot/tests/reply-bots/conditions/conditions.test.ts
+++ b/src/bunkbot/tests/reply-bots/conditions/conditions.test.ts
@@ -65,6 +65,13 @@ describe('Conditions', () => {
 
       expect(condition(message as Message)).toBe(true);
     });
+
+    it('should still match a word immediately after a parenthesised URL', () => {
+      const message = createMockMessage('(https://example.com)banana');
+      const condition = containsWord('banana');
+
+      expect(condition(message as Message)).toBe(true);
+    });
   });
 
   describe('containsPhrase', () => {

--- a/src/bunkbot/tests/reply-bots/conditions/conditions.test.ts
+++ b/src/bunkbot/tests/reply-bots/conditions/conditions.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { containsWord, containsPhrase, fromUser, withChance, matchesPattern, and, or, not } from '@/reply-bots/conditions/conditions';
+import {
+  containsWord,
+  containsPhrase,
+  fromUser,
+  withChance,
+  matchesPattern,
+  and,
+  or,
+  not,
+} from '@/reply-bots/conditions/conditions';
 import { Message } from 'discord.js';
 
 // Helper to create a mock message
@@ -42,6 +51,20 @@ describe('Conditions', () => {
       // Should NOT match because "banana" is part of "bananasplit"
       expect(condition(message as Message)).toBe(false);
     });
+
+    it('should not match a word that only appears inside a URL', () => {
+      const message = createMockMessage('check https://banana.com/buy');
+      const condition = containsWord('banana');
+
+      expect(condition(message as Message)).toBe(false);
+    });
+
+    it('should still match a word that appears outside a URL', () => {
+      const message = createMockMessage('banana https://example.com/buy');
+      const condition = containsWord('banana');
+
+      expect(condition(message as Message)).toBe(true);
+    });
   });
 
   describe('containsPhrase', () => {
@@ -61,6 +84,20 @@ describe('Conditions', () => {
 
     it('should match case-insensitively', () => {
       const message = createMockMessage('TEST MESSAGE here');
+      const condition = containsPhrase('test message');
+
+      expect(condition(message as Message)).toBe(true);
+    });
+
+    it('should not match a phrase that only appears inside a URL', () => {
+      const message = createMockMessage('see https://example.com/test-message/foo');
+      const condition = containsPhrase('test-message');
+
+      expect(condition(message as Message)).toBe(false);
+    });
+
+    it('should still match a phrase that appears outside a URL', () => {
+      const message = createMockMessage('test message https://example.com/foo');
       const condition = containsPhrase('test message');
 
       expect(condition(message as Message)).toBe(true);
@@ -117,26 +154,34 @@ describe('Conditions', () => {
 
       expect(condition(message as Message)).toBe(false);
     });
+
+    it('should not match a pattern that only appears inside a URL', () => {
+      const message = createMockMessage('visit https://test@example.com');
+      const condition = matchesPattern('[a-z]+@[a-z]+\\.[a-z]+');
+
+      expect(condition(message as Message)).toBe(false);
+    });
+
+    it('should still match a pattern that appears outside a URL', () => {
+      const message = createMockMessage('email me at test@example.com or visit https://site.com');
+      const condition = matchesPattern('[a-z]+@[a-z]+\\.[a-z]+');
+
+      expect(condition(message as Message)).toBe(true);
+    });
   });
 
   describe('Logical Operators', () => {
     describe('and', () => {
       it('should return true when all conditions are true', async () => {
         const message = createMockMessage('I love banana', '123');
-        const condition = and(
-          containsWord('banana'),
-          fromUser('123')
-        );
+        const condition = and(containsWord('banana'), fromUser('123'));
 
         expect(await condition(message as Message)).toBe(true);
       });
 
       it('should return false when any condition is false', async () => {
         const message = createMockMessage('I love banana', '456');
-        const condition = and(
-          containsWord('banana'),
-          fromUser('123')
-        );
+        const condition = and(containsWord('banana'), fromUser('123'));
 
         expect(await condition(message as Message)).toBe(false);
       });
@@ -145,20 +190,14 @@ describe('Conditions', () => {
     describe('or', () => {
       it('should return true when at least one condition is true', async () => {
         const message = createMockMessage('I love apples', '123');
-        const condition = or(
-          containsWord('banana'),
-          fromUser('123')
-        );
+        const condition = or(containsWord('banana'), fromUser('123'));
 
         expect(await condition(message as Message)).toBe(true);
       });
 
       it('should return false when all conditions are false', async () => {
         const message = createMockMessage('I love apples', '456');
-        const condition = or(
-          containsWord('banana'),
-          fromUser('123')
-        );
+        const condition = or(containsWord('banana'), fromUser('123'));
 
         expect(await condition(message as Message)).toBe(false);
       });
@@ -181,4 +220,3 @@ describe('Conditions', () => {
     });
   });
 });
-


### PR DESCRIPTION
## Summary
- Reply bots were sometimes responding to messages that contained a trigger word or pattern only inside a URL (e.g. a bot configured to match `banana` would fire on `https://banana.com/shop`)
- Added a `stripUrls` helper in `conditions.ts` that removes `http://` and `https://` URLs from message content before the three text-matching conditions evaluate it
- `containsWord`, `containsPhrase`, and `matchesPattern` all use the stripped content for matching; the original content is still logged in metadata for debugging
- `fromUser` and `withChance` are unchanged — they don't match on text

## Test plan
- [x] Added URL-exclusion tests for all three affected conditions (word-only-in-URL → no match, word-outside-URL → still matches)
- [x] All 38 conditions tests pass
- [x] Full pre-push suite (113 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)