### PR TITLE
fix(djcova): preserve stop failure context

### DIFF
--- a/.changeset/fix-djcova-stop-error.md
+++ b/.changeset/fix-djcova-stop-error.md
@@ -1,0 +1,5 @@
+---
+"@starbunk/djcova": patch
+---
+
+Return stop command error messages to users while retaining a generic fallback for non-Error failures.

--- a/src/djcova/src/commands/stop.ts
+++ b/src/djcova/src/commands/stop.ts
@@ -34,7 +34,10 @@ export default {
       logger
         .withError(error instanceof Error ? error : new Error(String(error)))
         .error('Error executing stop command');
-      await sendErrorResponse(interaction, 'An error occurred while stopping the music.');
+      const errorMessage =
+        error instanceof Error ? error.message : 'An error occurred while stopping the music.';
+
+      await sendErrorResponse(interaction, errorMessage);
     }
   },
 };

--- a/src/djcova/tests/music-commands.test.ts
+++ b/src/djcova/tests/music-commands.test.ts
@@ -204,9 +204,19 @@ describe('Music Commands Tests', () => {
       );
     });
 
-    it('should handle service errors during stop', async () => {
+    it('returns the stop failure message to the user', async () => {
       mockService.stop.mockImplementation(() => {
         throw new Error('Stop failed');
+      });
+
+      await stopCommand.execute(mockInteraction as ChatInputCommandInteraction);
+
+      expect(mockedSendErrorResponse).toHaveBeenCalledWith(mockInteraction, 'Stop failed');
+    });
+
+    it('uses the generic stop failure message for non-Error throws', async () => {
+      mockService.stop.mockImplementation(() => {
+        throw 'Sensitive non-Error value';
       });
 
       await stopCommand.execute(mockInteraction as ChatInputCommandInteraction);


### PR DESCRIPTION
## Summary

Return the thrown Error message when the DJCova stop command fails while retaining the generic fallback for non-Error values.

## Change

- `.changeset/fix-djcova-stop-error.md`
- `src/djcova/src/commands/stop.ts`
- `src/djcova/tests/music-commands.test.ts`

### Checks
- `npm --prefix src/djcova test -- tests/music-commands.test.ts` — passed in a network-isolated container.

Fixes #604

---
AI assistance was used; I reviewed and own this change.

<!-- northset-receipt:M-170:start -->
### Verification

[Northset proof-of-pass receipt M-170](https://northset-oss.github.io/verification-pilot/receipts/M-170/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-170:end -->
