### PR TITLE
fix(covabot): retain ignored messages in context and detect direct replies

### DIFF
--- a/src/covabot/src/handlers/message-handler.ts
+++ b/src/covabot/src/handlers/message-handler.ts
@@ -150,6 +150,16 @@ export class MessageHandler {
             reason: decision.reason,
           })
           .info('Message skipped');
+
+        // Step 1.5: Record the user message even if we skip (unless it's structural noise)
+        await this.memoryService.storeConversation(
+          profile.id,
+          message.channelId,
+          message.author.id,
+          message.author.username,
+          message.content,
+          null,
+        );
       } else if (VERBOSE_LOGGING) {
         logger
           .withMetadata({
@@ -198,6 +208,17 @@ export class MessageHandler {
           })
           .info('Message skipped (LLM chose silence)');
       }
+
+      // Step 2.5: Record the user message even if LLM ignores
+      await this.memoryService.storeConversation(
+        profile.id,
+        message.channelId,
+        message.author.id,
+        message.author.username,
+        message.content,
+        null,
+      );
+
       return;
     }
 

--- a/src/covabot/src/services/response-decision-service.ts
+++ b/src/covabot/src/services/response-decision-service.ts
@@ -148,6 +148,9 @@ export class ResponseDecisionService {
     if (message.mentions.users.has(botUserId)) {
       return true;
     }
+    if (message.mentions.repliedUser?.id === botUserId) {
+      return true;
+    }
     const mentionPattern = new RegExp(`<@!?${botUserId}>`);
     return mentionPattern.test(message.content);
   }

--- a/src/covabot/tests/handlers/message-handler.test.ts
+++ b/src/covabot/tests/handlers/message-handler.test.ts
@@ -161,7 +161,14 @@ describe('MessageHandler', () => {
     await handler.handleMessage(msg);
 
     expect(msg.reply).not.toHaveBeenCalled();
-    expect(memoryService.storeConversation).not.toHaveBeenCalled();
+    expect(memoryService.storeConversation).toHaveBeenCalledWith(
+      'p1',
+      'c1',
+      'u1',
+      'Alice',
+      'ping',
+      null,
+    );
     expect(socialBatteryService.recordMessage).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
This PR fixes two main issues with CovaBot's short-term conversation memory:
1. Previously, CovaBot was completely deaf to the channel when he chose to stay silent. `covabot_conversations` only saved his explicit interactions. Now, CovaBot saves every valid message he hears to `covabot_conversations` (with a null bot response), meaning he maintains context of active discussions even while ignoring them.
2. CovaBot now checks `message.mentions.repliedUser` to accurately detect direct replies, even if the user toggles off the `@ping`.