### PR TITLE
feat: switch to nightly deployments and fix CI version-bump race condition

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,10 +18,8 @@ name: Deploy to Production
 #      with the "auth_keys" scope and tag:ci assigned.
 
 on:
-  workflow_run:
-    workflows: ["CD / Main Merge"]
-    types: [completed]
-    branches: [main]
+  schedule:
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions:
@@ -41,6 +39,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Needed to diff against the previous deployed commit
 
       - name: Set short SHA
         run: echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
@@ -82,7 +82,37 @@ jobs:
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
 
+      - name: Check if deploy is needed
+        id: check
+        run: |
+          DEPLOYED_SHA=$(ssh -i ~/.ssh/deploy_key \
+            -o StrictHostKeyChecking=accept-new \
+            -o ConnectTimeout=30 \
+            "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
+            "cat ${{ vars.PROD_DOCKER_COMPOSE_DIR }}/.deployed_commit 2>/dev/null || echo 'none'")
+          
+          if [ "$DEPLOYED_SHA" == "none" ]; then
+            echo "No previous deploy found. Deploy needed."
+            echo "SHOULD_DEPLOY=true" >> $GITHUB_ENV
+          elif [ "$DEPLOYED_SHA" == "${SHORT_SHA}" ] && [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+            echo "Deploy is up to date with $SHORT_SHA. Skipping."
+            echo "SHOULD_DEPLOY=false" >> $GITHUB_ENV
+          elif [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+            # Check for production-impacting changes
+            if git diff --quiet $DEPLOYED_SHA..${GITHUB_SHA} -- src/ docker-compose.yml infrastructure/ scripts/deployment/ package.json package-lock.json; then
+              echo "No production-impacting changes since $DEPLOYED_SHA. Skipping."
+              echo "SHOULD_DEPLOY=false" >> $GITHUB_ENV
+            else
+              echo "Production-impacting changes found ($DEPLOYED_SHA -> $SHORT_SHA)."
+              echo "SHOULD_DEPLOY=true" >> $GITHUB_ENV
+            fi
+          else
+            echo "Manual dispatch triggered. Deploying."
+            echo "SHOULD_DEPLOY=true" >> $GITHUB_ENV
+          fi
+
       - name: Stage docker-compose.yml on Tower
+        if: env.SHOULD_DEPLOY == 'true'
         run: |
           scp -i ~/.ssh/deploy_key \
             -o StrictHostKeyChecking=accept-new \
@@ -91,6 +121,7 @@ jobs:
             "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${{ vars.PROD_DOCKER_COMPOSE_DIR }}/docker-compose.yml.incoming"
 
       - name: Sync infrastructure files to Tower
+        if: env.SHOULD_DEPLOY == 'true'
         run: |
           # Sync infrastructure/ (Grafana dashboards, provisioning, Prometheus config, etc.)
           # to PROD_DOCKER_COMPOSE_DIR/infrastructure/ so bind mounts are always up to date.
@@ -101,7 +132,7 @@ jobs:
             "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${{ vars.PROD_DOCKER_COMPOSE_DIR }}/infrastructure/"
 
       - name: Notify — deploy started
-        if: vars.DISCORD_NOTIFY_USER_ID != ''
+        if: env.SHOULD_DEPLOY == 'true' && vars.DISCORD_NOTIFY_USER_ID != ''
         uses: ./.github/actions/discord-dm
         with:
           bot_token: ${{ secrets.DISCORD_NOTIFY_TOKEN }}
@@ -111,6 +142,7 @@ jobs:
             — [View deployment](${{ github.server_url }}/${{ github.repository }}/deployments/activity_log?environment=production)
 
       - name: Deploy
+        if: env.SHOULD_DEPLOY == 'true'
         run: |
           ssh -i ~/.ssh/deploy_key \
             -o StrictHostKeyChecking=accept-new \
@@ -120,6 +152,7 @@ jobs:
             < scripts/deployment/deploy.sh
 
       - name: Health check
+        if: env.SHOULD_DEPLOY == 'true'
         run: |
           ssh -i ~/.ssh/deploy_key \
             -o StrictHostKeyChecking=accept-new \
@@ -129,7 +162,7 @@ jobs:
             < scripts/deployment/health-check.sh
 
       - name: Notify — deploy succeeded
-        if: success() && vars.DISCORD_NOTIFY_USER_ID != ''
+        if: success() && env.SHOULD_DEPLOY == 'true' && vars.DISCORD_NOTIFY_USER_ID != ''
         uses: ./.github/actions/discord-dm
         with:
           bot_token: ${{ secrets.DISCORD_NOTIFY_TOKEN }}
@@ -140,7 +173,7 @@ jobs:
             — [View deployment](${{ github.server_url }}/${{ github.repository }}/deployments/activity_log?environment=production)
 
       - name: Notify — deploy failed
-        if: failure() && vars.DISCORD_NOTIFY_USER_ID != ''
+        if: failure() && env.SHOULD_DEPLOY == 'true' && vars.DISCORD_NOTIFY_USER_ID != ''
         uses: ./.github/actions/discord-dm
         with:
           bot_token: ${{ secrets.DISCORD_NOTIFY_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,14 @@ jobs:
               - 'src/bluebot/**'
             shared:
               - 'src/shared/**'
+            global:
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig*.json'
+              - '.github/workflows/**'
+              - 'src/e2e/**'
+              - 'scripts/**'
+              - '.changeset/**'
 
       - name: Build app matrix
         id: matrix
@@ -53,6 +61,7 @@ jobs:
           fi
 
           SHARED="${{ steps.filter.outputs.shared }}"
+          GLOBAL="${{ steps.filter.outputs.global }}"
           APPS=()
           # Shared changes alone do NOT force app image rebuilds.
           # Apps only rebuild when their own source changes (or they explicitly
@@ -62,9 +71,12 @@ jobs:
           [[ "${{ steps.filter.outputs.covabot }}" == "true" ]] && APPS+=("covabot")
           [[ "${{ steps.filter.outputs.bluebot }}" == "true" ]] && APPS+=("bluebot")
 
-          if [ ${#APPS[@]} -eq 0 ] && [ "$SHARED" != "true" ]; then
-            # No app-level or shared changes (CI/root files only) — rebuild all as safety net
+          if [ "$GLOBAL" == "true" ]; then
+            # Global dependency or config changed - rebuild all
             echo 'apps=["bunkbot","djcova","covabot","bluebot"]' >> $GITHUB_OUTPUT
+          elif [ ${#APPS[@]} -eq 0 ] && [ "$SHARED" != "true" ]; then
+            # No relevant changes at all (e.g. only .md files)
+            echo 'apps=[]' >> $GITHUB_OUTPUT
           else
             APPS_JSON=$(printf '%s\n' "${APPS[@]}" | jq -R . | jq -sc .)
             echo "apps=$APPS_JSON" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -448,6 +448,7 @@ jobs:
             echo "bumped=false" >> $GITHUB_OUTPUT
           else
             git commit -m "chore(release): version packages [skip ci]"
+            git pull --rebase origin main
             git push
             echo "bumped=true" >> $GITHUB_OUTPUT
           fi

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -190,6 +190,9 @@ main() {
   echo "🏷️  Tag: ${DEPLOY_TAG}"
   echo "⏰ Completed: $(date)"
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  
+  # Save the deployed version so future runs can skip if no updates
+  echo "${VERSION}" > .deployed_commit
 }
 
 # Execute deployment


### PR DESCRIPTION
This PR introduces two main changes:

1. Switches to a nightly deployments schedule with diff check optimization to minimize unnecessary deploys.
2. Fixes a race condition in the CD / Main Merge workflow (publish_releases job) by running git pull --rebase origin main before git push on the version-bump commit, preventing non-fast-forward push rejections.