### PR TITLE
Fix Covabot relationship rules and tone enforcement

### DIFF
--- a/src/covabot/src/handlers/message-handler.ts
+++ b/src/covabot/src/handlers/message-handler.ts
@@ -150,6 +150,16 @@ export class MessageHandler {
             reason: decision.reason,
           })
           .info('Message skipped');
+
+        // Step 1.5: Record the user message even if we skip (unless it's structural noise)
+        await this.memoryService.storeConversation(
+          profile.id,
+          message.channelId,
+          message.author.id,
+          message.author.username,
+          message.content,
+          null,
+        );
       } else if (VERBOSE_LOGGING) {
         logger
           .withMetadata({
@@ -198,6 +208,17 @@ export class MessageHandler {
           })
           .info('Message skipped (LLM chose silence)');
       }
+
+      // Step 2.5: Record the user message even if LLM ignores
+      await this.memoryService.storeConversation(
+        profile.id,
+        message.channelId,
+        message.author.id,
+        message.author.username,
+        message.content,
+        null,
+      );
+
       return;
     }
 

--- a/src/covabot/src/handlers/message-handler.ts
+++ b/src/covabot/src/handlers/message-handler.ts
@@ -348,7 +348,7 @@ export class MessageHandler {
 
     let userRelationshipsModifier: string | undefined = undefined;
     if (relationshipLines.length > 0) {
-      userRelationshipsModifier = `Your internal biases towards current participants:\n${relationshipLines.join('\n')}\n(Keep these biases as background knowledge. Do not explicitly state them, just let them naturally influence your tone and behavior.)`;
+      userRelationshipsModifier = `Your relationships and internal biases towards current participants:\n${relationshipLines.join('\n')}\nIMPORTANT: Shift your mood, tone, and voice based on these relationships. Talk a certain way to these specific people according to your relationship with them. Do not explicitly state these rules, but let them heavily influence how you address them.`;
     }
 
     if (VERBOSE_LOGGING) {

--- a/src/covabot/src/serialization/personality-schema.ts
+++ b/src/covabot/src/serialization/personality-schema.ts
@@ -43,9 +43,9 @@ export const personalitySchema = z.object({
     .default([])
     .describe('Personal background details — mentioned rarely and only when naturally relevant'),
   user_relationships: z
-    .record(z.string())
+    .record(z.string(), z.string())
     .default({})
-    .describe('Specific relationship instructions keyed by Discord User ID'),
+    .describe('Specific relationship rules or tone to adopt per user Discord ID'),
   speech_patterns: speechPatternsSchema.default({
     lowercase: false,
     sarcasm_level: 0.3,

--- a/src/covabot/src/services/llm-service.ts
+++ b/src/covabot/src/services/llm-service.ts
@@ -256,6 +256,11 @@ export class LlmService {
       parts.push(`\n${context.traitModifiers}`);
     }
 
+    // Relationship modifiers (tone and mood shifts based on specific people)
+    if (context.userRelationshipsModifier) {
+      parts.push(`\n${context.userRelationshipsModifier}`);
+    }
+
     // Engagement guidance — full behavioral description replaces single-line IGNORE instruction
     parts.push(
       `\nHow you decide whether to respond:\n\nYou are in a group Discord chat. You participate with natural, human conversational instincts — not on every message, not randomly, but when you genuinely have something to contribute.\n\nRespond when:\n- Someone addresses you directly\n- The conversation touches something you genuinely care about and you have a real reaction, insight, or take to add — not just an excuse to mention your interests\n- There is a natural opening that fits your personality\n\nRespond with exactly "${IGNORE_CONVERSATION_MARKER}" (nothing else) when:\n- Two people are clearly in their own back-and-forth and don't need you\n- The topic is completely outside your world and you have nothing real to offer\n- You would be forcing engagement — looking for excuses to speak rather than having something to say\n- You spoke recently and don't have something new to add\n- Your only reaction is a hollow affirmation like "Great!", "Fantastic!", "Nice!", "Cool!" or similar — a one-word or one-phrase acknowledgment with no substance is worse than silence\n\nUse ${IGNORE_CONVERSATION_MARKER} generously. A natural participant in a group chat is silent most of the time. Silence when you have nothing to say is better than speaking just to be present.\n\nWhen you do respond, give complete thoughts. Do not cut off mid-sentence. Responses up to a few sentences are fine.`,

--- a/src/covabot/src/services/response-decision-service.ts
+++ b/src/covabot/src/services/response-decision-service.ts
@@ -148,6 +148,9 @@ export class ResponseDecisionService {
     if (message.mentions.users.has(botUserId)) {
       return true;
     }
+    if (message.mentions.repliedUser?.id === botUserId) {
+      return true;
+    }
     const mentionPattern = new RegExp(`<@!?${botUserId}>`);
     return mentionPattern.test(message.content);
   }

--- a/src/covabot/tests/handlers/message-handler.test.ts
+++ b/src/covabot/tests/handlers/message-handler.test.ts
@@ -161,7 +161,14 @@ describe('MessageHandler', () => {
     await handler.handleMessage(msg);
 
     expect(msg.reply).not.toHaveBeenCalled();
-    expect(memoryService.storeConversation).not.toHaveBeenCalled();
+    expect(memoryService.storeConversation).toHaveBeenCalledWith(
+      'p1',
+      'c1',
+      'u1',
+      'Alice',
+      'ping',
+      null,
+    );
     expect(socialBatteryService.recordMessage).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Covabot was not properly enforcing relationship rules due to two issues:

1. `user_relationships` was missing from the `personalitySchema` Zod validation, meaning it wasn't parsed from configuration files.
2. Even though `MessageHandler` parsed the rules into `LlmContext`, `LlmService` ignored the `userRelationshipsModifier` when building the system prompt.

This PR fixes both issues and strengthens the prompt template to explicitly instruct the LLM to shift its mood, tone, and voice according to these relationships.