### PR TITLE
refactor: simplify covabot to support single personality

### DIFF
--- a/src/covabot/src/cova-bot.ts
+++ b/src/covabot/src/cova-bot.ts
@@ -26,8 +26,8 @@ import { InterestRepository } from '@/repositories/interest-repository';
 import { PersonalityRepository } from '@/repositories/personality-repository';
 import { CovaProfile } from '@/models/memory-types';
 import {
-  loadPersonalitiesFromDirectory,
-  getDefaultPersonalitiesPath,
+  loadPersonalityFromDirectory,
+  getDefaultPersonalityPath,
 } from '@/serialization/personality-parser';
 import { EmbeddingManager } from '@/services/llm';
 import { VERBOSE_LOGGING } from '@/utils/verbose-mode';
@@ -62,7 +62,7 @@ export class CovaBot {
 
   private config: CovaBotConfig;
   private client: Client | null = null;
-  private profiles: Map<string, CovaProfile> = new Map();
+  private profile: CovaProfile | null = null;
 
   // Services
   private pgService: PostgresService | null = null;
@@ -94,12 +94,12 @@ export class CovaBot {
 
     try {
       await this.initializeDatabase();
-      await this.loadProfiles();
+      await this.loadProfile();
       await this.initializeServices();
       await this.initializeDiscord();
 
       logger
-        .withMetadata({ profiles_loaded: this.profiles.size })
+        .withMetadata({ profile_loaded: !!this.profile })
         .info('CovaBot v2 started successfully');
     } catch (error) {
       logger.withError(error).error('Failed to start CovaBot');
@@ -127,12 +127,12 @@ export class CovaBot {
     logger.info('CovaBot v2 stopped');
   }
 
-  getProfile(profileId: string): CovaProfile | undefined {
-    return this.profiles.get(profileId);
+  getProfile(): CovaProfile | undefined {
+    return this.profile || undefined;
   }
 
   getAllProfiles(): CovaProfile[] {
-    return Array.from(this.profiles.values());
+    return this.profile ? [this.profile] : [];
   }
 
   getServices(): {
@@ -161,69 +161,61 @@ export class CovaBot {
     this.pgService = await initializeDatabase();
   }
 
-  private async loadProfiles(): Promise<void> {
-    const personalitiesPath = this.config.personalitiesPath || getDefaultPersonalitiesPath();
-    const profiles = loadPersonalitiesFromDirectory(personalitiesPath);
-    this.profiles = new Map(profiles.map(profile => [profile.id, profile]));
-
-    if (this.profiles.size === 0) {
+  private async loadProfile(): Promise<void> {
+    const personalityPath = this.config.personalitiesPath || getDefaultPersonalityPath();
+    try {
+      this.profile = loadPersonalityFromDirectory(personalityPath);
+      logger.withMetadata({ path: personalityPath }).info('Profile loaded');
+    } catch {
       logger
-        .withMetadata({ path: personalitiesPath })
+        .withMetadata({ path: personalityPath })
         .warn(
-          'No personality profiles found — CovaBot will not respond to any messages. ' +
-            'Create a subdirectory with a profile.yml in the personalities path.',
+          'Failed to load personality profile. CovaBot will not respond to any messages. ' +
+            'Create a profile.yml in the personalities path.',
         );
-    } else {
-      logger
-        .withMetadata({ count: this.profiles.size, path: personalitiesPath })
-        .info('Profiles loaded');
+      return;
     }
 
-    // Always audit personality data completeness — warns on startup if data is missing
-    for (const profile of this.profiles.values()) {
-      const issues: string[] = [];
+    const profile = this.profile;
+    const issues: string[] = [];
 
-      if (
-        !profile.personality.systemPrompt ||
-        profile.personality.systemPrompt.trim().length < 50
-      ) {
-        issues.push(
-          `system_prompt too short or missing (${profile.personality.systemPrompt.length} chars)`,
-        );
-      }
-      if (profile.personality.traits.length === 0) {
-        issues.push('no traits defined');
-      }
-      if (profile.personality.topicAffinities.length === 0) {
-        issues.push('no topic_affinities defined');
-      }
-      if (profile.nameAliases.length === 0) {
-        issues.push('no name_aliases — bot will never detect name mentions');
-      }
+    if (!profile.personality.systemPrompt || profile.personality.systemPrompt.trim().length < 50) {
+      issues.push(
+        `system_prompt too short or missing (${profile.personality.systemPrompt.length} chars)`,
+      );
+    }
+    if (profile.personality.traits.length === 0) {
+      issues.push('no traits defined');
+    }
+    if (profile.personality.topicAffinities.length === 0) {
+      issues.push('no topic_affinities defined');
+    }
+    if (profile.nameAliases.length === 0) {
+      issues.push('no name_aliases — bot will never detect name mentions');
+    }
 
-      if (issues.length > 0) {
-        logger
-          .withMetadata({
-            profile_id: profile.id,
-            display_name: profile.displayName,
-            issues,
-          })
-          .warn('Personality data incomplete');
-      } else if (VERBOSE_LOGGING) {
-        logger
-          .withMetadata({
-            profile_id: profile.id,
-            display_name: profile.displayName,
-            system_prompt_length: profile.personality.systemPrompt.length,
-            traits: profile.personality.traits,
-            topic_affinities: profile.personality.topicAffinities,
-            background_facts_count: profile.personality.backgroundFacts.length,
-            name_aliases: profile.nameAliases,
-            social_battery: profile.socialBattery,
-            llm_model: profile.llmConfig.model,
-          })
-          .info('Personality loaded OK');
-      }
+    if (issues.length > 0) {
+      logger
+        .withMetadata({
+          profile_id: profile.id,
+          display_name: profile.displayName,
+          issues,
+        })
+        .warn('Personality data incomplete');
+    } else if (VERBOSE_LOGGING) {
+      logger
+        .withMetadata({
+          profile_id: profile.id,
+          display_name: profile.displayName,
+          system_prompt_length: profile.personality.systemPrompt.length,
+          traits: profile.personality.traits,
+          topic_affinities: profile.personality.topicAffinities,
+          background_facts_count: profile.personality.backgroundFacts.length,
+          name_aliases: profile.nameAliases,
+          social_battery: profile.socialBattery,
+          llm_model: profile.llmConfig.model,
+        })
+        .info('Personality loaded OK');
     }
 
     if (VERBOSE_LOGGING) {
@@ -279,7 +271,7 @@ export class CovaBot {
     this.responseDecisionService = new ResponseDecisionService(this.socialBatteryService);
 
     this.messageHandler = new MessageHandler(
-      this.profiles,
+      this.profile,
       this.memoryService,
       this.responseDecisionService,
       this.llmService,

--- a/src/covabot/src/handlers/message-handler.ts
+++ b/src/covabot/src/handlers/message-handler.ts
@@ -12,7 +12,7 @@
 import { Message } from 'discord.js';
 import { logLayer } from '@starbunk/shared/observability/log-layer';
 import { DiscordService } from '@starbunk/shared/discord/discord-service';
-import { BotIdentity } from '@starbunk/shared/types/bot-identity';
+
 import { MemoryService } from '@/services/memory-service';
 import { ResponseDecisionService, DecisionContext } from '@/services/response-decision-service';
 import { LlmService } from '@/services/llm-service';
@@ -31,7 +31,7 @@ import { messageDecisionsTotal } from '@/observability/covabot-metrics';
 const logger = logLayer.withPrefix('MessageHandler');
 
 export class MessageHandler {
-  private profiles: Map<string, CovaProfile>;
+  private profile: CovaProfile | null;
   private memoryService: MemoryService;
   private decisionService: ResponseDecisionService;
   private llmService: LlmService;
@@ -39,14 +39,14 @@ export class MessageHandler {
   private socialBatteryService: SocialBatteryService;
 
   constructor(
-    profiles: Map<string, CovaProfile>,
+    profile: CovaProfile | null,
     memoryService: MemoryService,
     decisionService: ResponseDecisionService,
     llmService: LlmService,
     personalityService: PersonalityService,
     socialBatteryService: SocialBatteryService,
   ) {
-    this.profiles = profiles;
+    this.profile = profile;
     this.memoryService = memoryService;
     this.decisionService = decisionService;
     this.llmService = llmService;
@@ -72,8 +72,8 @@ export class MessageHandler {
 
     getBotActivityTracker('bot_activity').onMessageReceived();
 
-    if (this.profiles.size === 0) {
-      logger.warn('Received message but no profiles are loaded — cannot respond');
+    if (!this.profile) {
+      logger.warn('Received message but no profile is loaded — cannot respond');
       return;
     }
 
@@ -87,20 +87,17 @@ export class MessageHandler {
       })
       .debug('Processing message');
 
-    // Process message for each loaded profile
-    for (const profile of this.profiles.values()) {
-      try {
-        await this.processForProfile(profile, message, botUserId);
-      } catch (error) {
-        logger
-          .withError(error)
-          .withMetadata({
-            profile_id: profile.id,
-            message_id: message.id,
-          })
-          .error('Error processing message for profile');
-        getBotActivityTracker('bot_activity').onError('profile_processing');
-      }
+    try {
+      await this.processForProfile(this.profile, message, botUserId);
+    } catch (error) {
+      logger
+        .withError(error)
+        .withMetadata({
+          profile_id: this.profile.id,
+          message_id: message.id,
+        })
+        .error('Error processing message for profile');
+      getBotActivityTracker('bot_activity').onError('profile_processing');
     }
 
     const duration = Date.now() - startTime;
@@ -108,7 +105,7 @@ export class MessageHandler {
       .withMetadata({
         message_id: message.id,
         duration_ms: duration,
-        profiles_count: this.profiles.size,
+        profiles_count: this.profile ? 1 : 0,
       })
       .debug('Message processing complete');
   }
@@ -408,69 +405,13 @@ export class MessageHandler {
   }
 
   /**
-   * Send response via Discord webhook
+   * Send response via Discord API chat calls
    */
   private async sendResponse(
     profile: CovaProfile,
     message: Message,
     content: string,
   ): Promise<void> {
-    const discordService = DiscordService.getInstance();
-
-    // Build bot identity from profile
-    const identity: BotIdentity = await this.resolveBotIdentity(profile, message);
-
-    await discordService.sendMessageWithBotIdentity(message, identity, content);
-  }
-
-  /**
-   * Resolve bot identity based on profile configuration
-   */
-  private async resolveBotIdentity(profile: CovaProfile, message: Message): Promise<BotIdentity> {
-    const identity = profile.identity;
-
-    switch (identity.type) {
-      case 'static':
-        return {
-          botName: identity.botName || profile.displayName,
-          avatarUrl: identity.avatarUrl || profile.avatarUrl || '',
-        };
-
-      case 'mimic':
-        if (identity.as_member && message.guild) {
-          const discordService = DiscordService.getInstance();
-          return discordService.getBotIdentityFromDiscord(message.guild.id, identity.as_member);
-        }
-        // Fallback to profile defaults
-        return {
-          botName: profile.displayName,
-          avatarUrl: profile.avatarUrl || '',
-        };
-
-      case 'random':
-        // Pick random member from guild
-        if (message.guild) {
-          const members = message.guild.members.cache.filter(m => !m.user.bot).map(m => m);
-
-          if (members.length > 0) {
-            const randomMember = members[Math.floor(Math.random() * members.length)];
-            return {
-              botName: randomMember.nickname || randomMember.user.username,
-              avatarUrl: randomMember.displayAvatarURL({ size: 256, extension: 'png' }),
-            };
-          }
-        }
-        // Fallback to profile defaults
-        return {
-          botName: profile.displayName,
-          avatarUrl: profile.avatarUrl || '',
-        };
-
-      default:
-        return {
-          botName: profile.displayName,
-          avatarUrl: profile.avatarUrl || '',
-        };
-    }
+    await message.reply(content);
   }
 }

--- a/src/covabot/src/models/memory-types.ts
+++ b/src/covabot/src/models/memory-types.ts
@@ -143,14 +143,6 @@ export interface LlmContext {
 
 // ─── Profile Config Types (mirrors YAML schema) ───────────────────────────
 
-export interface BotIdentityConfig {
-  type: 'static' | 'mimic' | 'random';
-  botName?: string;
-  avatarUrl?: string;
-  // as_member intentionally uses snake_case to match the YAML field name
-  as_member?: string;
-}
-
 export interface SpeechPatterns {
   lowercase: boolean;
   sarcasmLevel: number;
@@ -190,9 +182,7 @@ export interface PersonalityConfig {
 export interface ProfileConfig {
   id: string;
   display_name: string;
-  avatar_url?: string;
   name_aliases?: string[];
-  identity: BotIdentityConfig;
   personality: PersonalityConfig;
   social_battery: SocialBatteryConfig;
   memory?: { channel_window?: number };
@@ -210,9 +200,7 @@ export interface ProfileConfig {
 export interface CovaProfile {
   id: string;
   displayName: string;
-  avatarUrl?: string;
   nameAliases: string[]; // names/aliases used to detect when the bot is being addressed
-  identity: BotIdentityConfig;
   personality: {
     systemPrompt: string;
     traits: string[];

--- a/src/covabot/src/serialization/normalizers.ts
+++ b/src/covabot/src/serialization/normalizers.ts
@@ -10,8 +10,8 @@
  * clamp and clamp01 are general utilities exported for testing and ad-hoc use.
  */
 
-import type { BotIdentityConfig, LlmConfig, SpeechPatterns } from '@/models/memory-types';
-import type { IdentityConfig, LlmSchemaType, SpeechPatternsConfig } from './personality-schema';
+import type { LlmConfig, SpeechPatterns } from '@/models/memory-types';
+import type { LlmSchemaType, SpeechPatternsConfig } from './personality-schema';
 
 export function clamp(n: number, min: number, max: number): number {
   if (Number.isNaN(n)) return min;
@@ -29,24 +29,6 @@ export function normalizeSpeechPatterns(sp: SpeechPatternsConfig): SpeechPattern
     sarcasmLevel: clamp(sp.sarcasm_level, 0, 1),
     technicalBias: clamp(sp.technical_bias, 0, 1),
   };
-}
-
-export function normalizeIdentity(id: IdentityConfig): BotIdentityConfig {
-  switch (id.type) {
-    case 'static':
-      return {
-        type: 'static',
-        botName: id.botName,
-        avatarUrl: id.avatarUrl,
-      };
-    case 'mimic':
-      return { type: 'mimic', as_member: id.as_member };
-    case 'random':
-      return { type: 'random' };
-    default:
-      // Exhaustiveness
-      return { type: 'random' } as BotIdentityConfig;
-  }
 }
 
 export function normalizeLlmConfig(llm: LlmSchemaType): LlmConfig {

--- a/src/covabot/src/serialization/personality-manager.ts
+++ b/src/covabot/src/serialization/personality-manager.ts
@@ -29,7 +29,7 @@ export class PersonalityManager implements PersonalityService {
     if (fs.existsSync(this.dir)) {
       this.startWatching();
     } else {
-      this.logger.warn(`Personalities directory '${this.dir}' does not exist; watcher not started`);
+      this.logger.warn(`Personality directory '${this.dir}' does not exist; watcher not started`);
     }
   }
 
@@ -103,7 +103,7 @@ export class PersonalityManager implements PersonalityService {
         }, 500);
       });
     } catch (err) {
-      this.logger.withError(err as Error).warn(`Failed to watch personalities directory '${dir}'`);
+      this.logger.withError(err as Error).warn(`Failed to watch personality directory '${dir}'`);
     }
   }
 

--- a/src/covabot/src/serialization/personality-manager.ts
+++ b/src/covabot/src/serialization/personality-manager.ts
@@ -1,38 +1,30 @@
 import * as fs from 'fs';
 import { LiveData, ReadonlyLiveData, getTraceService } from '@starbunk/shared';
 import { logLayer } from '@starbunk/shared/observability/log-layer';
-import { getDefaultPersonalitiesPath, loadPersonalitiesFromDirectory } from './personality-parser';
+import { getDefaultPersonalityPath, loadPersonalityFromDirectory } from './personality-parser';
 import type { CovaProfile } from '@/models/memory-types';
 
 export interface PersonalityService {
-  getPersonalityById(id: string): CovaProfile | undefined;
-  getPersonalityByName(name: string): CovaProfile | undefined;
-  activatePersonality(personality: CovaProfile): void;
-  getActivePersonality(): CovaProfile | null | undefined;
-  refreshPersonalities(): void;
-  getPersonalitiesLive(): ReadonlyLiveData<readonly CovaProfile[]>;
-  getActivePersonalityLive(): ReadonlyLiveData<CovaProfile | null>;
-  getAllPersonalities(): readonly CovaProfile[];
-  getPersonalityCount(): number;
+  getPersonality(): CovaProfile | null;
+  refreshPersonality(): void;
+  getPersonalityLive(): ReadonlyLiveData<CovaProfile | null>;
 }
 
 export class PersonalityManager implements PersonalityService {
-  private personalities: Map<string, CovaProfile> = new Map();
-  private activePersonality: CovaProfile | null = null;
+  private personality: CovaProfile | null = null;
   private readonly dir: string;
   private readonly logger = logLayer.withPrefix('PersonalityManager');
   private readonly tracing = getTraceService('covabot');
 
   // LiveData streams for observers
-  private readonly personalities$ = new LiveData<readonly CovaProfile[]>([]);
-  private readonly activePersonality$ = new LiveData<CovaProfile | null>(null);
+  private readonly personality$ = new LiveData<CovaProfile | null>(null);
 
   // FS watch support
   private watcher?: fs.FSWatcher;
   private watchDebounce?: NodeJS.Timeout;
 
   constructor(configPath?: string) {
-    this.dir = configPath ?? getDefaultPersonalitiesPath();
+    this.dir = configPath ?? getDefaultPersonalityPath();
     this.loadFromDirectory();
     if (fs.existsSync(this.dir)) {
       this.startWatching();
@@ -46,14 +38,11 @@ export class PersonalityManager implements PersonalityService {
       'personality.dir': this.dir,
     });
     try {
-      this.personalities.clear();
-      const profiles = loadPersonalitiesFromDirectory(this.dir);
-      for (const profile of profiles) {
-        this.personalities.set(profile.id, profile);
-      }
-      this.publishPersonalities();
+      const profile = loadPersonalityFromDirectory(this.dir);
+      this.personality = profile;
+      this.personality$.setValue(this.personality);
       this.tracing.endSpanSuccess(span, {
-        'personalities.count': this.personalities.size,
+        'personality.id': profile.id,
       });
     } catch (error) {
       this.tracing.endSpanError(span, error as Error);
@@ -61,87 +50,31 @@ export class PersonalityManager implements PersonalityService {
     }
   }
 
-  public getPersonalityById(id: string): CovaProfile | undefined {
-    return this.personalities.get(id);
+  public getPersonality(): CovaProfile | null {
+    return this.personality;
   }
 
-  public getPersonalityByName(name: string): CovaProfile | undefined {
-    for (const personality of this.personalities.values()) {
-      if (personality.displayName === name) {
-        return personality;
-      }
-    }
-    return undefined;
-  }
-
-  public activatePersonality(personality: CovaProfile): void {
-    this.activePersonality = personality;
-    this.activePersonality$.setValue(personality);
-  }
-
-  public getActivePersonality(): CovaProfile | null {
-    return this.activePersonality;
-  }
-
-  public refreshPersonalities(): void {
-    // Atomic refresh: only publish new state after successful load
-    const prevActiveId = this.activePersonality?.id ?? null;
-    const span = this.tracing.startSpan('PersonalityManager.refreshPersonalities', {
+  public refreshPersonality(): void {
+    const span = this.tracing.startSpan('PersonalityManager.refreshPersonality', {
       'personality.dir': this.dir,
-      'personality.prev_active_id': prevActiveId ?? 'null',
     });
     try {
-      const profiles = loadPersonalitiesFromDirectory(this.dir);
-      const nextPersonalities = new Map<string, CovaProfile>();
-      for (const profile of profiles) {
-        nextPersonalities.set(profile.id, profile);
-      }
-
-      // Swap in new state atomically
-      this.personalities = nextPersonalities;
-      this.publishPersonalities();
-
-      // Restore previous active personality if available
-      const restored = prevActiveId ? this.getPersonalityById(prevActiveId) : null;
-      if (prevActiveId && !restored) {
-        this.logger.warn(`Active personality '${prevActiveId}' no longer exists after refresh`);
-      }
-      this.activePersonality = restored ?? null;
-      this.activePersonality$.setValue(this.activePersonality);
+      const profile = loadPersonalityFromDirectory(this.dir);
+      this.personality = profile;
+      this.personality$.setValue(this.personality);
 
       this.tracing.endSpanSuccess(span, {
-        'personalities.count': this.personalities.size,
-        'personality.restored_active_id': this.activePersonality?.id ?? 'null',
+        'personality.id': profile.id,
       });
     } catch (error) {
-      // On failure, keep previous state untouched
-      this.logger.withError(error as Error).error('Failed to refresh personalities');
+      this.logger.withError(error as Error).error('Failed to refresh personality');
       this.tracing.endSpanError(span, error as Error);
     }
   }
 
   // LiveData accessors
-  public getPersonalitiesLive(): ReadonlyLiveData<readonly CovaProfile[]> {
-    return this.personalities$.asReadonly();
-  }
-
-  public getActivePersonalityLive(): ReadonlyLiveData<CovaProfile | null> {
-    return this.activePersonality$.asReadonly();
-  }
-
-  // Convenience accessors maintained for synchronous reads
-  public getAllPersonalities(): readonly CovaProfile[] {
-    return this.personalities$.getValue();
-  }
-
-  public getPersonalityCount(): number {
-    return this.personalities.size;
-  }
-
-  private publishPersonalities(): void {
-    // Ensure a stable array reference only when content changed
-    const next = Array.from(this.personalities.values());
-    this.personalities$.setValue(next);
+  public getPersonalityLive(): ReadonlyLiveData<CovaProfile | null> {
+    return this.personality$.asReadonly();
   }
 
   // ---------------------------------------------------------------------------
@@ -163,7 +96,7 @@ export class PersonalityManager implements PersonalityService {
         if (this.watchDebounce) clearTimeout(this.watchDebounce);
         this.watchDebounce = setTimeout(() => {
           try {
-            this.refreshPersonalities();
+            this.refreshPersonality();
           } catch (err) {
             this.logger.withError(err as Error).error('Auto-refresh failed');
           }

--- a/src/covabot/src/serialization/personality-mapper.ts
+++ b/src/covabot/src/serialization/personality-mapper.ts
@@ -1,7 +1,7 @@
 import type { CovaProfile } from '@/models/memory-types';
 import type { YamlConfigType } from './personality-schema';
 import { deepFreeze } from './deep-freeze';
-import { normalizeIdentity, normalizeLlmConfig, normalizeSpeechPatterns } from './normalizers';
+import { normalizeLlmConfig, normalizeSpeechPatterns } from './normalizers';
 
 /**
  * Maps a validated, Zod-parsed YAML config to the immutable CovaProfile runtime model.
@@ -36,12 +36,10 @@ export function mapToCovaProfile(config: YamlConfigType): CovaProfile {
   const result: CovaProfile = {
     id: rawProfile.id,
     displayName: rawProfile.display_name,
-    avatarUrl: rawProfile.avatar_url,
     // Lowercased so name-reference checks don't need case handling at call sites
     nameAliases: (rawProfile.name_aliases ?? [])
       .map(a => String(a).trim().toLowerCase())
       .filter(Boolean),
-    identity: normalizeIdentity(rawProfile.identity),
     personality,
     socialBattery: {
       // Truncate to integers and enforce minimums — YAML floats and zeros are common mistakes

--- a/src/covabot/src/serialization/personality-parser.ts
+++ b/src/covabot/src/serialization/personality-parser.ts
@@ -3,15 +3,7 @@ import * as yaml from 'js-yaml';
 import { logLayer } from '@starbunk/shared/observability/log-layer';
 import type { CovaProfile } from '@/models/memory-types';
 import { VERBOSE_LOGGING } from '@/utils/verbose-mode';
-import {
-  readDirectory,
-  directoryExists,
-  isDirectory,
-  fileExists,
-  createDirectory,
-  readFileUtf8,
-  checkReadAccess,
-} from './file-reader';
+import { fileExists, readFileUtf8 } from './file-reader';
 import { validateOrThrow } from './personality-validator';
 import { mapToCovaProfile } from './personality-mapper';
 import { deepFreeze } from './deep-freeze';
@@ -163,89 +155,7 @@ export function loadPersonalityFromDirectory(dirPath: string): CovaProfile {
   }) as unknown as CovaProfile;
 }
 
-/**
- * Load all personality profiles from a directory.
- *
- * Convention: each personality is a subdirectory containing a `profile.yml`
- * and optional markdown files.
- * Example:
- *   personalities/
- *     cova/
- *       profile.yml
- *       core.md
- *       likes.md
- *       ...
- *
- * The subdirectory name is the deployer's identifier — the display name and
- * character details are defined inside profile.yml and the markdown files.
- */
-export function loadPersonalitiesFromDirectory(dirPath: string): CovaProfile[] {
-  if (!directoryExists(dirPath)) {
-    try {
-      createDirectory(dirPath);
-      logger.withMetadata({ path: dirPath }).info('Created personalities directory');
-    } catch (_err) {
-      throw new PersonalityParserError(`Unable to create directory: ${dirPath}`);
-    }
-    return [];
-  }
-
-  let entries: string[] = [];
-  try {
-    entries = readDirectory(dirPath);
-  } catch (_err) {
-    throw new PersonalityParserError(`Unable to read directory: ${dirPath}`);
-  }
-
-  const profiles: CovaProfile[] = [];
-
-  for (const entry of entries) {
-    const entryPath = path.join(dirPath, entry);
-
-    if (isDirectory(entryPath)) {
-      // Subdirectory format: [name]/profile.yml with optional markdown files
-      try {
-        checkReadAccess(entryPath);
-      } catch {
-        logger
-          .withMetadata({ dir: entry, path: entryPath })
-          .warn('Personality directory is not readable — check file permissions (chmod a+rX)');
-        continue;
-      }
-
-      const profileFilePath = path.join(entryPath, 'profile.yml');
-      if (!fileExists(profileFilePath)) continue;
-
-
-      try {
-        const profile = loadPersonalityFromDirectory(entryPath);
-        profiles.push(profile);
-        logger.withMetadata({ dir: entry, profileId: profile.id }).info('Loaded personality');
-      } catch (error) {
-        logger
-          .withError(error)
-          .withMetadata({ dir: entry, path: profileFilePath })
-          .error('Failed to load personality');
-      }
-    } else if (entry.endsWith('.yml') || entry.endsWith('.yaml')) {
-      // Flat file format: [name].yml directly in the personalities directory
-      try {
-        const profile = parsePersonalityFile(entryPath);
-        profiles.push(profile);
-        logger.withMetadata({ file: entry, profileId: profile.id }).info('Loaded personality');
-      } catch (error) {
-        logger
-          .withError(error)
-          .withMetadata({ file: entry, path: entryPath })
-          .error('Failed to load personality');
-      }
-    }
-  }
-
-  return profiles;
-}
-
-export function getDefaultPersonalitiesPath(): string {
+export function getDefaultPersonalityPath(): string {
   if (process.env.COVABOT_CONFIG_DIR) {
     return process.env.COVABOT_CONFIG_DIR;
   }

--- a/src/covabot/src/serialization/personality-schema.ts
+++ b/src/covabot/src/serialization/personality-schema.ts
@@ -4,25 +4,6 @@
 
 import { z } from 'zod';
 
-// Identity discriminated union
-export const identitySchema = z.discriminatedUnion('type', [
-  z.object({
-    type: z.literal('static'),
-    botName: z.string().describe('Display name for the bot'),
-    avatarUrl: z.string().url().optional().describe('Avatar URL for webhook messages'),
-  }),
-  z.object({
-    type: z.literal('mimic'),
-    as_member: z
-      .string()
-      .regex(/^\d{17,19}$/)
-      .describe('Discord User ID to mimic'),
-  }),
-  z.object({
-    type: z.literal('random'),
-  }),
-]);
-
 // Speech patterns
 export const speechPatternsSchema = z.object({
   lowercase: z.boolean().default(false).describe('Force lowercase responses'),
@@ -91,12 +72,10 @@ export const llmConfigSchema = z.object({
 export const profileSchema = z.object({
   id: z.string().describe('Unique internal identifier'),
   display_name: z.string().describe('Display name for Discord'),
-  avatar_url: z.string().url().optional().describe('Avatar URL for webhook'),
   name_aliases: z
     .array(z.string())
     .default([])
     .describe('Names and aliases the bot goes by — used as context signals for the LLM'),
-  identity: identitySchema,
   personality: personalitySchema,
   social_battery: socialBatterySchema.default({
     max_messages: 5,
@@ -119,7 +98,6 @@ export const yamlConfigSchema = z.object({
 
 // Type exports
 export type MemoryConfigType = z.infer<typeof memoryConfigSchema>;
-export type IdentityConfig = z.infer<typeof identitySchema>;
 export type SpeechPatternsConfig = z.infer<typeof speechPatternsSchema>;
 export type PersonalitySchemaType = z.infer<typeof personalitySchema>;
 export type SocialBatterySchemaType = z.infer<typeof socialBatterySchema>;

--- a/src/covabot/tests/handlers/message-handler.test.ts
+++ b/src/covabot/tests/handlers/message-handler.test.ts
@@ -3,12 +3,6 @@ import type { Message, User, Guild } from 'discord.js';
 import { MessageHandler } from '../../src/handlers/message-handler';
 import type { CovaProfile } from '../../src/models/memory-types';
 
-// Mock DiscordService singleton used inside the handler
-const mockSendMessageWithBotIdentity = vi.fn();
-const mockGetBotIdentityFromDiscord: any = vi.fn(async (..._args: any[]) => ({
-  botName: 'Mimic',
-  avatarUrl: 'x',
-}));
 let getClientImpl: any = () => ({ user: { id: 'bot-123' } });
 
 vi.mock('@starbunk/shared/discord/discord-service', () => ({
@@ -20,12 +14,6 @@ vi.mock('@starbunk/shared/discord/discord-service', () => ({
     }
     getClient() {
       return getClientImpl();
-    }
-    sendMessageWithBotIdentity(message: any, identity: any, content: any) {
-      return mockSendMessageWithBotIdentity(message, identity, content);
-    }
-    getBotIdentityFromDiscord(guildId: string, memberId: string) {
-      return mockGetBotIdentityFromDiscord(guildId, memberId);
     }
   },
 }));
@@ -57,12 +45,12 @@ function createMessage(
     author: { id: cfg.authorId!, username: cfg.authorUsername!, bot: false } as User,
     guild: cfg.guildId ? ({ id: cfg.guildId } as Guild) : null,
     mentions: { users: { has: (_: string) => false } },
+    reply: vi.fn(),
   } as unknown as Message;
 }
 
 describe('MessageHandler', () => {
   let profile: CovaProfile;
-  let profiles: Map<string, CovaProfile>;
 
   // Service mocks
   const memoryService = {
@@ -92,14 +80,11 @@ describe('MessageHandler', () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockSendMessageWithBotIdentity.mockClear();
-    mockGetBotIdentityFromDiscord.mockClear();
     getClientImpl = () => ({ user: { id: 'bot-123' } });
 
     profile = {
       id: 'p1',
       displayName: 'Test',
-      identity: { type: 'static', botName: 'Test' },
       personality: {
         systemPrompt: 'You are Test.',
         traits: [],
@@ -114,7 +99,6 @@ describe('MessageHandler', () => {
       llmConfig: { model: 'fake', temperature: 0.2, max_tokens: 64 },
       ignoreBots: true,
     };
-    profiles = new Map([[profile.id, profile]]);
   });
 
   it('uses LLM and records memory', async () => {
@@ -131,7 +115,7 @@ describe('MessageHandler', () => {
     });
 
     const handler = new MessageHandler(
-      profiles,
+      profile,
       memoryService,
       decisionService,
       llmService,
@@ -143,14 +127,13 @@ describe('MessageHandler', () => {
     await handler.handleMessage(msg);
 
     expect(llmService.generateResponse).toHaveBeenCalled();
-    expect(mockSendMessageWithBotIdentity).toHaveBeenCalled();
+    expect(msg.reply).toHaveBeenCalledWith('sure, how can i help?');
     const call = memoryService.storeConversation.mock.calls.at(-1);
     expect(call[5]).toBe('sure, how can i help?');
   });
 
   it('skips sending when LLM says to ignore', async () => {
     // Ensure previous calls do not leak into this test
-    mockSendMessageWithBotIdentity.mockReset();
     memoryService.storeConversation.mockReset();
     socialBatteryService.recordMessage.mockReset();
     decisionService.shouldRespond.mockResolvedValueOnce({
@@ -166,7 +149,7 @@ describe('MessageHandler', () => {
     });
 
     const handler = new MessageHandler(
-      profiles,
+      profile,
       memoryService,
       decisionService,
       llmService,
@@ -177,7 +160,7 @@ describe('MessageHandler', () => {
     const msg = createMessage({ content: 'ping' });
     await handler.handleMessage(msg);
 
-    expect(mockSendMessageWithBotIdentity).not.toHaveBeenCalled();
+    expect(msg.reply).not.toHaveBeenCalled();
     expect(memoryService.storeConversation).not.toHaveBeenCalled();
     expect(socialBatteryService.recordMessage).not.toHaveBeenCalled();
   });
@@ -186,7 +169,7 @@ describe('MessageHandler', () => {
     getClientImpl = () => ({ user: undefined });
     decisionService.shouldRespond.mockReset();
     const handler = new MessageHandler(
-      profiles,
+      profile,
       memoryService,
       decisionService,
       llmService,

--- a/src/covabot/tests/serialization/normalizers.test.ts
+++ b/src/covabot/tests/serialization/normalizers.test.ts
@@ -3,7 +3,6 @@ import {
   clamp,
   clamp01,
   normalizeSpeechPatterns,
-  normalizeIdentity,
   normalizeLlmConfig,
 } from '../../src/serialization/normalizers';
 
@@ -91,57 +90,6 @@ describe('normalizers', () => {
       });
 
       expect(result.lowercase).toBe(true);
-    });
-  });
-
-  describe('normalizeIdentity', () => {
-    it('should normalize static identity', () => {
-      const result = normalizeIdentity({
-        type: 'static',
-        botName: 'Test Bot',
-        avatarUrl: 'https://example.com/avatar.png',
-      });
-
-      expect(result).toEqual({
-        type: 'static',
-        botName: 'Test Bot',
-        avatarUrl: 'https://example.com/avatar.png',
-      });
-    });
-
-    it('should normalize static identity without avatar', () => {
-      const result = normalizeIdentity({
-        type: 'static',
-        botName: 'Test Bot',
-      });
-
-      expect(result).toEqual({
-        type: 'static',
-        botName: 'Test Bot',
-        avatarUrl: undefined,
-      });
-    });
-
-    it('should normalize mimic identity', () => {
-      const result = normalizeIdentity({
-        type: 'mimic',
-        as_member: '123456789012345678',
-      });
-
-      expect(result).toEqual({
-        type: 'mimic',
-        as_member: '123456789012345678',
-      });
-    });
-
-    it('should normalize random identity', () => {
-      const result = normalizeIdentity({
-        type: 'random',
-      });
-
-      expect(result).toEqual({
-        type: 'random',
-      });
     });
   });
 

--- a/src/covabot/tests/serialization/personality-manager.refresh.test.ts
+++ b/src/covabot/tests/serialization/personality-manager.refresh.test.ts
@@ -3,27 +3,18 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { PersonalityManager } from '../../src/serialization/personality-manager';
 
-const validYaml = (id: string, name: string) => `
+const validYaml = (name: string) => `
 profile:
-  id: "${id}"
+  id: "test-bot"
   display_name: "${name}"
-  identity:
-    type: static
-    botName: "${name}"
   personality:
     system_prompt: "Hello"
 `;
 
-/** Create a personality subdirectory containing profile.yml */
-function mkPersonality(testDir: string, id: string, name: string) {
-  const dir = path.join(testDir, id);
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, 'profile.yml'), validYaml(id, name));
-}
-
-/** Remove a personality subdirectory */
-function rmPersonality(testDir: string, id: string) {
-  fs.rmSync(path.join(testDir, id), { recursive: true, force: true });
+/** Create or update the profile.yml in the directory */
+function writeProfile(testDir: string, name: string) {
+  if (!fs.existsSync(testDir)) fs.mkdirSync(testDir, { recursive: true });
+  fs.writeFileSync(path.join(testDir, 'profile.yml'), validYaml(name));
 }
 
 describe('PersonalityManager refresh & watch', () => {
@@ -48,50 +39,41 @@ describe('PersonalityManager refresh & watch', () => {
     vi.useRealTimers();
   });
 
-  it('keeps previous state if directory read fails during refresh (rollback)', () => {
-    mkPersonality(testDir, 'a', 'A');
+  it('keeps previous state if file read fails during refresh (rollback)', () => {
+    writeProfile(testDir, 'A');
     const mgr = new PersonalityManager(testDir);
-    expect(mgr.getPersonalityCount()).toBe(1);
+    expect(mgr.getPersonality()?.displayName).toBe('A');
 
-    // Turn the directory into a file to force readdirSync to throw
+    // Turn the directory into a file to force read failure
     fs.rmSync(testDir, { recursive: true, force: true });
     fs.writeFileSync(testDir, 'not-a-directory');
 
-    mgr.refreshPersonalities();
-    expect(mgr.getPersonalityCount()).toBe(1); // unchanged
-    expect(mgr.getActivePersonality()).toBeNull();
+    mgr.refreshPersonality();
+    expect(mgr.getPersonality()?.displayName).toBe('A'); // unchanged
   });
 
-  it('restores previous active personality after refresh when still present; clears when removed', () => {
-    mkPersonality(testDir, 'x', 'X');
-    mkPersonality(testDir, 'y', 'Y');
+  it('updates personality after refresh', () => {
+    writeProfile(testDir, 'X');
     const mgr = new PersonalityManager(testDir);
-    const x = mgr.getPersonalityById('x')!;
-    mgr.activatePersonality(x);
-    expect(mgr.getActivePersonality()?.id).toBe('x');
+    expect(mgr.getPersonality()?.displayName).toBe('X');
 
-    // Add new personality and refresh (x still exists)
-    mkPersonality(testDir, 'z', 'Z');
-    mgr.refreshPersonalities();
-    expect(mgr.getPersonalityCount()).toBe(3);
-    expect(mgr.getActivePersonality()?.id).toBe('x');
-
-    // Remove x and refresh -> active becomes null
-    rmPersonality(testDir, 'x');
-    mgr.refreshPersonalities();
-    expect(mgr.getPersonalityCount()).toBe(2);
-    expect(mgr.getActivePersonality()).toBeNull();
+    // Update personality and refresh
+    writeProfile(testDir, 'Z');
+    mgr.refreshPersonality();
+    expect(mgr.getPersonality()?.displayName).toBe('Z');
   });
 
   it('fs.watch triggers debounced refresh and dispose does not throw', async () => {
+    // start with a profile so it initializes cleanly
+    writeProfile(testDir, 'Old');
     const mgr = new PersonalityManager(testDir);
-    expect(mgr.getPersonalityCount()).toBe(0);
+    expect(mgr.getPersonality()?.displayName).toBe('Old');
 
-    // Create a new personality subdir and rely on real fs.watch debounce (~500ms)
-    mkPersonality(testDir, 'n', 'N');
+    // Update the profile to trigger fs.watch
+    writeProfile(testDir, 'New');
     await new Promise(r => setTimeout(r, 700));
 
-    expect(mgr.getPersonalityCount()).toBe(1);
+    expect(mgr.getPersonality()?.displayName).toBe('New');
 
     expect(() => mgr.dispose()).not.toThrow();
   });

--- a/src/covabot/tests/serialization/personality-manager.test.ts
+++ b/src/covabot/tests/serialization/personality-manager.test.ts
@@ -6,11 +6,9 @@ import { PersonalityManager } from '../../src/serialization/personality-manager'
 describe('PersonalityManager', () => {
   const testDir = path.join(__dirname, '../../data/test-personality-manager');
 
-  const mkPersonalityDir = (name: string, yaml: string) => {
-    const dir = path.join(testDir, name);
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(path.join(dir, 'profile.yml'), yaml);
-    return dir;
+  const mkPersonalityDir = (yaml: string) => {
+    fs.writeFileSync(path.join(testDir, 'profile.yml'), yaml);
+    return testDir;
   };
 
   beforeEach(() => {
@@ -30,16 +28,12 @@ describe('PersonalityManager', () => {
   });
 
   describe('constructor', () => {
-    it('should load personalities from specified directory', () => {
+    it('should load personality from specified directory', () => {
       mkPersonalityDir(
-        'test-bot',
         `
 profile:
   id: "test-bot"
   display_name: "Test Bot"
-  identity:
-    type: static
-    botName: "Test Bot"
   personality:
     system_prompt: "You are a test bot."
     traits: ["friendly"]
@@ -49,121 +43,35 @@ profile:
 
       const manager = new PersonalityManager(testDir);
 
-      expect(manager.getPersonalityCount()).toBe(1);
-      expect(manager.getPersonalityById('test-bot')).toBeDefined();
+      expect(manager.getPersonality()).toBeDefined();
+      expect(manager.getPersonality()?.id).toBe('test-bot');
     });
 
-    it('should handle empty directory', () => {
-      const manager = new PersonalityManager(testDir);
-
-      expect(manager.getPersonalityCount()).toBe(0);
-      expect(manager.getAllPersonalities()).toEqual([]);
-    });
-
-    it('should use default path when no path provided', () => {
-      expect(() => new PersonalityManager()).not.toThrow();
+    it('should handle empty directory by throwing or keeping null', () => {
+      // In the current implementation, if the file is missing it throws FileNotFoundError.
+      // So let's wrap it in an expect.toThrow()
+      expect(() => new PersonalityManager(testDir)).toThrow();
     });
   });
 
-  describe('getPersonalityById', () => {
-    it('should return personality by id', () => {
+  describe('getPersonality', () => {
+    it('should return personality', () => {
       mkPersonalityDir(
-        'bot-1',
         `
 profile:
   id: "bot-1"
   display_name: "Bot 1"
-  identity:
-    type: static
-    botName: "Bot 1"
   personality:
     system_prompt: "Bot 1"
 `,
       );
 
       const manager = new PersonalityManager(testDir);
-      const personality = manager.getPersonalityById('bot-1');
+      const personality = manager.getPersonality();
 
       expect(personality).toBeDefined();
       expect(personality?.id).toBe('bot-1');
       expect(personality?.displayName).toBe('Bot 1');
-    });
-
-    it('should return undefined for non-existent id', () => {
-      const manager = new PersonalityManager(testDir);
-      const personality = manager.getPersonalityById('non-existent');
-
-      expect(personality).toBeUndefined();
-    });
-  });
-
-  describe('getPersonalityByName', () => {
-    it('should return personality by display name', () => {
-      mkPersonalityDir(
-        'bot-1',
-        `
-profile:
-  id: "bot-1"
-  display_name: "Bot One"
-  identity:
-    type: static
-    botName: "Bot One"
-  personality:
-    system_prompt: "Bot 1"
-`,
-      );
-
-      const manager = new PersonalityManager(testDir);
-      const personality = manager.getPersonalityByName('Bot One');
-
-      expect(personality).toBeDefined();
-      expect(personality?.id).toBe('bot-1');
-      expect(personality?.displayName).toBe('Bot One');
-    });
-
-    it('should return undefined for non-existent name', () => {
-      const manager = new PersonalityManager(testDir);
-      const personality = manager.getPersonalityByName('Non-existent Bot');
-
-      expect(personality).toBeUndefined();
-    });
-  });
-
-  describe('getAllPersonalities', () => {
-    it('should return all loaded personalities', () => {
-      mkPersonalityDir(
-        'bot-1',
-        `
-profile:
-  id: "bot-1"
-  display_name: "Bot 1"
-  identity:
-    type: static
-    botName: "Bot 1"
-  personality:
-    system_prompt: "Bot 1"
-`,
-      );
-      mkPersonalityDir(
-        'bot-2',
-        `
-profile:
-  id: "bot-2"
-  display_name: "Bot 2"
-  identity:
-    type: static
-    botName: "Bot 2"
-  personality:
-    system_prompt: "Bot 2"
-`,
-      );
-
-      const manager = new PersonalityManager(testDir);
-      const personalities = manager.getAllPersonalities();
-
-      expect(personalities).toHaveLength(2);
-      expect(personalities.map(p => p.id)).toContain('bot-1');
-      expect(personalities.map(p => p.id)).toContain('bot-2');
     });
   });
 });

--- a/src/covabot/tests/serialization/personality-mapper.test.ts
+++ b/src/covabot/tests/serialization/personality-mapper.test.ts
@@ -9,12 +9,6 @@ describe('personality-mapper', () => {
     profile: {
       id: 'test-bot',
       display_name: 'Test Bot',
-      avatar_url: 'https://example.com/avatar.png',
-      identity: {
-        type: 'static',
-        botName: 'Test Bot',
-        avatarUrl: 'https://example.com/avatar.png',
-      },
       personality: {
         system_prompt: 'You are a test bot.',
         traits: ['friendly', 'helpful'],
@@ -51,7 +45,6 @@ describe('personality-mapper', () => {
 
       expect(result.id).toBe('test-bot');
       expect(result.displayName).toBe('Test Bot');
-      expect(result.avatarUrl).toBe('https://example.com/avatar.png');
       expect(result.ignoreBots).toBe(true);
     });
 
@@ -122,54 +115,6 @@ describe('personality-mapper', () => {
         lowercase: true,
         sarcasmLevel: 0.3,
         technicalBias: 0.5,
-      });
-    });
-
-    it('should map static identity', () => {
-      const config = createValidConfig({
-        identity: {
-          type: 'static',
-          botName: 'Custom Bot',
-          avatarUrl: 'https://example.com/custom.png',
-        },
-      });
-
-      const result = mapToCovaProfile(config);
-
-      expect(result.identity).toEqual({
-        type: 'static',
-        botName: 'Custom Bot',
-        avatarUrl: 'https://example.com/custom.png',
-      });
-    });
-
-    it('should map mimic identity', () => {
-      const config = createValidConfig({
-        identity: {
-          type: 'mimic',
-          as_member: '123456789012345678',
-        },
-      });
-
-      const result = mapToCovaProfile(config);
-
-      expect(result.identity).toEqual({
-        type: 'mimic',
-        as_member: '123456789012345678',
-      });
-    });
-
-    it('should map random identity', () => {
-      const config = createValidConfig({
-        identity: {
-          type: 'random',
-        },
-      });
-
-      const result = mapToCovaProfile(config);
-
-      expect(result.identity).toEqual({
-        type: 'random',
       });
     });
 

--- a/src/covabot/tests/serialization/personality-parser.test.ts
+++ b/src/covabot/tests/serialization/personality-parser.test.ts
@@ -3,7 +3,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 import {
   parsePersonalityFile,
-  loadPersonalitiesFromDirectory,
   loadPersonalityFromDirectory,
 } from '../../src/serialization/personality-parser';
 
@@ -30,15 +29,9 @@ describe('PersonalityParser', () => {
 profile:
   id: "test-bot"
   display_name: "Test Bot"
-  avatar_url: "https://example.com/avatar.png"
   name_aliases:
     - "test"
     - "testbot"
-
-  identity:
-    type: static
-    botName: "Test Bot"
-    avatarUrl: "https://example.com/avatar.png"
 
   personality:
     system_prompt: "You are a test bot."
@@ -98,9 +91,6 @@ profile:
 profile:
   id: "test-bot"
   display_name: "Test Bot"
-  identity:
-    type: static
-    botName: "Test Bot"
 `;
       const filePath = path.join(testDir, 'incomplete.yml');
       fs.writeFileSync(filePath, yamlContent);
@@ -113,10 +103,6 @@ profile:
 profile:
   id: "minimal-bot"
   display_name: "Minimal Bot"
-
-  identity:
-    type: static
-    botName: "Minimal Bot"
 
   personality:
     system_prompt: "You are minimal."
@@ -135,28 +121,6 @@ profile:
       expect(profile.ignoreBots).toBe(true);
     });
 
-    it('should parse mimic identity type', () => {
-      const yamlContent = `
-profile:
-  id: "mimic-bot"
-  display_name: "Mimic Bot"
-
-  identity:
-    type: mimic
-    as_member: "123456789012345678"
-
-  personality:
-    system_prompt: "You mimic a user."
-`;
-      const filePath = path.join(testDir, 'mimic.yml');
-      fs.writeFileSync(filePath, yamlContent);
-
-      const profile = parsePersonalityFile(filePath);
-
-      expect(profile.identity.type).toBe('mimic');
-      expect((profile.identity as { as_member: string }).as_member).toBe('123456789012345678');
-    });
-
     it('should parse name_aliases', () => {
       const yamlContent = `
 profile:
@@ -165,10 +129,6 @@ profile:
   name_aliases:
     - "alias"
     - "aliasbot"
-
-  identity:
-    type: static
-    botName: "Alias Bot"
 
   personality:
     system_prompt: "You respond to aliases."
@@ -179,132 +139,6 @@ profile:
       const profile = parsePersonalityFile(filePath);
 
       expect(profile.nameAliases).toEqual(['alias', 'aliasbot']);
-    });
-  });
-
-  describe('loadPersonalitiesFromDirectory', () => {
-    const mkPersonalityDir = (name: string, yaml: string) => {
-      const dir = path.join(testDir, name);
-      fs.mkdirSync(dir, { recursive: true });
-      fs.writeFileSync(path.join(dir, 'profile.yml'), yaml);
-      return dir;
-    };
-
-    it('should load all personality subdirectories', () => {
-      const yaml1 = `
-profile:
-  id: "bot-1"
-  display_name: "Bot 1"
-  identity:
-    type: static
-    botName: "Bot 1"
-  personality:
-    system_prompt: "Bot 1"
-`;
-      const yaml2 = `
-profile:
-  id: "bot-2"
-  display_name: "Bot 2"
-  identity:
-    type: static
-    botName: "Bot 2"
-  personality:
-    system_prompt: "Bot 2"
-`;
-      mkPersonalityDir('bot-1', yaml1);
-      mkPersonalityDir('bot-2', yaml2);
-
-      const profiles = loadPersonalitiesFromDirectory(testDir);
-
-      expect(profiles).toHaveLength(2);
-      expect(profiles.map(p => p.id)).toContain('bot-1');
-      expect(profiles.map(p => p.id)).toContain('bot-2');
-    });
-
-    it('should create directory if it does not exist', () => {
-      const newDir = path.join(testDir, 'new-dir');
-      const profiles = loadPersonalitiesFromDirectory(newDir);
-
-      expect(profiles).toHaveLength(0);
-      expect(fs.existsSync(newDir)).toBe(true);
-    });
-
-    it('should skip subdirectories with invalid profile.yml and continue loading', () => {
-      const validYaml = `
-profile:
-  id: "valid-bot"
-  display_name: "Valid Bot"
-  identity:
-    type: static
-    botName: "Valid Bot"
-  personality:
-    system_prompt: "Valid"
-`;
-      mkPersonalityDir('valid-bot', validYaml);
-
-      const invalidDir = path.join(testDir, 'invalid-bot');
-      fs.mkdirSync(invalidDir, { recursive: true });
-      fs.writeFileSync(path.join(invalidDir, 'profile.yml'), 'invalid yaml content [[[');
-
-      const profiles = loadPersonalitiesFromDirectory(testDir);
-
-      expect(profiles).toHaveLength(1);
-      expect(profiles[0].id).toBe('valid-bot');
-    });
-
-    it('should load flat .yml files alongside subdirectory personalities', () => {
-      const validYaml = `
-profile:
-  id: "test-bot"
-  display_name: "Test Bot"
-  identity:
-    type: static
-    botName: "Test Bot"
-  personality:
-    system_prompt: "Test"
-`;
-      const flatYaml = `
-profile:
-  id: "flat-bot"
-  display_name: "Flat Bot"
-  identity:
-    type: static
-    botName: "Flat Bot"
-  personality:
-    system_prompt: "Flat test"
-`;
-      mkPersonalityDir('test-bot', validYaml);
-      // Non-YAML files should still be ignored; flat YAML files should be loaded
-      fs.writeFileSync(path.join(testDir, 'readme.txt'), 'Not a personality dir');
-      fs.writeFileSync(path.join(testDir, 'flat-bot.yml'), flatYaml);
-
-      const profiles = loadPersonalitiesFromDirectory(testDir);
-
-      expect(profiles).toHaveLength(2);
-      const ids = profiles.map(p => p.id).sort();
-      expect(ids).toEqual(['flat-bot', 'test-bot']);
-    });
-
-    it('should skip subdirectories without a profile.yml', () => {
-      const validYaml = `
-profile:
-  id: "test-bot"
-  display_name: "Test Bot"
-  identity:
-    type: static
-    botName: "Test Bot"
-  personality:
-    system_prompt: "Test"
-`;
-      mkPersonalityDir('test-bot', validYaml);
-
-      // subdir without profile.yml
-      fs.mkdirSync(path.join(testDir, 'no-profile'), { recursive: true });
-      fs.writeFileSync(path.join(testDir, 'no-profile', 'core.md'), 'Just markdown, no profile');
-
-      const profiles = loadPersonalitiesFromDirectory(testDir);
-
-      expect(profiles).toHaveLength(1);
     });
   });
 
@@ -330,9 +164,6 @@ profile:
 profile:
   id: "yaml-bot"
   display_name: "YAML Bot"
-  identity:
-    type: static
-    botName: "YAML Bot"
   personality:
     system_prompt: "Defined in YAML."
 `;
@@ -347,9 +178,6 @@ profile:
 profile:
   id: "md-bot"
   display_name: "Markdown Bot"
-  identity:
-    type: static
-    botName: "Markdown Bot"
   personality:
     system_prompt: "See core.md"
 `;
@@ -369,9 +197,6 @@ profile:
 profile:
   id: "memory-bot"
   display_name: "Memory Bot"
-  identity:
-    type: static
-    botName: "Memory Bot"
   personality:
     system_prompt: "Test"
   memory:

--- a/src/covabot/tests/serialization/personality-schema.test.ts
+++ b/src/covabot/tests/serialization/personality-schema.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import {
-  identitySchema,
   speechPatternsSchema,
   personalitySchema,
   socialBatterySchema,
@@ -10,85 +9,6 @@ import {
 } from '../../src/serialization/personality-schema';
 
 describe('personality-schema', () => {
-  describe('identitySchema', () => {
-    it('should validate static identity with all fields', () => {
-      const result = identitySchema.safeParse({
-        type: 'static',
-        botName: 'Test Bot',
-        avatarUrl: 'https://example.com/avatar.png',
-      });
-
-      expect(result.success).toBe(true);
-    });
-
-    it('should validate static identity without optional avatarUrl', () => {
-      const result = identitySchema.safeParse({
-        type: 'static',
-        botName: 'Test Bot',
-      });
-
-      expect(result.success).toBe(true);
-    });
-
-    it('should reject static identity without botName', () => {
-      const result = identitySchema.safeParse({
-        type: 'static',
-      });
-
-      expect(result.success).toBe(false);
-    });
-
-    it('should validate mimic identity with valid Discord user ID', () => {
-      const result = identitySchema.safeParse({
-        type: 'mimic',
-        as_member: '123456789012345678',
-      });
-
-      expect(result.success).toBe(true);
-    });
-
-    it('should reject mimic identity with invalid user ID', () => {
-      const result = identitySchema.safeParse({
-        type: 'mimic',
-        as_member: 'not-a-valid-id',
-      });
-
-      expect(result.success).toBe(false);
-    });
-
-    it('should reject mimic identity with too short user ID', () => {
-      const result = identitySchema.safeParse({
-        type: 'mimic',
-        as_member: '12345678901234567', // 17 digits min
-      });
-
-      expect(result.success).toBe(true); // 17 is valid
-
-      const tooShort = identitySchema.safeParse({
-        type: 'mimic',
-        as_member: '1234567890123456', // 16 digits - too short
-      });
-
-      expect(tooShort.success).toBe(false);
-    });
-
-    it('should validate random identity', () => {
-      const result = identitySchema.safeParse({
-        type: 'random',
-      });
-
-      expect(result.success).toBe(true);
-    });
-
-    it('should reject unknown identity type', () => {
-      const result = identitySchema.safeParse({
-        type: 'unknown',
-      });
-
-      expect(result.success).toBe(false);
-    });
-  });
-
   describe('speechPatternsSchema', () => {
     it('should validate with all fields', () => {
       const result = speechPatternsSchema.safeParse({
@@ -257,10 +177,6 @@ describe('personality-schema', () => {
     const validProfile = {
       id: 'test-bot',
       display_name: 'Test Bot',
-      identity: {
-        type: 'static',
-        botName: 'Test Bot',
-      },
       personality: {
         system_prompt: 'You are a test bot.',
       },
@@ -303,22 +219,6 @@ describe('personality-schema', () => {
       expect(result.data?.name_aliases).toEqual([]);
     });
 
-    it('should validate optional avatar_url as URL', () => {
-      const withAvatar = profileSchema.safeParse({
-        ...validProfile,
-        avatar_url: 'https://example.com/avatar.png',
-      });
-
-      expect(withAvatar.success).toBe(true);
-
-      const invalidAvatar = profileSchema.safeParse({
-        ...validProfile,
-        avatar_url: 'not-a-url',
-      });
-
-      expect(invalidAvatar.success).toBe(false);
-    });
-
     it('should apply defaults for social_battery, llm, and ignore_bots', () => {
       const result = profileSchema.safeParse(validProfile);
 
@@ -343,10 +243,6 @@ describe('personality-schema', () => {
         profile: {
           id: 'test-bot',
           display_name: 'Test Bot',
-          identity: {
-            type: 'static',
-            botName: 'Test Bot',
-          },
           personality: {
             system_prompt: 'You are a test bot.',
           },
@@ -367,7 +263,6 @@ describe('personality-schema', () => {
         profile: {
           id: 'test-bot',
           display_name: 'Test Bot',
-          identity: { type: 'random' },
           personality: { system_prompt: 'Test' },
         },
         extraKey: 'should be ignored',

--- a/src/covabot/tests/serialization/personality-validator.test.ts
+++ b/src/covabot/tests/serialization/personality-validator.test.ts
@@ -6,10 +6,7 @@ describe('personality-validator', () => {
     profile: {
       id: 'test-bot',
       display_name: 'Test Bot',
-      identity: {
-        type: 'static',
-        botName: 'Test Bot',
-      },
+
       personality: {
         system_prompt: 'You are a test bot.',
         traits: ['friendly'],
@@ -66,28 +63,6 @@ describe('personality-validator', () => {
       expect(() => validateOrThrow(invalid)).toThrow();
     });
 
-    it('should throw for missing identity', () => {
-      const invalid = {
-        profile: {
-          ...validProfile.profile,
-          identity: undefined,
-        },
-      };
-      expect(() => validateOrThrow(invalid)).toThrow();
-    });
-
-    it('should throw for invalid identity type', () => {
-      const invalid = {
-        profile: {
-          ...validProfile.profile,
-          identity: {
-            type: 'unknown',
-          },
-        },
-      };
-      expect(() => validateOrThrow(invalid)).toThrow();
-    });
-
     it('should accept missing system_prompt (populated from markdown files at load time)', () => {
       const withoutPrompt = {
         profile: {
@@ -99,29 +74,6 @@ describe('personality-validator', () => {
         },
       };
       expect(() => validateOrThrow(withoutPrompt)).not.toThrow();
-    });
-
-    it('should throw for invalid mimic identity (bad user ID format)', () => {
-      const invalid = {
-        profile: {
-          ...validProfile.profile,
-          identity: {
-            type: 'mimic',
-            as_member: 'not-a-valid-id',
-          },
-        },
-      };
-      expect(() => validateOrThrow(invalid)).toThrow();
-    });
-
-    it('should throw for invalid avatar_url (not a URL)', () => {
-      const invalid = {
-        profile: {
-          ...validProfile.profile,
-          avatar_url: 'not-a-valid-url',
-        },
-      };
-      expect(() => validateOrThrow(invalid)).toThrow();
     });
 
     it('should throw for sarcasm_level out of range', () => {
@@ -174,9 +126,7 @@ describe('personality-validator', () => {
         profile: {
           id: 'minimal',
           display_name: 'Minimal',
-          identity: {
-            type: 'random',
-          },
+
           personality: {
             system_prompt: 'Minimal prompt',
           },
@@ -194,48 +144,19 @@ describe('personality-validator', () => {
       expect(result.profile.ignore_bots).toBe(true);
     });
 
-    it('should validate mimic identity with valid Discord user ID', () => {
-      const mimicProfile = {
-        profile: {
-          ...validProfile.profile,
-          identity: {
-            type: 'mimic',
-            as_member: '123456789012345678',
-          },
-        },
-      };
-
-      const result = validateOrThrow(mimicProfile);
-      expect(result.profile.identity.type).toBe('mimic');
-    });
-
-    it('should validate random identity', () => {
-      const randomProfile = {
-        profile: {
-          ...validProfile.profile,
-          identity: {
-            type: 'random',
-          },
-        },
-      };
-
-      const result = validateOrThrow(randomProfile);
-      expect(result.profile.identity.type).toBe('random');
-    });
-
     it('should format error messages with paths', () => {
       const invalid = {
         profile: {
           id: 'test',
           display_name: 'Test',
-          identity: { type: 'static' }, // missing botName
+          social_battery: { max_messages: 'invalid' },
           personality: {
             system_prompt: 'Test',
           },
         },
       };
 
-      expect(() => validateOrThrow(invalid)).toThrow('botName');
+      expect(() => validateOrThrow(invalid)).toThrow('max_messages');
     });
 
     it('should throw for non-object input', () => {


### PR DESCRIPTION
This PR removes the multi-personality support from CovaBot. We now assume only one personality, exclusively use API chat calls, and remove all webhooks. The personality files and directories have been changed to support a flat, single profile layout.