### PR TITLE
fix(covabot): suppress truncated LLM responses; Gemini as default provider

### DIFF
--- a/.changeset/llm-finish-reason-gemini-default.md
+++ b/.changeset/llm-finish-reason-gemini-default.md
@@ -1,0 +1,6 @@
+---
+"@starbunk/shared": minor
+"@starbunk/covabot": patch
+---
+
+Surface finish_reason/stop_reason from all LLM providers; suppress truncated responses in CovaBot; promote Gemini to first-priority provider

--- a/src/covabot/src/services/llm-service.ts
+++ b/src/covabot/src/services/llm-service.ts
@@ -117,8 +117,7 @@ export class LlmService {
       const duration = Date.now() - startTime;
 
       // A truncated response means the model was cut off mid-sentence — suppress it
-      // rather than sending an incomplete message. Values: Anthropic='max_tokens',
-      // Ollama='length', OpenAI/Gemini='length'.
+      // rather than sending an incomplete message to Discord.
       const wasTruncated = result.finishReason === 'max_tokens' || result.finishReason === 'length';
       if (wasTruncated) {
         logger

--- a/src/covabot/src/services/llm-service.ts
+++ b/src/covabot/src/services/llm-service.ts
@@ -116,6 +116,30 @@ export class LlmService {
       const tokensUsed = result.tokensUsed || 0;
       const duration = Date.now() - startTime;
 
+      // A truncated response means the model was cut off mid-sentence — suppress it
+      // rather than sending an incomplete message. Values: Anthropic='max_tokens',
+      // Ollama='length', OpenAI/Gemini='length'.
+      const wasTruncated = result.finishReason === 'max_tokens' || result.finishReason === 'length';
+      if (wasTruncated) {
+        logger
+          .withMetadata({
+            profile_id: profile.id,
+            model: result.model,
+            provider: result.provider,
+            tokens_used: tokensUsed,
+            duration_ms: duration,
+            finish_reason: result.finishReason,
+          })
+          .warn('LLM response truncated at token limit — suppressing to avoid mid-sentence cutoff');
+        return {
+          content: '',
+          shouldIgnore: true,
+          tokensUsed,
+          model: result.model,
+          provider: result.provider,
+        };
+      }
+
       // Check for ignore marker
       const shouldIgnore = responseContent.includes(IGNORE_CONVERSATION_MARKER);
 

--- a/src/covabot/tests/services/llm-service.test.ts
+++ b/src/covabot/tests/services/llm-service.test.ts
@@ -139,6 +139,58 @@ describe('LlmService', () => {
     expect(svc.getProviderManager()).toBeDefined();
   });
 
+  it('suppresses response when finishReason is max_tokens (Anthropic truncation)', async () => {
+    const { LlmProviderManager } = await import('@starbunk/shared');
+    vi.spyOn(LlmProviderManager.prototype as any, 'generateCompletion').mockResolvedValue({
+      content: 'This sentence was cut off mid',
+      tokensUsed: 128,
+      model: 'claude-3-sonnet',
+      provider: 'anthropic',
+      finishReason: 'max_tokens',
+    });
+
+    const svc = new LlmService();
+    const res = await svc.generateResponse(baseProfile, baseContext, 'Tell me more', 'Alice');
+    expect(res.shouldIgnore).toBe(true);
+    expect(res.content).toBe('');
+    expect(res.tokensUsed).toBe(128);
+    expect(res.provider).toBe('anthropic');
+  });
+
+  it('suppresses response when finishReason is length (Ollama/OpenAI/Gemini truncation)', async () => {
+    const { LlmProviderManager } = await import('@starbunk/shared');
+    vi.spyOn(LlmProviderManager.prototype as any, 'generateCompletion').mockResolvedValue({
+      content: 'This sentence was also cut',
+      tokensUsed: 64,
+      model: 'gemini-2.5-flash',
+      provider: 'gemini',
+      finishReason: 'length',
+    });
+
+    const svc = new LlmService();
+    const res = await svc.generateResponse(baseProfile, baseContext, 'Tell me more', 'Alice');
+    expect(res.shouldIgnore).toBe(true);
+    expect(res.content).toBe('');
+    expect(res.tokensUsed).toBe(64);
+    expect(res.provider).toBe('gemini');
+  });
+
+  it('does not suppress response when finishReason is stop (normal completion)', async () => {
+    const { LlmProviderManager } = await import('@starbunk/shared');
+    vi.spyOn(LlmProviderManager.prototype as any, 'generateCompletion').mockResolvedValue({
+      content: 'This Is A COMPLETE RESPONSE',
+      tokensUsed: 20,
+      model: 'fake-model',
+      provider: 'fake-provider',
+      finishReason: 'stop',
+    });
+
+    const svc = new LlmService();
+    const res = await svc.generateResponse(baseProfile, baseContext, 'Hello?', 'Alice');
+    expect(res.shouldIgnore).toBe(false);
+    expect(res.content).toBe('this is a complete response');
+  });
+
   it('rethrows on provider failure', async () => {
     const { LlmProviderManager } = await import('@starbunk/shared');
     vi.spyOn(LlmProviderManager.prototype as any, 'generateCompletion').mockRejectedValue(

--- a/src/shared/src/services/llm/anthropic-provider.ts
+++ b/src/shared/src/services/llm/anthropic-provider.ts
@@ -21,6 +21,7 @@ interface AnthropicMessage {
 interface AnthropicResponse {
   id: string;
   model: string;
+  stop_reason?: string;
   content: Array<{ type: string; text: string }>;
   usage: {
     input_tokens: number;
@@ -103,6 +104,7 @@ export class AnthropicProvider implements LlmProvider {
       model: data.model,
       tokensUsed,
       provider: this.name,
+      finishReason: data.stop_reason,
     };
   }
 }

--- a/src/shared/src/services/llm/gemini-provider.ts
+++ b/src/shared/src/services/llm/gemini-provider.ts
@@ -62,6 +62,7 @@ export class GeminiProvider implements LlmProvider {
       model: completion.model,
       tokensUsed,
       provider: this.name,
+      finishReason: completion.choices[0]?.finish_reason ?? undefined,
     };
   }
 }

--- a/src/shared/src/services/llm/gemini-provider.ts
+++ b/src/shared/src/services/llm/gemini-provider.ts
@@ -62,6 +62,7 @@ export class GeminiProvider implements LlmProvider {
       model: completion.model,
       tokensUsed,
       provider: this.name,
+      // Gemini uses the OpenAI-compat endpoint; finish_reason is string | null — normalise to undefined
       finishReason: completion.choices[0]?.finish_reason ?? undefined,
     };
   }

--- a/src/shared/src/services/llm/llm-provider-manager.ts
+++ b/src/shared/src/services/llm/llm-provider-manager.ts
@@ -42,7 +42,10 @@ export class LlmProviderManager {
    * Initialize providers in priority order
    */
   private initializeProviders(config?: LlmProviderConfig): void {
-    // 1. Google Gemini (primary — capable models, generous token limits)
+    // 1. Google Gemini (primary — capable models, generous default token limits)
+    // Trade-off: cloud API call (requires GEMINI_API_KEY, not private). Ollama was previously
+    // primary because it is local and free; Gemini is now preferred for its higher token ceiling
+    // which reduces truncation. Users without a Gemini key fall back to Ollama automatically.
     const gemini = new GeminiProvider(config?.geminiApiKey, config?.geminiDefaultModel);
     if (gemini.isAvailable()) {
       this.providers.push(gemini);

--- a/src/shared/src/services/llm/llm-provider-manager.ts
+++ b/src/shared/src/services/llm/llm-provider-manager.ts
@@ -7,9 +7,9 @@
  * If all providers fail, the last error is re-thrown.
  *
  * Default priority (set at construction time):
- *   1. OllamaProvider    — local, free, private (primary)
- *   2. AnthropicProvider — Claude models
- *   3. GeminiProvider    — Google Gemini models
+ *   1. GeminiProvider    — Google Gemini models (primary)
+ *   2. OllamaProvider    — local, free, private
+ *   3. AnthropicProvider — Claude models
  *   4. OpenAIProvider    — OpenAI / legacy CLOUD_LLM_API_KEY (final fallback)
  *
  * Only providers whose isAvailable() returns true at construction time are
@@ -42,7 +42,14 @@ export class LlmProviderManager {
    * Initialize providers in priority order
    */
   private initializeProviders(config?: LlmProviderConfig): void {
-    // 1. Ollama (local, free, private)
+    // 1. Google Gemini (primary — capable models, generous token limits)
+    const gemini = new GeminiProvider(config?.geminiApiKey, config?.geminiDefaultModel);
+    if (gemini.isAvailable()) {
+      this.providers.push(gemini);
+      logger.info('Gemini provider registered');
+    }
+
+    // 2. Ollama (local, free, private)
     const ollama = new OllamaProvider(
       config?.ollamaBaseUrl || config?.localLlmApiKey,
       config?.ollamaDefaultModel || config?.localLlmDefaultModel,
@@ -52,18 +59,11 @@ export class LlmProviderManager {
       logger.info('Ollama provider registered');
     }
 
-    // 2. Anthropic / Claude
+    // 3. Anthropic / Claude
     const anthropic = new AnthropicProvider(config?.anthropicApiKey, config?.anthropicDefaultModel);
     if (anthropic.isAvailable()) {
       this.providers.push(anthropic);
       logger.info('Anthropic provider registered');
-    }
-
-    // 3. Google Gemini
-    const gemini = new GeminiProvider(config?.geminiApiKey, config?.geminiDefaultModel);
-    if (gemini.isAvailable()) {
-      this.providers.push(gemini);
-      logger.info('Gemini provider registered');
     }
 
     // 4. OpenAI (legacy fallback via OPENAI_API_KEY or CLOUD_LLM_API_KEY)

--- a/src/shared/src/services/llm/llm-provider.ts
+++ b/src/shared/src/services/llm/llm-provider.ts
@@ -23,6 +23,8 @@ export interface LlmCompletionResult {
   model: string;
   tokensUsed?: number;
   provider: string;
+  /** The reason the model stopped generating. 'max_tokens'/'length' means the response was cut off. */
+  finishReason?: string;
 }
 
 /**

--- a/src/shared/src/services/llm/llm-provider.ts
+++ b/src/shared/src/services/llm/llm-provider.ts
@@ -23,7 +23,17 @@ export interface LlmCompletionResult {
   model: string;
   tokensUsed?: number;
   provider: string;
-  /** The reason the model stopped generating. 'max_tokens'/'length' means the response was cut off. */
+  /**
+   * The reason the model stopped generating.
+   *
+   * Provider-specific values:
+   *   - Anthropic: 'end_turn' (normal) | 'max_tokens' (truncated) | 'stop_sequence' | 'tool_use'
+   *   - Ollama:    'stop'   (normal) | 'length'     (truncated)
+   *   - OpenAI:   'stop'   (normal) | 'length'     (truncated) | 'content_filter' | 'tool_calls'
+   *   - Gemini:   'stop'   (normal) | 'length'     (truncated)  (via OpenAI-compat endpoint)
+   *
+   * 'max_tokens' or 'length' indicates the response was cut off mid-sentence.
+   */
   finishReason?: string;
 }
 
@@ -48,9 +58,9 @@ export interface LlmProvider {
  * Configuration passed to LlmProviderManager to initialise all providers.
  *
  * Provider priority (first configured wins, then falls back):
- *   1. Ollama   — OLLAMA_BASE_URL (no API key needed)
- *   2. Anthropic — ANTHROPIC_API_KEY
- *   3. Gemini   — GEMINI_API_KEY
+ *   1. Gemini   — GEMINI_API_KEY (cloud; generous token limits)
+ *   2. Ollama   — OLLAMA_BASE_URL (local, free, private; no API key needed)
+ *   3. Anthropic — ANTHROPIC_API_KEY
  *   4. OpenAI   — OPENAI_API_KEY (legacy: CLOUD_LLM_API_KEY)
  *
  * Fields are optional — providers whose key/URL is absent will be skipped.

--- a/src/shared/src/services/llm/ollama-provider.ts
+++ b/src/shared/src/services/llm/ollama-provider.ts
@@ -26,6 +26,7 @@ interface OllamaChatResponse {
     content: string;
   };
   done: boolean;
+  done_reason?: string;
   total_duration?: number;
   prompt_eval_count?: number;
   eval_count?: number;
@@ -116,6 +117,7 @@ export class OllamaProvider implements LlmProvider {
       model: data.model,
       tokensUsed,
       provider: this.name,
+      finishReason: data.done_reason,
     };
   }
 }

--- a/src/shared/src/services/llm/openai-provider.ts
+++ b/src/shared/src/services/llm/openai-provider.ts
@@ -70,6 +70,7 @@ export class OpenAIProvider implements LlmProvider {
       model: completion.model,
       tokensUsed,
       provider: this.name,
+      // OpenAI SDK types finish_reason as string | null; ?? undefined normalises null → undefined
       finishReason: completion.choices[0]?.finish_reason ?? undefined,
     };
   }

--- a/src/shared/src/services/llm/openai-provider.ts
+++ b/src/shared/src/services/llm/openai-provider.ts
@@ -70,6 +70,7 @@ export class OpenAIProvider implements LlmProvider {
       model: completion.model,
       tokensUsed,
       provider: this.name,
+      finishReason: completion.choices[0]?.finish_reason ?? undefined,
     };
   }
 }


### PR DESCRIPTION
## Summary
- **Root cause fixed**: All four LLM providers (Anthropic, Gemini, OpenAI, Ollama) now surface `finishReason` in `LlmCompletionResult`. Previously `stop_reason`/`finish_reason` from the API was silently discarded, so a response cut off mid-sentence by the token limit was sent to Discord unchanged.
- **Truncation suppressed**: `LlmService` now checks for `finishReason === 'max_tokens'` (Anthropic) or `'length'` (Ollama/OpenAI/Gemini) and returns `shouldIgnore: true` — CovaBot stays silent rather than posting a broken half-sentence.
- **Gemini promoted to first priority**: Provider order is now Gemini → Ollama → Anthropic → OpenAI.

## Test plan
- [ ] All 235 covabot unit tests pass (`npm run test --workspace=src/covabot`)
- [ ] All shared tests pass (`npm run test --workspace=src/shared`)
- [ ] Deploy and confirm CovaBot no longer cuts off mid-response
- [ ] Check logs for `LLM response truncated at token limit` warnings if truncation still occurs (indicates `max_tokens` in profile config needs raising)

🤖 Generated with [Claude Code](https://claude.com/claude-code)